### PR TITLE
ENH: Remove DeformationField parameter from GenericTransformImage

### DIFF
--- a/BRAINSCommonLib/GenericTransformImage.h
+++ b/BRAINSCommonLib/GenericTransformImage.h
@@ -196,7 +196,7 @@ template <typename InputImageType, class OutputImageType, typename DisplacementI
 typename OutputImageType::Pointer GenericTransformImage(
   InputImageType const *const OperandImage,
   const itk::ImageBase<InputImageType::ImageDimension> *ReferenceImage,
-  typename DisplacementImageType::Pointer DisplacementField,
+  // typename DisplacementImageType::Pointer DisplacementField,
   typename GenericTransformType::Pointer genericTransform,
   typename InputImageType::PixelType suggestedDefaultValue, // NOTE:  This is
                                                             // ignored in the

--- a/BRAINSCut/BRAINSCutDataHandler.cxx
+++ b/BRAINSCut/BRAINSCutDataHandler.cxx
@@ -1,6 +1,7 @@
 #include "BRAINSCutDataHandler.h"
 #include "XMLConfigurationFileParser.h"
 #include "GenericTransformImage.h"
+#include "itkDisplacementFieldTransform.h"
 
 /** constructors */
 BRAINSCutDataHandler
@@ -250,6 +251,17 @@ BRAINSCutDataHandler
   DisplacementFieldType::Pointer deformation = GetDeformationField( atlasSubjectRegistrationFilename );
   GenericTransformType::Pointer  genericTransform = GetGenericTransform( atlasSubjectRegistrationFilename );
 
+  // GenericTransformImage's behavior was OR not and -- if both a
+  // deformation and a genericTransform were non-null then the generic
+  // transform was ignored.
+  if(deformation.IsNotNull())
+    {
+    typedef itk::DisplacementFieldTransform<DeformationScalarType,DisplacementFieldType::ImageDimension>
+      DisplacementFieldTransformType;
+    DisplacementFieldTransformType::Pointer dispXfrm = DisplacementFieldTransformType::New();
+    dispXfrm->SetDisplacementField(deformation);
+    genericTransform = dispXfrm.GetPointer();
+    }
   std::string subjectFilenameToUse = subject.GetImageFilenameByType(registrationImageTypeToUse);
 
   if( !itksys::SystemTools::FileExists( subjectFilenameToUse.c_str(), false ) )
@@ -271,19 +283,19 @@ BRAINSCutDataHandler
                                         ("rho", GenericTransformImage<WorkingImageType,
                                                                       WorkingImageType,
                                                                       DisplacementFieldType>
-                                          ( m_rho, referenceImage, deformation, genericTransform,
+                                          ( m_rho, referenceImage, genericTransform,
                                           0.0, "Linear", transoformationPixelType == "binary") ) );
   warpedSpatialLocationImages.insert( std::pair<std::string, WorkingImagePointer>
                                         ("phi", GenericTransformImage<WorkingImageType,
                                                                       WorkingImageType,
                                                                       DisplacementFieldType>
-                                          ( m_phi, referenceImage, deformation, genericTransform,
+                                          ( m_phi, referenceImage, genericTransform,
                                           0.0, "Linear", transoformationPixelType == "binary") ) );
   warpedSpatialLocationImages.insert( std::pair<std::string, WorkingImagePointer>
                                         ("theta", GenericTransformImage<WorkingImageType,
                                                                         WorkingImageType,
                                                                         DisplacementFieldType>
-                                          ( m_theta, referenceImage, deformation, genericTransform,
+                                          ( m_theta, referenceImage, genericTransform,
                                           0.0, "Linear", transoformationPixelType == "binary") ) );
 }
 
@@ -341,6 +353,18 @@ BRAINSCutDataHandler
   DisplacementFieldType::Pointer deformation = GetDeformationField( atlasSubjectRegistrationFilename );
   GenericTransformType::Pointer  genericTransform = GetGenericTransform( atlasSubjectRegistrationFilename );
 
+  // GenericTransformImage's behavior was OR not and -- if both a
+  // deformation and a genericTransform were non-null then the generic
+  // transform was ignored.
+  if(deformation.IsNotNull())
+    {
+    typedef itk::DisplacementFieldTransform<DeformationScalarType,DisplacementFieldType::ImageDimension>
+      DisplacementFieldTransformType;
+    DisplacementFieldTransformType::Pointer dispXfrm = DisplacementFieldTransformType::New();
+    dispXfrm->SetDisplacementField(deformation);
+    genericTransform = dispXfrm.GetPointer();
+    }
+
   WorkingImagePointer referenceImage =
     ReadImageByFilename( subject.GetImageFilenameByType(registrationImageTypeToUse) );
 
@@ -358,8 +382,7 @@ BRAINSCutDataHandler
                          (*roiTyIt), GenericTransformImage<WorkingImageType,
                                                            WorkingImageType,
                                                            DisplacementFieldType>
-                           ( currentROI, referenceImage, deformation,
-                           genericTransform, 0.0, "Linear",
+                         ( currentROI, referenceImage,genericTransform, 0.0, "Linear",
                            transformationPixelType == "binary") ) );
     }
 }

--- a/BRAINSCut/BRAINSCutUtilities.h
+++ b/BRAINSCut/BRAINSCutUtilities.h
@@ -66,7 +66,7 @@ typedef WorkingImageType::Pointer               WorkingImagePointer;
 typedef std::vector<WorkingImagePointer> WorkingImageVectorType;
 
 /* Deformations */
-typedef float                                         DeformationScalarType;
+typedef double                                        DeformationScalarType;
 typedef itk::Vector<DeformationScalarType, DIMENSION> DeformationPixelType;
 typedef itk::Image<DeformationPixelType, DIMENSION>   DisplacementFieldType;
 

--- a/BRAINSFit/BRAINSFit.cxx
+++ b/BRAINSFit/BRAINSFit.cxx
@@ -518,7 +518,7 @@ int main(int argc, char *argv[])
       resampledImage = GenericTransformImage<MovingVolumeType, FixedVolumeType, DisplacementFieldType>(
           preprocessedMovingVolume,
           extractFixedVolume,
-          NULL,
+          // NULL,
           currentGenericTransform,
           backgroundFillValue,
           interpolationMode,

--- a/BRAINSFit/BRAINSFitEZ.cxx
+++ b/BRAINSFit/BRAINSFitEZ.cxx
@@ -520,7 +520,7 @@ int main(int argc, char *argv[])
       resampledImage = GenericTransformImage<MovingVolumeType, FixedVolumeType, DisplacementFieldType>(
           preprocessedMovingVolume,
           extractFixedVolume,
-          NULL,
+          // NULL, // deformation field
           currentGenericTransform,
           backgroundFillValue,
           interpolationMode,


### PR DESCRIPTION
See https://www.icts.uiowa.edu/jira/browse/PREDICTIMG-1667

The GenericTransformImage template function isn't used that many
places. In most it's clear that either a DeformationField or
a Transform is passed in. A few places in BRAINSCut it looks like
both are passed in, but in practice only one or the other is
actually defined.

The way GenericTransformImage was actually written, if both a
transform and a displacement field are passed in, the transform
is ignored.  So I felt justified in enforcing that at the
point of call.  If needed, a DisplaceFieldTransform is created
and the Displacement Image is passed in.

The biggest 'hidden' change this brings about is that the
DisplacementField type is defined as
itk::Imageitk::Vector<float,3,3> but the transform parameter
type is double, so I changed type DisplacementField type so it
was compatible with the Transform type.
