### PR TITLE
COMP: Set graduated testing options

### DIFF
--- a/AutoWorkup/TestSuite/CMakeLists.txt
+++ b/AutoWorkup/TestSuite/CMakeLists.txt
@@ -1,6 +1,7 @@
 ## Set testing environment
 ##
 
+if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 6)
 ## TODO:  This needs to become a real test where several configure file options are used
 ##        to transform the hardcoded values in the scripts in this directory to build
 ##        specific versions.
@@ -12,5 +13,6 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME AutoWorkupDownloadData
     DATA{${TestData_DIR}/SUBJ_B_small_T1.nii.gz}
     DATA{${TestData_DIR}/SUBJ_B_small_T2.nii.gz}
 )
+endif()
 
 ## - ExternalData_Add_Target( ${PROJECT_NAME}FetchData )  # Name of data management target

--- a/BRAINSABC/TestSuite/CMakeLists.txt
+++ b/BRAINSABC/TestSuite/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(
 
 MakeTestDriverFromSEMTool(BRAINSABC BRAINSABCTest.cxx)
 
-# if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 5) #These test takes way to long to run all the time
 ExternalData_add_test( ${PROJECT_NAME}FetchData NAME BRAINSABCLongTest
   COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSABCTestDriver>
   --compare DATA{${TestData_DIR}/labels.nii.gz}
@@ -34,9 +34,9 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME BRAINSABCLongTest
   --atlasDefinition ${ReferenceAtlas_DIR}/${ATLAS_NAME}/AtlasPVDefinition.xml
   )
 set_tests_properties(BRAINSABCLongTest PROPERTIES TIMEOUT 6500)
-# endif()
+endif()
 
-if(0) # This should be restored after fixing.
+if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 8) # This should be restored after fixing.
   add_executable(BlendImageFilterTest BlendImageFilterTest.cxx)
   target_link_libraries(BlendImageFilterTest ${ITK_LIBRARIES})
   ExternalData_add_test( ${PROJECT_NAME}FetchData NAME BlendImageFilterTest COMMAND ${LAUNCH_EXE}  $<TARGET_FILE:BlendImageFilterTest> )

--- a/BRAINSCommonLib/TestSuite/CMakeLists.txt
+++ b/BRAINSCommonLib/TestSuite/CMakeLists.txt
@@ -47,7 +47,7 @@ ExternalData_expand_arguments(FindCenterOFBrainFetchData FindCenterClippedImageM
 ExternalData_expand_arguments(FindCenterOfBrainFetchData
   FindCenterTrimmedImage DATA{${TestData_DIR}/FindCenter/FindCenterTrimmedImage.nii.gz})
 
-if( 0 )
+if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 8) # This should be restored after fixing.
 ExternalData_add_test(FindCenterOfBrainFetchData
   NAME FindCenterOfBrainOutputTest
   COMMAND $<TARGET_FILE:ImageCompare>

--- a/BRAINSConstellationDetector/TestSuite/CMakeLists.txt
+++ b/BRAINSConstellationDetector/TestSuite/CMakeLists.txt
@@ -32,7 +32,7 @@ foreach(prog ${ALL_PROGS_LIST})
   StandardBRAINSBuildMacro(NAME ${prog} TARGET_LIBRARIES landmarksConstellationCOMMONLIB )
 endforeach()
 
-if(0)
+if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 8) # This should be restored after fixing.
 ## Programs for landmarks statistics. These programs do not have any xml file
 set(ALL_PROGS_LIST
     LmkStatistics
@@ -51,7 +51,7 @@ endif()
 # add_executable(BRAINSClipInferiorTest BRAINSClipInferiorTest.cxx)
 # target_link_libraries(BRAINSClipInferiorTest BRAINSClipInferiorCOMMONLIB)
 
-if(0)
+if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 8) # This should be restored after fixing.
 ## Test Versor,  This does not currently have a formal test, so disable building it.
 ## TODO:  Create a test for the VersorTester
 ##
@@ -582,17 +582,6 @@ ExternalData_add_test(${PROJECT_NAME}FetchData NAME ${BRAINSConstellationDetecto
   set_property(TEST ${BRAINSConstellationDetectorTestName} APPEND PROPERTY
     DEPENDS BRAINSConstellationDetectorTestForLandmarkCompare)
 
-  set(BRAINSConstellationDetectorTestName landmarksConstellationWeightsTest)
-  ExternalData_add_test(${PROJECT_NAME}FetchData NAME ${BRAINSConstellationDetectorTestName}
-    COMMAND ${LAUNCH_EXE} $<TARGET_FILE:landmarksConstellationWeightsTestDriver>
-    ${BRAINSConstellationDetectorTestName}
-    --inputTrainingList ${CMAKE_CURRENT_BINARY_DIR}/obliq_setup.txt
-    --inputTemplateModel DATA{${TestData_DIR}/T1-2ndVersion.mdl}
-    --LLSModel DATA{${TestData_DIR}/Transforms_h5/LLSModel-2ndVersion.${XFRM_EXT}}
-    --outputWeightsList ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSConstellationDetectorTestName}.wts #output of the program
-    )
-  set_tests_properties(${BRAINSConstellationDetectorTestName} PROPERTIES TIMEOUT 15000)
-
   set(BRAINSConstellationDetectorTestName landmarksWeightsCompareTest)
   ExternalData_add_test(${PROJECT_NAME}FetchData NAME ${BRAINSConstellationDetectorTestName}
     COMMAND ${LAUNCH_EXE} $<TARGET_FILE:LandmarksCompare>
@@ -612,6 +601,20 @@ if ( 0 ) ## HACK:  Just silencing failing tests until they can be proper address
       )
   endif()
 endif()
+
+if(0)  ## This is a very long running test that is too intensive for everyday testing
+  set(BRAINSConstellationDetectorTestName landmarksConstellationWeightsTest)
+  ExternalData_add_test(${PROJECT_NAME}FetchData NAME ${BRAINSConstellationDetectorTestName}
+    COMMAND ${LAUNCH_EXE} $<TARGET_FILE:landmarksConstellationWeightsTestDriver>
+    ${BRAINSConstellationDetectorTestName}
+    --inputTrainingList ${CMAKE_CURRENT_BINARY_DIR}/obliq_setup.txt
+    --inputTemplateModel DATA{${TestData_DIR}/T1-2ndVersion.mdl}
+    --LLSModel DATA{${TestData_DIR}/Transforms_h5/LLSModel-2ndVersion.${XFRM_EXT}}
+    --outputWeightsList ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSConstellationDetectorTestName}.wts #output of the program
+    )
+  set_tests_properties(${BRAINSConstellationDetectorTestName} PROPERTIES TIMEOUT 15000)
+endif()
+
 
 # endif()
 

--- a/BRAINSDemonWarp/TestSuite/CMakeLists.txt
+++ b/BRAINSDemonWarp/TestSuite/CMakeLists.txt
@@ -55,7 +55,6 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ValidateFastSymmetricForces
   )
 
 #3
-if ( 1 )
 ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ValidateDiffeomorphicTest1_nii
   COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSDemonWarpTestDriver>
   --compare
@@ -82,35 +81,6 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ValidateDiffeomorphicTest1_
   --minimumMovingPyramid 4,4,4
   --registrationFilterType Diffeomorphic
   )
-else()
-  ## Simplified
-ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ValidateDiffeomorphicTest1_nii
-  COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSDemonWarpTestDriver>
-  --compare
-  DATA{${TestData_DIR}/diffeomorphicDemons1.nii.gz}
-  ${CMAKE_CURRENT_BINARY_DIR}/diffeomorphicDemons1_test.nii.gz
-  --compareNumberOfPixelsTolerance 220
-  --compareIntensityTolerance 10
-  BRAINSDemonWarpTest
-  --movingVolume DATA{${TestData_DIR}/SUBJ_B_small_T1.nii.gz}
-  --fixedVolume DATA{${TestData_DIR}/SUBJ_A_small_T1.nii.gz}
-  --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/diffeomorphicDemons1_test.nii.gz
-  --outputDisplacementFieldVolume ${CMAKE_CURRENT_BINARY_DIR}/OutDefField.nii.gz
-  --inputPixelType short
-  --outputPixelType uchar
-  --outputNormalized
-  --outputDebug
-  --histogramMatch
-  --numberOfHistogramBins 1024
-  --numberOfMatchPoints 7
-  # --smoothDisplacementFieldSigma 1.5
-  --numberOfPyramidLevels 1
-  --arrayOfPyramidLevelIterations 1
-  --minimumFixedPyramid 1,1,1
-  --minimumMovingPyramid 1,1,1
-  --registrationFilterType Diffeomorphic
-  )
-endif()
 #4
 ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ValidateDiffeomorphicTest2_nii
   COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSDemonWarpTestDriver>
@@ -548,7 +518,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ValidateDiffeomorphicWithMa
   )
 
 #Test for initial Transform
-if(ENABLE_EXTENDED_TESTING)
+if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 5)
 # TODO # I think this test is failing because the reference data is wrong.
 ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ValidateInitialTransform_Test_nii
   COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSDemonWarpTestDriver>
@@ -573,7 +543,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ValidateInitialTransform_Te
   )
 endif()
 
-if(0)
+if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 8) # This should be restored after fixing.
 # TODO Determine if this is even a valid test any longer
 # These do not work, and appear to have never worked
 #Test for Log Domain

--- a/BRAINSFit/TestSuite/CMakeLists.txt
+++ b/BRAINSFit/TestSuite/CMakeLists.txt
@@ -1181,8 +1181,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   --outputTransform ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.${XFRM_EXT}
 )
 
-set(RUN_SYN_TESTS ON)
-if(RUN_SYN_TESTS)
+if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 5) #These test takes way to long to run all the time
   set(SyNCompareIntensityTol 9.0)
   set(SyNCompareRadius 0)
   set(SyNComparePixelTol 3000) # Roughly 0.5% of the head on a 64^3 image
@@ -1364,7 +1363,7 @@ if(RUN_SYN_TESTS)
     --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${SyNSkewTestName}.test.nii.gz
     --outputTransform ${CMAKE_CURRENT_BINARY_DIR}/${SyNSkewTestName}.${XFRM_EXT}
   )
-endif(RUN_SYN_TESTS)
+endif()
 
 
 # Start of broken metric tests

--- a/BRAINSMultiSTAPLE/TestSuite/CMakeLists.txt
+++ b/BRAINSMultiSTAPLE/TestSuite/CMakeLists.txt
@@ -1,6 +1,6 @@
 MakeTestDriverFromSEMTool(BRAINSMultiSTAPLE BRAINSMultiSTAPLETest.cxx)
 
-if(0) #This test takes way to long to run at the current scale.  It needs to be made smaller
+if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 5) #This test takes way to long to run at the current scale.  It needs to be made smaller
 ExternalData_add_test(BRAINSMultiSTAPLEFetchData
   NAME BRAINSMultiSTAPLETest
   COMMAND $<TARGET_FILE:BRAINSMultiSTAPLE>
@@ -15,4 +15,4 @@ ExternalData_add_test(BRAINSMultiSTAPLEFetchData
   --outputMultiSTAPLE ${CMAKE_CURRENT_BINARY_DIR}/MultiSTAPLE.nii.gz
   )
 ExternalData_Add_Target(BRAINSMultiSTAPLEFetchData)
-endif(0)
+endif()

--- a/BRAINSResample/TestSuite/CMakeLists.txt
+++ b/BRAINSResample/TestSuite/CMakeLists.txt
@@ -116,7 +116,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ValidateBRAINSResampleTest3
   --deformationVolume DATA{${TestData_DIR}/OutDefField_orientedImage.nii.gz}
   )
 
-if(0) ##This functionality does not work yet
+if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 8) ##This functionality does not work yet
   ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ValidateBRAINSResampleInvertTest
     COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSResampleTestDriver>
     --compare
@@ -135,7 +135,7 @@ if(0) ##This functionality does not work yet
     )
 endif()
 
-if(ENABLE_EXTENDED_TESTING)
+if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 5)
 # TODO Fix the code to accept displace field inputs
 # I think this test is failing because the displacement field is and
 # "itkImage" rather than a "itkTransform that stores and itkImage"

--- a/BRAINSTools.cmake
+++ b/BRAINSTools.cmake
@@ -59,6 +59,17 @@ mark_as_advanced(ENABLE_EXTENDED_TESTING)
 set(CTEST_TEST_TIMEOUT 1800 CACHE STRING "Maximum seconds allowed before CTest will kill the test." FORCE)
 set(DART_TESTING_TIMEOUT ${CTEST_TEST_TIMEOUT} CACHE STRING "Maximum seconds allowed before CTest will kill the test." FORCE)
 
+## BRAINSTools_MAX_TEST_LEVEL adjusts how agressive the test suite is
+## so that long running tests or incomplete tests can easily be
+## silenced
+## 1 - Run the absolute minimum very fast tests (These should always pass before any code commit)
+## 3 - Run fast tests on continous builds (These need immediate attention if they begin to fail)
+## 5 - Run moderate nightly tests (These need immediate attention if they begin to fail)
+## 7 - Run long running extensive test that are a burden to normal development (perhaps test 1x per week)
+## 8 - Run tests that fail due to incomplete test building, these are good ideas for test that we don't have time to make robust)
+## 9 - Run silly tests that don't have much untility
+set(BRAINSTools_MAX_TEST_LEVEL 4 CACHE STRING "Testing level for managing test burden")
+
 #-----------------------------------------------------------------------
 # Setup locations to find externally maintained test data.
 #-----------------------------------------------------------------------
@@ -114,7 +125,6 @@ set(brains_modulenames
   BRAINSCreateLabelMapFromProbabilityMaps
   BRAINSMultiSTAPLE
   )
-
 
 if(USE_DebugImageViewer)
   list(APPEND brains_modulenames

--- a/ICCDEF/TestSuite/CMakeLists.txt
+++ b/ICCDEF/TestSuite/CMakeLists.txt
@@ -95,7 +95,7 @@ ExternalData_add_test(${PROJECT_NAME}FetchData NAME ValidateICCDEF_Test3_nii
     --initialFixedDisplacementFieldVolume ${CMAKE_CURRENT_BINARY_DIR}/test1/backward/test1_iteration450resolution2500_backward.nii.gz
 )
 
-if(0) ## HACK: This test needs to be fixed!
+if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 8) ##This functionality does not work yet
 ExternalData_add_test(${PROJECT_NAME}FetchData NAME ValidateICCDEF_Test4_nii
   COMMAND iccdefRegistration_NewTestDriver
   --compare
@@ -148,7 +148,7 @@ ExternalData_add_test(${PROJECT_NAME}FetchData NAME ValidateICCDEF_Test5_nii
     --medianFilterSize 0,0,0
 )
 
-if(0) #HACK: This test needs to be fixed!
+if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 8) ##This functionality does not work yet
 ExternalData_add_test(${PROJECT_NAME}FetchData NAME ValidateICCDEF_Test6_nii
   COMMAND iccdefRegistration_NewTestDriver
   --compare
@@ -179,7 +179,8 @@ ExternalData_add_test(${PROJECT_NAME}FetchData NAME ValidateICCDEF_Test6_nii
 )
 endif() #HACK: This test needs to be fixed!
 
-if(0) ## These should be re-written to use BRAINSResample instead of ApplyWarp
+## These should be re-written to use BRAINSResample instead of ApplyWarp
+if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 8) ##This functionality does not work yet
 ExternalData_add_test(${PROJECT_NAME}FetchData NAME ValidateApplyWarpTest2_nii
   COMMAND ApplyWarpTestDriver
   --compare
@@ -284,6 +285,4 @@ add_test(NAME itkIterativeInverseDisplacementFieldFilterTest2 COMMAND $<TARGET_F
      ${UNIT_TEST_TEMP_DIR}/inverse_test2.nii.gz
 )
 
-if(0)
-endif()
 ## - ExternalData_Add_Target( ${PROJECT_NAME}FetchData )  # Name of data management target

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -349,7 +349,16 @@ endif()
 #------------------------------------------------------------------------------
 # Configure and build
 #------------------------------------------------------------------------------
-
+## BRAINSTools_MAX_TEST_LEVEL adjusts how agressive the test suite is
+## so that long running tests or incomplete tests can easily be
+## silenced
+## 1 - Run the absolute minimum very fast tests (These should always pass before any code commit)
+## 3 - Run fast tests on continous builds (These need immediate attention if they begin to fail)
+## 5 - Run moderate nightly tests (These need immediate attention if they begin to fail)
+## 7 - Run long running extensive test that are a burden to normal development (perhaps test 1x per week)
+## 8 - Run tests that fail due to incomplete test building, these are good ideas for test that we don't have time to make robust)
+## 9 - Run silly tests that don't have much untility
+set(BRAINSTools_MAX_TEST_LEVEL 3 CACHE STRING "Testing level for managing test burden")
 
 set(proj ${LOCAL_PROJECT_NAME})
 ExternalProject_Add(${proj}
@@ -362,6 +371,7 @@ ExternalProject_Add(${proj}
     --no-warn-unused-cli # HACK Only expected variables should be passed down.
     ${CMAKE_OSX_EXTERNAL_PROJECT_ARGS}
     ${BRAINSTOOLS_EXTERNAL_PROJECT_ARGS}
+    -DBRAINSTools_MAX_TEST_LEVEL:STRING=${BRAINSTools_MAX_TEST_LEVEL}
     -D${LOCAL_PROJECT_NAME}_SUPERBUILD:BOOL=OFF
     -DANTS_SOURCE_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/ANTS
     -DBRAINSTools_LIBRARY_PATH:PATH=${CMAKE_CURRENT_BINARY_DIR}/lib


### PR DESCRIPTION
BRAINSTools_MAX_TEST_LEVEL adjusts how agressive the test suite is
so that long running tests or incomplete tests can easily be
silenced
1 - Run the absolute minimum very fast tests (These should always pass before any code commit)
3 - Run fast tests on continous builds (These need immediate attention if they begin to fail)
5 - Run moderate nightly tests (These need immediate attention if they begin to fail)
7 - Run long running extensive test that are a burden to normal development (perhaps test 1x per week)
8 - Run tests that fail due to incomplete test building, these are good ideas for test that we don't have time to make robust)
9 - Run silly tests that don't have much untility
set(BRAINSTools_MAX_TEST_LEVEL 3 CACHE STRING "Testing level for managing test burden")
