### PR TITLE
COMP: Replace linear image list with map of lists by type.

### DIFF
--- a/BRAINSABC/brainseg/AtlasRegistrationMethod.h
+++ b/BRAINSABC/brainseg/AtlasRegistrationMethod.h
@@ -85,20 +85,38 @@ public:
 
   typedef itk::Array<unsigned char> FlagArrayType;
 
+  typedef std::vector<std::string> StringVector;
+  typedef std::map<std::string,StringVector > MapOfStringVectors;
+
+  typedef std::vector<InternalImagePointer> FloatImageVector;
+  typedef std::map<std::string, FloatImageVector> MapOfFloatImageVectors;
+
+  typedef std::vector<GenericTransformType::Pointer> TransformList;
+  typedef std::map<std::string,TransformList>        MapOfTransformLists;
+
   void SetSuffix(std::string suffix);
 
   itkGetConstMacro(OutputDebugDir, std::string);
   itkSetMacro(OutputDebugDir, std::string);
 
-  void SetAtlasOriginalImageList(std::vector<InternalImagePointer> & NewAtlasList);
+  InternalImagePointer GetFirstIntraSubjectOriginalImage()
+    {
+      return *(this->m_IntraSubjectOriginalImageList.begin()->second.begin());
+    }
+  InternalImagePointer GetFirstAtlasOriginalImage()
+    {
+      return *(this->m_AtlasOriginalImageList.begin()->second.begin());
+    }
 
-  void SetIntraSubjectOriginalImageList(std::vector<InternalImagePointer> & NewImageList);
+  void SetAtlasOriginalImageList(MapOfFloatImageVectors & NewAtlasList);
+
+  void SetIntraSubjectOriginalImageList(MapOfFloatImageVectors & NewImageList);
 
   // itkSetMacro( IntraSubjectTransformFileNames, std::vector<std::string> );
   itkSetMacro( AtlasToSubjectTransformFileName, std::string );
 
   // TODO: KENT:  Move all code from class definition to the .hxx file outside the class definition
-  void SetIntraSubjectTransformFileNames(std::vector<std::string> userlist)
+  void SetIntraSubjectTransformFileNames(MapOfStringVectors userlist)
   {
     m_IntraSubjectTransformFileNames = userlist;
     m_RegistrationUpdateNeeded = true;
@@ -111,7 +129,7 @@ public:
     return m_AtlasToSubjectTransform;
   }
 
-  std::vector<GenericTransformType::Pointer> GetIntraSubjectTransforms()
+  MapOfTransformLists  GetIntraSubjectTransforms()
   {
     return m_IntraSubjectTransforms;
   }
@@ -141,13 +159,6 @@ public:
     m_RegistrationUpdateNeeded = true;
   }
 
-  // Get and set the input volume image types.  i.e. T1 or T2 or PD
-  void SetInputVolumeTypes(const std::vector<std::string> & newInputVolumeTypes)
-  {
-    this->m_InputVolumeTypes = newInputVolumeTypes;
-    m_RegistrationUpdateNeeded = true;
-  }
-
   void SetAtlasToSubjectInitialTransform( const GenericTransformType::Pointer atlasToSubjectInitialTransform)
   {
     if( this->m_AtlasToSubjectInitialTransform != atlasToSubjectInitialTransform )
@@ -155,11 +166,6 @@ public:
       this->m_AtlasToSubjectInitialTransform = atlasToSubjectInitialTransform;
       m_RegistrationUpdateNeeded = true;
       }
-  }
-
-  std::vector<std::string> GetInputVolumeTypes(void) const
-  {
-    return this->m_InputVolumeTypes;
   }
 
   void Update();
@@ -182,20 +188,18 @@ private:
   std::string m_OutputDebugDir;
 
   //  ByteImagePointer                  m_AtlasOriginalMask;
-  std::vector<InternalImagePointer> m_AtlasOriginalImageList;
-  std::vector<InternalImagePointer> m_IntraSubjectOriginalImageList;
-  ByteImagePointer                  m_InputImageTissueRegion;
-  ImageMaskPointer                  m_InputSpatialObjectTissueRegion;
+  MapOfFloatImageVectors m_AtlasOriginalImageList;
+  MapOfFloatImageVectors m_IntraSubjectOriginalImageList;
+  ByteImagePointer m_InputImageTissueRegion;
+  ImageMaskPointer m_InputSpatialObjectTissueRegion;
 
   std::vector<unsigned int> m_WarpGrid;
-  std::vector<std::string>  m_IntraSubjectTransformFileNames;
+  MapOfStringVectors          m_IntraSubjectTransformFileNames;
   std::string               m_AtlasToSubjectTransformFileName;
 
-  std::vector<std::string> m_InputVolumeTypes;
-
-  GenericTransformType::Pointer              m_AtlasToSubjectTransform;
-  GenericTransformType::Pointer              m_AtlasToSubjectInitialTransform;
-  std::vector<GenericTransformType::Pointer> m_IntraSubjectTransforms;
+  GenericTransformType::Pointer m_AtlasToSubjectTransform;
+  GenericTransformType::Pointer m_AtlasToSubjectInitialTransform;
+  MapOfTransformLists           m_IntraSubjectTransforms;
 
   bool m_UseNonLinearInterpolation;
   bool m_DoneRegistration;

--- a/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
+++ b/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
@@ -67,7 +67,7 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
 template <class TOutputPixel, class TProbabilityPixel>
 void
 AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
-::SetAtlasOriginalImageList(std::vector<InternalImagePointer> & NewAtlasList)
+::SetAtlasOriginalImageList(MapOfFloatImageVectors & NewAtlasList)
 {
   m_AtlasOriginalImageList = NewAtlasList;
   m_AtlasToSubjectTransform = MakeRigidIdentity();
@@ -78,7 +78,7 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
 template <class TOutputPixel, class TProbabilityPixel>
 void
 AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
-::SetIntraSubjectOriginalImageList(std::vector<InternalImagePointer> & NewIntraSubjectOriginalImageList)
+::SetIntraSubjectOriginalImageList(MapOfFloatImageVectors &NewIntraSubjectOriginalImageList)
 {
   muLogMacro(<< "Set Intrasubject original image list" << std::endl);
 
@@ -92,11 +92,15 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
   m_AtlasToSubjectTransform = MakeRigidIdentity();
   // Clear previous transforms
   m_IntraSubjectTransforms.clear();
-  m_IntraSubjectTransforms.resize(numIntraSubjectOriginalImages);
-  for( unsigned int i = 0; i < numIntraSubjectOriginalImages; i++ )
-    { // Also append identity matrix for each image
-    GenericTransformType::Pointer transform = MakeRigidIdentity();
-    m_IntraSubjectTransforms[i] = transform;
+  for(MapOfFloatImageVectors::iterator mapIt = this->m_IntraSubjectOriginalImageList.begin();
+      mapIt != this->m_IntraSubjectOriginalImageList.end(); ++mapIt)
+    {
+    for(FloatImageVector::iterator imIt = mapIt->second.begin();
+        imIt != mapIt->second.end(); ++imIt)
+      { // Also append identity matrix for each image
+      GenericTransformType::Pointer transform = MakeRigidIdentity();
+      m_IntraSubjectTransforms[mapIt->first].push_back(transform);
+      }
     }
   m_DoneRegistration = false;
   m_RegistrationUpdateNeeded = true;
@@ -125,55 +129,62 @@ void
 AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
 ::RegisterIntraSubjectImages()
 {
+
   muLogMacro(<< "Register Intra subject images" << std::endl);
-  for( unsigned int i = 1; i < m_IntraSubjectOriginalImageList.size(); i++ )
+  int i = 0;
+  for(MapOfFloatImageVectors::iterator mapIt = this->m_IntraSubjectOriginalImageList.begin();
+      mapIt != this->m_IntraSubjectOriginalImageList.end(); ++mapIt)
     {
-    if( itksys::SystemTools::FileExists( this->m_IntraSubjectTransformFileNames[i].c_str() ) )
+    FloatImageVector::iterator imIt = mapIt->second.begin();
+    FloatImageVector::iterator intraImIt = this->m_IntraSubjectOriginalImageList[mapIt->first].begin();
+    StringVector::iterator isNamesIt = this->m_IntraSubjectTransformFileNames[mapIt->first].begin();
+
+    for(;imIt != mapIt->second.end(); ++imIt, ++isNamesIt, ++intraImIt, ++i)
       {
-      try
+      if( itksys::SystemTools::FileExists( (*isNamesIt).c_str() ) )
         {
-        muLogMacro(<< "Reading transform from file: "
-                   << this->m_IntraSubjectTransformFileNames[i] << "." << std::endl);
-        m_IntraSubjectTransforms[i] = itk::ReadTransformFromDisk(this->m_IntraSubjectTransformFileNames[i]);
+        try
+          {
+          muLogMacro(<< "Reading transform from file: "
+                     << (*isNamesIt).c_str() << "." << std::endl);
+          m_IntraSubjectTransforms[mapIt->first].push_back(itk::ReadTransformFromDisk((*isNamesIt).c_str()));
+          }
+        catch( ... )
+          {
+          muLogMacro(<< "Failed to read transform file caused exception." << (*isNamesIt) <<  std::endl );
+          itkExceptionMacro(<< "Failed to read transform file " <<  (*isNamesIt));
+          }
         }
-      catch( ... )
+      else if( m_ImageLinearTransformChoice == "Identity" )
         {
-        muLogMacro(<< "Failed to read transform file caused exception." << this->m_IntraSubjectTransformFileNames[i]
-                   <<  std::endl );
-        itkExceptionMacro(<< "Failed to read transform file " <<  this->m_IntraSubjectTransformFileNames[i]);
+        muLogMacro(<< "Registering (Identity) image " << i + 1 << " to first image." << std::endl);
+        m_IntraSubjectTransforms[mapIt->first].push_back(MakeRigidIdentity());
         }
-      }
-    else if( m_ImageLinearTransformChoice == "Identity" )
-      {
-      muLogMacro(<< "Registering (Identity) image " << i + 1 << " to first image." << std::endl);
-      m_IntraSubjectTransforms[i] = MakeRigidIdentity();
-      }
-    else
-      {
-      typedef itk::BRAINSFitHelper HelperType;
-      HelperType::Pointer intraSubjectRegistrationHelper = HelperType::New();
-      intraSubjectRegistrationHelper->SetNumberOfSamples(500000);
-      intraSubjectRegistrationHelper->SetNumberOfHistogramBins(50);
-      std::vector<int> numberOfIterations(1);
-      numberOfIterations[0] = 1500;
-      intraSubjectRegistrationHelper->SetNumberOfIterations(numberOfIterations);
-      //
-      //
-      //
-      // intraSubjectRegistrationHelper->SetMaximumStepLength(maximumStepSize);
-      intraSubjectRegistrationHelper->SetTranslationScale(1000);
-      intraSubjectRegistrationHelper->SetReproportionScale(1.0);
-      intraSubjectRegistrationHelper->SetSkewScale(1.0);
-      // Register each intrasubject image mode to first image
-      intraSubjectRegistrationHelper->SetFixedVolume(m_IntraSubjectOriginalImageList[0]);
-      // TODO: Find way to turn on histogram equalization for same mode images
-      const int dilateSize = 15;
-      intraSubjectRegistrationHelper->SetMovingVolume(m_IntraSubjectOriginalImageList[i]);
+      else
         {
+        typedef itk::BRAINSFitHelper HelperType;
+        HelperType::Pointer intraSubjectRegistrationHelper = HelperType::New();
+        intraSubjectRegistrationHelper->SetNumberOfSamples(500000);
+        intraSubjectRegistrationHelper->SetNumberOfHistogramBins(50);
+        std::vector<int> numberOfIterations(1);
+        numberOfIterations[0] = 1500;
+        intraSubjectRegistrationHelper->SetNumberOfIterations(numberOfIterations);
+        //
+        //
+        //
+        // intraSubjectRegistrationHelper->SetMaximumStepLength(maximumStepSize);
+        intraSubjectRegistrationHelper->SetTranslationScale(1000);
+        intraSubjectRegistrationHelper->SetReproportionScale(1.0);
+        intraSubjectRegistrationHelper->SetSkewScale(1.0);
+        // Register each intrasubject image mode to first image
+        intraSubjectRegistrationHelper->SetFixedVolume(this->GetFirstIntraSubjectOriginalImage());
+        // TODO: Find way to turn on histogram equalization for same mode images
+        const int dilateSize = 15;
+        intraSubjectRegistrationHelper->SetMovingVolume((*intraImIt));
         muLogMacro( << "Generating MovingImage Mask (Intrasubject  " << i << ")" <<  std::endl );
         typedef itk::BRAINSROIAutoImageFilter<InternalImageType, itk::Image<unsigned char, 3> > ROIAutoType;
         typename ROIAutoType::Pointer  ROIFilter = ROIAutoType::New();
-        ROIFilter->SetInput(m_IntraSubjectOriginalImageList[i]);
+        ROIFilter->SetInput((*intraImIt));
         ROIFilter->SetDilateSize(dilateSize); // Only use a very small non-tissue
         // region outside of head during initial
         // runnings
@@ -195,15 +206,14 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
           writer->Update();
           muLogMacro( << __FILE__ << " " << __LINE__ << " "  <<  std::endl );
           }
-        }
-        {
+
         // Delayed until first use, but only create it once.
         if( m_InputImageTissueRegion.IsNull() || m_InputSpatialObjectTissueRegion.IsNull() )
           {
           muLogMacro( << "Generating FixedImage Mask (Intrasubject)" <<  std::endl );
           typedef itk::BRAINSROIAutoImageFilter<InternalImageType, itk::Image<unsigned char, 3> > ROIAutoType;
-          typename ROIAutoType::Pointer  ROIFilter = ROIAutoType::New();
-          ROIFilter->SetInput(m_IntraSubjectOriginalImageList[0]);
+          ROIFilter = ROIAutoType::New();
+          ROIFilter->SetInput(this->GetFirstIntraSubjectOriginalImage());
           ROIFilter->SetDilateSize(dilateSize); // Only use a very small non-tissue
           // region outside of head during
           // initial runnings
@@ -227,108 +237,107 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
             }
           }
         intraSubjectRegistrationHelper->SetFixedBinaryVolume(m_InputSpatialObjectTissueRegion);
-        }
-      if( m_ImageLinearTransformChoice == "Rigid" )
-        {
-        muLogMacro(<< "Registering (Rigid) image " << i << " to first image." << std::endl);
-        std::vector<double> minimumStepSize(1);
-        minimumStepSize[0] = 0.00005;
-        intraSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
-        std::vector<std::string> transformType(1);
-        transformType[0] = "Rigid";
-        intraSubjectRegistrationHelper->SetTransformType(transformType);
-        }
-      else if( m_ImageLinearTransformChoice == "Affine" )
-        {
-        muLogMacro(<< "Registering (Affine) image " << i << " to first image." << std::endl);
-        std::vector<double> minimumStepSize(4);
-        minimumStepSize[0] = 0.00005;
-        minimumStepSize[1] = 0.005;
-        minimumStepSize[2] = 0.005;
-        minimumStepSize[3] = 0.005;
-        intraSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
-        std::vector<std::string> transformType(4);
-        transformType[0] = "Rigid";
-        transformType[1] = "ScaleVersor3D";
-        transformType[2] = "ScaleSkewVersor3D";
-        transformType[3] = "Affine";
-        intraSubjectRegistrationHelper->SetTransformType(transformType);
-        }
-      else if( m_ImageLinearTransformChoice == "BSpline" )
-        {
-        muLogMacro(<< "Registering (BSpline) image " << i << " to first subject image." << std::endl);
-        std::vector<double> minimumStepSize(5);
-        minimumStepSize[0] = 0.00005;
-        minimumStepSize[1] = 0.005;
-        minimumStepSize[2] = 0.005;
-        minimumStepSize[3] = 0.005;
-        minimumStepSize[4] = 0.005;
-        intraSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
-        std::vector<std::string> transformType(5);
-        transformType[0] = "Rigid";
-        transformType[1] = "ScaleVersor3D";
-        transformType[2] = "ScaleSkewVersor3D";
-        transformType[3] = "Affine";
-        transformType[4] = "BSpline";
-        intraSubjectRegistrationHelper->SetTransformType(transformType);
-        std::vector<int> splineGridSize(3);
-        splineGridSize[0] = this->m_WarpGrid[0];
-        splineGridSize[1] = this->m_WarpGrid[1];
-        splineGridSize[2] = this->m_WarpGrid[2];
-        intraSubjectRegistrationHelper->SetSplineGridSize(splineGridSize);
-        // Setting max displace
-        intraSubjectRegistrationHelper->SetMaxBSplineDisplacement(6.0);
-        // intraSubjectRegistrationHelper->SetUseExplicitPDFDerivativesMode(useExplicitPDFDerivativesMode);
-        // intraSubjectRegistrationHelper->SetUseCachingOfBSplineWeightsMode(useCachingOfBSplineWeightsMode);
-        }
-      else if( m_ImageLinearTransformChoice == "SyN" )
-        {
-        muLogMacro(<< "Registering (SyN) image " << i << " to first subject image." << std::endl);
-        std::vector<double> minimumStepSize(5);
-        minimumStepSize[0] = 0.00005;
-        minimumStepSize[1] = 0.005;
-        minimumStepSize[2] = 0.005;
-        minimumStepSize[3] = 0.005;
-        minimumStepSize[4] = 0.000005;
-        intraSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
-        std::vector<std::string> transformType(5);
-        transformType[0] = "Rigid";
-        transformType[1] = "ScaleVersor3D";
-        transformType[2] = "ScaleSkewVersor3D";
-        transformType[3] = "Affine";
-        transformType[4] = "SyN";
-        intraSubjectRegistrationHelper->SetTransformType(transformType);
-        }
-      //
-      // intraSubjectRegistrationHelper->SetBackgroundFillValue(backgroundFillValue);
-      // NOT VALID When using initializeTransformMode
-      //
-      // intraSubjectRegistrationHelper->SetCurrentGenericTransform(currentGenericTransform);
-      //  intraSubjectRegistrationHelper->SetUseWindowedSinc(useWindowedSinc);
-      const std::string initializeTransformMode("useCenterOfHeadAlign");
-      intraSubjectRegistrationHelper->SetInitializeTransformMode(initializeTransformMode);
-      intraSubjectRegistrationHelper->SetMaskInferiorCutOffFromCenter(65.0); //
-      //
-      // maskInferiorCutOffFromCenter);
-      m_IntraSubjectTransforms[i] = NULL;
-      intraSubjectRegistrationHelper->SetCurrentGenericTransform(m_IntraSubjectTransforms[i]);
-      if( this->m_DebugLevel > 9 )
-        {
-        static unsigned int IntraSubjectRegistration = 0;
-        std::stringstream   ss;
-        ss << std::setw(3) << std::setfill('0') << IntraSubjectRegistration;
-        intraSubjectRegistrationHelper->PrintCommandLine(true, std::string("IntraSubjectRegistration") + ss.str() );
-        muLogMacro( << __FILE__ << " " << __LINE__ << " "  <<  std::endl );
-        IntraSubjectRegistration++;
-        }
-      intraSubjectRegistrationHelper->Update();
-      const unsigned int actualIterations = intraSubjectRegistrationHelper->GetActualNumberOfIterations();
-      muLogMacro( << "Registration tool " << actualIterations << " iterations." << std::endl );
-      m_IntraSubjectTransforms[i] = intraSubjectRegistrationHelper->GetCurrentGenericTransform();
-      // Write out intermodal matricies
-        {
-        muLogMacro(<< "Writing " << this->m_IntraSubjectTransformFileNames[i] << "." << std::endl);
-        WriteTransformToDisk(m_IntraSubjectTransforms[i], this->m_IntraSubjectTransformFileNames[i]);
+        if( m_ImageLinearTransformChoice == "Rigid" )
+          {
+          muLogMacro(<< "Registering (Rigid) image " << i << " to first image." << std::endl);
+          std::vector<double> minimumStepSize(1);
+          minimumStepSize[0] = 0.00005;
+          intraSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
+          std::vector<std::string> transformType(1);
+          transformType[0] = "Rigid";
+          intraSubjectRegistrationHelper->SetTransformType(transformType);
+          }
+        else if( m_ImageLinearTransformChoice == "Affine" )
+          {
+          muLogMacro(<< "Registering (Affine) image " << i << " to first image." << std::endl);
+          std::vector<double> minimumStepSize(4);
+          minimumStepSize[0] = 0.00005;
+          minimumStepSize[1] = 0.005;
+          minimumStepSize[2] = 0.005;
+          minimumStepSize[3] = 0.005;
+          intraSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
+          std::vector<std::string> transformType(4);
+          transformType[0] = "Rigid";
+          transformType[1] = "ScaleVersor3D";
+          transformType[2] = "ScaleSkewVersor3D";
+          transformType[3] = "Affine";
+          intraSubjectRegistrationHelper->SetTransformType(transformType);
+          }
+        else if( m_ImageLinearTransformChoice == "BSpline" )
+          {
+          muLogMacro(<< "Registering (BSpline) image " << i << " to first subject image." << std::endl);
+          std::vector<double> minimumStepSize(5);
+          minimumStepSize[0] = 0.00005;
+          minimumStepSize[1] = 0.005;
+          minimumStepSize[2] = 0.005;
+          minimumStepSize[3] = 0.005;
+          minimumStepSize[4] = 0.005;
+          intraSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
+          std::vector<std::string> transformType(5);
+          transformType[0] = "Rigid";
+          transformType[1] = "ScaleVersor3D";
+          transformType[2] = "ScaleSkewVersor3D";
+          transformType[3] = "Affine";
+          transformType[4] = "BSpline";
+          intraSubjectRegistrationHelper->SetTransformType(transformType);
+          std::vector<int> splineGridSize(3);
+          splineGridSize[0] = this->m_WarpGrid[0];
+          splineGridSize[1] = this->m_WarpGrid[1];
+          splineGridSize[2] = this->m_WarpGrid[2];
+          intraSubjectRegistrationHelper->SetSplineGridSize(splineGridSize);
+          // Setting max displace
+          intraSubjectRegistrationHelper->SetMaxBSplineDisplacement(6.0);
+          // intraSubjectRegistrationHelper->SetUseExplicitPDFDerivativesMode(useExplicitPDFDerivativesMode);
+          // intraSubjectRegistrationHelper->SetUseCachingOfBSplineWeightsMode(useCachingOfBSplineWeightsMode);
+          }
+        else if( m_ImageLinearTransformChoice == "SyN" )
+          {
+          muLogMacro(<< "Registering (SyN) image " << i << " to first subject image." << std::endl);
+          std::vector<double> minimumStepSize(5);
+          minimumStepSize[0] = 0.00005;
+          minimumStepSize[1] = 0.005;
+          minimumStepSize[2] = 0.005;
+          minimumStepSize[3] = 0.005;
+          minimumStepSize[4] = 0.000005;
+          intraSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
+          std::vector<std::string> transformType(5);
+          transformType[0] = "Rigid";
+          transformType[1] = "ScaleVersor3D";
+          transformType[2] = "ScaleSkewVersor3D";
+          transformType[3] = "Affine";
+          transformType[4] = "SyN";
+          intraSubjectRegistrationHelper->SetTransformType(transformType);
+          }
+        //
+        // intraSubjectRegistrationHelper->SetBackgroundFillValue(backgroundFillValue);
+        // NOT VALID When using initializeTransformMode
+        //
+        // intraSubjectRegistrationHelper->SetCurrentGenericTransform(currentGenericTransform);
+        //  intraSubjectRegistrationHelper->SetUseWindowedSinc(useWindowedSinc);
+        const std::string initializeTransformMode("useCenterOfHeadAlign");
+        intraSubjectRegistrationHelper->SetInitializeTransformMode(initializeTransformMode);
+        intraSubjectRegistrationHelper->SetMaskInferiorCutOffFromCenter(65.0); //
+        //
+        // maskInferiorCutOffFromCenter);
+        intraSubjectRegistrationHelper->SetCurrentGenericTransform(0);
+        if( this->m_DebugLevel > 9 )
+          {
+          static unsigned int IntraSubjectRegistration = 0;
+          std::stringstream   ss;
+          ss << std::setw(3) << std::setfill('0') << IntraSubjectRegistration;
+          intraSubjectRegistrationHelper->PrintCommandLine(true, std::string("IntraSubjectRegistration") + ss.str() );
+          muLogMacro( << __FILE__ << " " << __LINE__ << " "  <<  std::endl );
+          IntraSubjectRegistration++;
+          }
+        intraSubjectRegistrationHelper->Update();
+        const unsigned int actualIterations = intraSubjectRegistrationHelper->GetActualNumberOfIterations();
+        muLogMacro( << "Registration tool " << actualIterations << " iterations." << std::endl );
+        GenericTransformType::Pointer p =
+          intraSubjectRegistrationHelper->GetCurrentGenericTransform();
+        this->m_IntraSubjectTransforms[mapIt->first].push_back(p);
+        // Write out intermodal matricies
+        muLogMacro(<< "Writing " << (*isNamesIt) << "." << std::endl);
+        WriteTransformToDisk(p, (*isNamesIt));
         }
       }
     }
@@ -431,184 +440,170 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
     // Initialize the outputTransform with the initializer before starting the loop.
     this->m_AtlasToSubjectTransform = this->m_AtlasToSubjectInitialTransform;
     atlasToSubjectRegistrationHelper->SetCurrentGenericTransform(m_AtlasToSubjectTransform);
-    const unsigned int atlasReferenceImageIndex = 0;
-      {   // Register all atlas images to first image
-        { // Set the fixed and moving image
-        atlasToSubjectRegistrationHelper->SetFixedVolume(m_IntraSubjectOriginalImageList[atlasReferenceImageIndex]);
-        atlasToSubjectRegistrationHelper->SetMovingVolume(m_AtlasOriginalImageList[atlasReferenceImageIndex]);
-        }
-        {
-        muLogMacro( << "Generating MovingImage Mask (Atlas " << atlasReferenceImageIndex << ")" <<   std::endl );
-        typedef itk::BRAINSROIAutoImageFilter<InternalImageType, itk::Image<unsigned char, 3> > ROIAutoType;
-        typename ROIAutoType::Pointer  ROIFilter = ROIAutoType::New();
-        ROIFilter->SetInput(m_AtlasOriginalImageList[atlasReferenceImageIndex]);
-        ROIFilter->SetDilateSize(1);   // Only use a very small non-tissue
-        // region outside of head during
-        // initial runnings
-        ROIFilter->Update();
-        atlasToSubjectRegistrationHelper->SetMovingBinaryVolume(ROIFilter->GetSpatialObjectROI() );
-        if( this->m_DebugLevel > 7 )
-          {
-          ByteImageType::Pointer movingMaskImage = ROIFilter->GetOutput();
-          typedef itk::ImageFileWriter<ByteImageType> ByteWriterType;
-          ByteWriterType::Pointer writer = ByteWriterType::New();
-          writer->UseCompressionOn();
-
-          std::ostringstream oss;
-          oss << this->m_OutputDebugDir << "Atlas_MovingMask_"
-              << atlasReferenceImageIndex <<  ".nii.gz" << std::ends;
-          std::string fn = oss.str();
-
-          writer->SetInput( movingMaskImage );
-          writer->SetFileName(fn.c_str() );
-          writer->Update();
-          muLogMacro( << __FILE__ << " " << __LINE__ << " "  <<   std::endl );
-          }
-        }
-        {
-        muLogMacro( << "Generating FixedImage Mask (Atlas)" <<   std::endl );
-        typedef itk::BRAINSROIAutoImageFilter<InternalImageType, itk::Image<unsigned char, 3> > ROIAutoType;
-        typename ROIAutoType::Pointer  ROIFilter = ROIAutoType::New();
-        ROIFilter->SetInput(m_IntraSubjectOriginalImageList[atlasReferenceImageIndex]);
-        ROIFilter->SetDilateSize(1);   // Only use a very small non-tissue
-        // region outside of head during
-        // initial runnings
-        ROIFilter->Update();
-        atlasToSubjectRegistrationHelper->SetFixedBinaryVolume(ROIFilter->GetSpatialObjectROI() );
-        if( this->m_DebugLevel > 7 )
-          {
-          ByteImageType::Pointer fixedMaskImage = ROIFilter->GetOutput();
-          typedef itk::ImageFileWriter<ByteImageType> ByteWriterType;
-          ByteWriterType::Pointer writer = ByteWriterType::New();
-          writer->UseCompressionOn();
-
-          std::ostringstream oss;
-          oss << this->m_OutputDebugDir << "SubjectForAtlas_FixedMask_"
-              << atlasReferenceImageIndex <<  ".nii.gz";
-          std::string fn = oss.str();
-
-          writer->SetInput( fixedMaskImage );
-          writer->SetFileName(fn.c_str() );
-          writer->Update();
-          muLogMacro( << __FILE__ << " " << __LINE__ << " "  <<   std::endl );
-          }
-        }
-      // ##########################################
-      // ##########################################
-      // Set up registration schedule
-      // ##########################################
-      // ##########################################
-        {   // Now do optimal registration based on requested transform choice.
-        if( m_AtlasLinearTransformChoice == "Affine" )
-          {
-          muLogMacro(
-            << "Registering (Affine) " <<  "atlas(" << atlasReferenceImageIndex
-            << ") to template("
-            << atlasReferenceImageIndex << ") image." << std::endl);
-          std::vector<double>      minimumStepSize;
-          std::vector<std::string> transformType;
-          // Do full registration at first iteration level if InitialTransform not given
-          if( atlasToSubjectInitialTransformName == "" )   // If no initial transform, then do full multi-step
-                                                           // registration.
-            {
-            minimumStepSize.push_back(0.0025);
-            transformType.push_back("Rigid");
-            minimumStepSize.push_back(0.0025);
-            transformType.push_back("ScaleVersor3D");
-            minimumStepSize.push_back(0.0025);
-            transformType.push_back("ScaleSkewVersor3D");
-            }
-          else if( atlasToSubjectInitialTransformName != "AffineTransform" )
-            {
-            itkExceptionMacro( << "ERROR: Invalid atlasToSubjectInitialTransformName"
-                               << " type for m_AtlasLinearTransformChoice of type Affine" );
-            }
-          minimumStepSize.push_back(0.0025);
-          transformType.push_back("Affine");
-          atlasToSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
-          atlasToSubjectRegistrationHelper->SetTransformType(transformType);
-          }
-        else if( m_AtlasLinearTransformChoice == "SyN" )
-          {
-          muLogMacro(
-            << "Registering (SyN) " << "atlas(" << atlasReferenceImageIndex
-            << ") to template("
-            << atlasReferenceImageIndex << ") image." << std::endl);
-          std::vector<double>      minimumStepSize;
-          std::vector<std::string> transformType;
-          if( atlasToSubjectInitialTransformName == "" )   // If no initial transform, then do full multi-step
-                                                           // registration.
-            {
-            minimumStepSize.push_back(0.0025);
-            transformType.push_back("Rigid");
-            minimumStepSize.push_back(0.0025);
-            transformType.push_back("ScaleVersor3D");
-            minimumStepSize.push_back(0.0025);
-            transformType.push_back("ScaleSkewVersor3D");
-            minimumStepSize.push_back(0.0025);
-            transformType.push_back("Affine");
-            }
-          else if( atlasToSubjectInitialTransformName == "AffineTransform" )   // If initial Transform is Affine, then
-                                                                               // update the affine stage
-            {
-            minimumStepSize.push_back(0.0025);
-            transformType.push_back("Affine");
-            }
-          else if( atlasToSubjectInitialTransformName != "SyN" )
-            {
-            itkExceptionMacro( << "ERROR: Invalid atlasToSubjectInitialTransformName"
-                               << " type for m_AtlasLinearTransformChoice of type SyN" );
-            }
-          minimumStepSize.push_back(0.0025);
-          transformType.push_back("SyN");
-          atlasToSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
-          atlasToSubjectRegistrationHelper->SetTransformType(transformType);
-          }
-        else
-          {
-          itkExceptionMacro(<< "ERROR: Invalid atlasToSubjectInitialTransformName"
-                            << " type for m_AtlasLinearTransformChoice of type "
-                            << m_AtlasLinearTransformChoice);
-          }
-        }
-
-      if( this->m_DebugLevel > 9 && m_AtlasToSubjectTransform.IsNotNull() )
-        {
-        muLogMacro( << "PRE_ASSIGNMENT" <<  atlasReferenceImageIndex << "  " );
-        // << transformType[0] << " first of " << transformType.size() << std::endl );
-        muLogMacro(<< __FILE__ << " " << __LINE__ << " "
-                   << m_AtlasToSubjectTransform->GetFixedParameters() <<   std::endl );
-        muLogMacro(<< __FILE__ << " " << __LINE__ << " "
-                   << m_AtlasToSubjectTransform->GetParameters() <<   std::endl );
-        }
-      if( this->m_DebugLevel > 9 )
-        {
-        static unsigned int originalAtlasToSubject = 0;
-        std::stringstream   ss;
-        ss << std::setw(3) << std::setfill('0') << originalAtlasToSubject;
-        atlasToSubjectRegistrationHelper->PrintCommandLine(true, std::string("AtlasToSubject") + ss.str() );
-        muLogMacro( << __FILE__ << " " << __LINE__ << " "  <<   std::endl );
-        originalAtlasToSubject++;
-        }
-      atlasToSubjectRegistrationHelper->Update();
-      const unsigned int actualIterations = atlasToSubjectRegistrationHelper->GetActualNumberOfIterations();
-      muLogMacro( << "Registration tool " << actualIterations << " iterations." << std::endl );
-      m_AtlasToSubjectTransform = atlasToSubjectRegistrationHelper->GetCurrentGenericTransform();
-      if( this->m_DebugLevel > 9 )
-        {
-        muLogMacro( << "POST_ASSIGNMENT" <<  atlasReferenceImageIndex << "  " );
-        // << transformType[0] << " first of " << transformType.size() << std::endl );
-        muLogMacro(<< __FILE__ << " " << __LINE__
-                   << " " << m_AtlasToSubjectTransform->GetFixedParameters() <<   std::endl );
-        muLogMacro(<< __FILE__ << " " << __LINE__
-                   << " " << m_AtlasToSubjectTransform->GetParameters() <<   std::endl );
-        }
-      }
-      // End generating the best initial transform for atlas T1 to subject T1
+    // Register all atlas images to first image
+    // Set the fixed and moving image
+    atlasToSubjectRegistrationHelper->SetFixedVolume(this->GetFirstIntraSubjectOriginalImage());
+    atlasToSubjectRegistrationHelper->SetMovingVolume(this->GetFirstAtlasOriginalImage());
+    muLogMacro( << "Generating MovingImage Mask (Atlas 0)" <<   std::endl );
+    typedef itk::BRAINSROIAutoImageFilter<InternalImageType, itk::Image<unsigned char, 3> > ROIAutoType;
+    typename ROIAutoType::Pointer  ROIFilter = ROIAutoType::New();
+    ROIFilter->SetInput(this->GetFirstAtlasOriginalImage());
+    ROIFilter->SetDilateSize(1);   // Only use a very small non-tissue
+    // region outside of head during
+    // initial runnings
+    ROIFilter->Update();
+    atlasToSubjectRegistrationHelper->SetMovingBinaryVolume(ROIFilter->GetSpatialObjectROI() );
+    if( this->m_DebugLevel > 7 )
       {
-      muLogMacro(<< "Writing " << this->m_AtlasToSubjectTransformFileName << "." << std::endl);
-      WriteTransformToDisk(m_AtlasToSubjectTransform, this->m_AtlasToSubjectTransformFileName);
+      ByteImageType::Pointer movingMaskImage = ROIFilter->GetOutput();
+      typedef itk::ImageFileWriter<ByteImageType> ByteWriterType;
+      ByteWriterType::Pointer writer = ByteWriterType::New();
+      writer->UseCompressionOn();
+
+      std::ostringstream oss;
+      oss << this->m_OutputDebugDir << "Atlas_MovingMask_0.nii.gz" << std::ends;
+      std::string fn = oss.str();
+
+      writer->SetInput( movingMaskImage );
+      writer->SetFileName(fn.c_str() );
+      writer->Update();
+      muLogMacro( << __FILE__ << " " << __LINE__ << " "  <<   std::endl );
       }
+
+    muLogMacro( << "Generating FixedImage Mask (Atlas)" <<   std::endl );
+    typedef itk::BRAINSROIAutoImageFilter<InternalImageType, itk::Image<unsigned char, 3> > ROIAutoType;
+    ROIFilter = ROIAutoType::New();
+    ROIFilter->SetInput(this->GetFirstIntraSubjectOriginalImage());
+    ROIFilter->SetDilateSize(1);   // Only use a very small non-tissue
+    // region outside of head during
+    // initial runnings
+    ROIFilter->Update();
+    atlasToSubjectRegistrationHelper->SetFixedBinaryVolume(ROIFilter->GetSpatialObjectROI() );
+    if( this->m_DebugLevel > 7 )
+      {
+      ByteImageType::Pointer fixedMaskImage = ROIFilter->GetOutput();
+      typedef itk::ImageFileWriter<ByteImageType> ByteWriterType;
+      ByteWriterType::Pointer writer = ByteWriterType::New();
+      writer->UseCompressionOn();
+
+      std::ostringstream oss;
+      oss << this->m_OutputDebugDir << "SubjectForAtlas_FixedMask_0.nii.gz";
+      std::string fn = oss.str();
+
+      writer->SetInput( fixedMaskImage );
+      writer->SetFileName(fn.c_str() );
+      writer->Update();
+      muLogMacro( << __FILE__ << " " << __LINE__ << " "  <<   std::endl );
+      }
+    // ##########################################
+    // ##########################################
+    // Set up registration schedule
+    // ##########################################
+    // ##########################################
+    {   // Now do optimal registration based on requested transform choice.
+    if( m_AtlasLinearTransformChoice == "Affine" )
+      {
+      muLogMacro(
+        << "Registering (Affine) " <<  "atlas(0) to template(0) image." << std::endl);
+      std::vector<double>      minimumStepSize;
+      std::vector<std::string> transformType;
+      // Do full registration at first iteration level if InitialTransform not given
+      if( atlasToSubjectInitialTransformName == "" )   // If no initial transform, then do full multi-step
+        // registration.
+        {
+        minimumStepSize.push_back(0.0025);
+        transformType.push_back("Rigid");
+        minimumStepSize.push_back(0.0025);
+        transformType.push_back("ScaleVersor3D");
+        minimumStepSize.push_back(0.0025);
+        transformType.push_back("ScaleSkewVersor3D");
+        }
+      else if( atlasToSubjectInitialTransformName != "AffineTransform" )
+        {
+        itkExceptionMacro( << "ERROR: Invalid atlasToSubjectInitialTransformName"
+                           << " type for m_AtlasLinearTransformChoice of type Affine" );
+        }
+      minimumStepSize.push_back(0.0025);
+      transformType.push_back("Affine");
+      atlasToSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
+      atlasToSubjectRegistrationHelper->SetTransformType(transformType);
+      }
+    else if( m_AtlasLinearTransformChoice == "SyN" )
+      {
+      muLogMacro(
+        << "Registering (SyN) " << "atlas(0) to template(0) image." << std::endl);
+      std::vector<double>      minimumStepSize;
+      std::vector<std::string> transformType;
+      if( atlasToSubjectInitialTransformName == "" )   // If no initial transform, then do full multi-step
+        // registration.
+        {
+        minimumStepSize.push_back(0.0025);
+        transformType.push_back("Rigid");
+        minimumStepSize.push_back(0.0025);
+        transformType.push_back("ScaleVersor3D");
+        minimumStepSize.push_back(0.0025);
+        transformType.push_back("ScaleSkewVersor3D");
+        minimumStepSize.push_back(0.0025);
+        transformType.push_back("Affine");
+        }
+      else if( atlasToSubjectInitialTransformName == "AffineTransform" )   // If initial Transform is Affine, then
+        // update the affine stage
+        {
+        minimumStepSize.push_back(0.0025);
+        transformType.push_back("Affine");
+        }
+      else if( atlasToSubjectInitialTransformName != "SyN" )
+        {
+        itkExceptionMacro( << "ERROR: Invalid atlasToSubjectInitialTransformName"
+                           << " type for m_AtlasLinearTransformChoice of type SyN" );
+        }
+      minimumStepSize.push_back(0.0025);
+      transformType.push_back("SyN");
+      atlasToSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
+      atlasToSubjectRegistrationHelper->SetTransformType(transformType);
+      }
+    else
+      {
+      itkExceptionMacro(<< "ERROR: Invalid atlasToSubjectInitialTransformName"
+                        << " type for m_AtlasLinearTransformChoice of type "
+                        << m_AtlasLinearTransformChoice);
+      }
+    }
+
+    if( this->m_DebugLevel > 9 && m_AtlasToSubjectTransform.IsNotNull() )
+      {
+      muLogMacro( << "PRE_ASSIGNMENT 0 " );
+      // << transformType[0] << " first of " << transformType.size() << std::endl );
+      muLogMacro(<< __FILE__ << " " << __LINE__ << " "
+                 << m_AtlasToSubjectTransform->GetFixedParameters() <<   std::endl );
+      muLogMacro(<< __FILE__ << " " << __LINE__ << " "
+                 << m_AtlasToSubjectTransform->GetParameters() <<   std::endl );
+      }
+    if( this->m_DebugLevel > 9 )
+      {
+      static unsigned int originalAtlasToSubject = 0;
+      std::stringstream   ss;
+      ss << std::setw(3) << std::setfill('0') << originalAtlasToSubject;
+      atlasToSubjectRegistrationHelper->PrintCommandLine(true, std::string("AtlasToSubject") + ss.str() );
+      muLogMacro( << __FILE__ << " " << __LINE__ << " "  <<   std::endl );
+      originalAtlasToSubject++;
+      }
+    atlasToSubjectRegistrationHelper->Update();
+    const unsigned int actualIterations = atlasToSubjectRegistrationHelper->GetActualNumberOfIterations();
+    muLogMacro( << "Registration tool " << actualIterations << " iterations." << std::endl );
+    m_AtlasToSubjectTransform = atlasToSubjectRegistrationHelper->GetCurrentGenericTransform();
+    if( this->m_DebugLevel > 9 )
+      {
+      muLogMacro( << "POST_ASSIGNMENT0  " );
+      // << transformType[0] << " first of " << transformType.size() << std::endl );
+      muLogMacro(<< __FILE__ << " " << __LINE__
+                 << " " << m_AtlasToSubjectTransform->GetFixedParameters() <<   std::endl );
+      muLogMacro(<< __FILE__ << " " << __LINE__
+                 << " " << m_AtlasToSubjectTransform->GetParameters() <<   std::endl );
+      }
+    // End generating the best initial transform for atlas T1 to subject T1
+    muLogMacro(<< "Writing " << this->m_AtlasToSubjectTransformFileName << "." << std::endl);
+    WriteTransformToDisk(m_AtlasToSubjectTransform, this->m_AtlasToSubjectTransformFileName);
     }
 }
 

--- a/BRAINSABC/brainseg/BRAINSABC.cxx
+++ b/BRAINSABC/brainseg/BRAINSABC.cxx
@@ -1,6 +1,7 @@
 #include "itkOutputWindow.h"
 #include "itkTextOutput.h"
 #include "itkTimeProbe.h"
+#include "itkImageDuplicator.h"
 #include <exception>
 #include <iostream>
 #include <string>
@@ -24,13 +25,6 @@
 #include "itkImageDuplicator.h"
 #include "itkBRAINSROIAutoImageFilter.h"
 
-typedef itk::Image<float, 3>         FloatImageType;
-typedef itk::Image<unsigned char, 3> ByteImageType;
-typedef itk::Image<short, 3>         ShortImageType;
-
-typedef FloatImageType::Pointer FloatImagePointer;
-typedef ByteImageType::Pointer  ByteImagePointer;
-typedef ShortImageType::Pointer ShortImagePointer;
 
 #include "mu.h"
 #include "EMSParameters.h"
@@ -55,8 +49,22 @@ typedef ShortImageType::Pointer ShortImagePointer;
 #define MU_MANUAL_INSTANTIATION
 #include "EMSegmentationFilter.h"
 #include "AtlasRegistrationMethod.h"
+
+typedef AtlasRegistrationMethod<float, float> AtlasRegType;
+typedef EMSegmentationFilter<AtlasRegType::OutputImageType,
+                             AtlasRegType::ProbabilityImageType> SegFilterType;
+
+typedef AtlasRegType::OutputImageType FloatImageType;
+typedef AtlasRegType::ByteImageType   ByteImageType;
+typedef itk::Image<short, 3>          ShortImageType;
+
+typedef FloatImageType::Pointer FloatImagePointer;
+typedef ByteImageType::Pointer  ByteImagePointer;
+typedef ShortImageType::Pointer ShortImagePointer;
+
 #undef MU_MANUAL_INSTANTIATION
 
+#if 0
 // From an inputVector create an outputVector that only contains the unique
 // elements.
 template <class T>
@@ -74,11 +82,12 @@ T RemoveDuplicates(T & origVect, const std::vector<bool> & dupsList)
     }
   return outVector;
 }
+#endif
 
 //
 // Get a version of the filename that does not include the preceeding path, or
 // the image file extensions.
-static std::string GetStripedImageFileNameExtension(const std::string & ImageFileName)
+static std::string GetStrippedImageFileNameExtension(const std::string & ImageFileName)
 {
   std::vector<std::string> ExtensionsToRemove(6);
 
@@ -103,187 +112,189 @@ static std::string GetStripedImageFileNameExtension(const std::string & ImageFil
   return returnString;
 }
 
-static FloatImageType::Pointer CopyOutputImage(FloatImageType::Pointer img )
+FloatImagePointer CopyOutputImage(FloatImagePointer input)
 {
-  // muLogMacro(<< "CopyOutputImage" << std::endl );
-
-  FloatImageType::Pointer outimg = FloatImageType::New();
-
-  outimg->CopyInformation(img);
-  outimg->SetRegions( img->GetLargestPossibleRegion() );
-  outimg->Allocate();
-
-  typedef itk::ImageRegionIterator<FloatImageType> InternalIteratorType;
-  InternalIteratorType inputIter( img, img->GetLargestPossibleRegion() );
-
-  typedef itk::ImageRegionIterator<FloatImageType> OutputIteratorType;
-  OutputIteratorType outputIter( outimg, outimg->GetLargestPossibleRegion() );
-
-  inputIter.GoToBegin();
-  outputIter.GoToBegin();
-
-  while( !inputIter.IsAtEnd() )
-    {
-    outputIter.Set( static_cast<FloatImageType::PixelType>( inputIter.Get() ) );
-    ++inputIter;
-    ++outputIter;
-    }
-
-  return outimg;
+  typedef itk::ImageDuplicator<FloatImageType> DupType;
+  DupType::Pointer dup = DupType::New();
+  dup->SetInputImage(input);
+  dup->Update();
+  return dup->GetModifiableOutput();
 }
 
+void PrintMapOfImageVectors(const AtlasRegType::MapOfFloatImageVectors &map)
+{
+  muLogMacro(<< "Map size: " << map.size() << std::endl);
+  for(AtlasRegType::MapOfFloatImageVectors::const_iterator mapIt = map.begin();
+      mapIt != map.end(); ++mapIt)
+    {
+    muLogMacro(<< "  " << mapIt->first << "(" << mapIt->second.size() <<"):" << std::endl);
+    for(AtlasRegType::FloatImageVector::const_iterator imIt = mapIt->second.begin();
+        imIt != mapIt->second.end(); ++imIt)
+      {
+      muLogMacro( << "    " << (*imIt).GetPointer()
+                  << (*imIt)->GetLargestPossibleRegion()
+                  << " " << (*imIt)->GetBufferedRegion()
+                  << std::endl );
+      }
+    }
+}
 // /////
 //
 //
 //
-static std::vector<FloatImageType::Pointer> ResampleImageList(
-  const std::string & resamplerInterpolatorType,
-  const std::vector<FloatImageType::Pointer> & inputImageList,
-  const std::vector<GenericTransformType::Pointer> & intraSubjectTransforms)
+AtlasRegType::MapOfFloatImageVectors
+ResampleImageList(const std::string & resamplerInterpolatorType,
+                  AtlasRegType::MapOfFloatImageVectors inputImageList,
+                  AtlasRegType::MapOfTransformLists & intraSubjectTransforms)
 {
   // Clear image list
-  std::vector<FloatImageType::Pointer> outputImageList;
+  AtlasRegType::MapOfFloatImageVectors outputImageList;
 
-  outputImageList.clear();
-  outputImageList.resize( inputImageList.size() );
-  outputImageList[0] = CopyOutputImage(inputImageList[0]);
+  // first image is the paradigm
+  AtlasRegType::InternalImagePointer firstImage(*(inputImageList.begin()->second.begin()));
 
-  const FloatImageType::PixelType outsideFOVCode = vnl_huge_val( static_cast<FloatImageType::PixelType>( 1.0f ) );
+  const FloatImageType::PixelType outsideFOVCode
+    = vnl_huge_val( static_cast<FloatImageType::PixelType>( 1.0f ) );
+  PrintMapOfImageVectors(inputImageList);
   // Resample the other images
-  for( unsigned int i = 1; i < inputImageList.size(); i++ )
+  for(AtlasRegType::MapOfFloatImageVectors::iterator mapIt = inputImageList.begin();
+      mapIt != inputImageList.end(); ++mapIt)
     {
-    muLogMacro(<< "Resampling input image " << i + 1 << "." << std::endl);
-    typedef itk::ResampleImageFilter<FloatImageType, FloatImageType> ResampleType;
-    typedef ResampleType::Pointer                                    ResamplePointer;
-    ResamplePointer resampler = ResampleType::New();
-    resampler->SetInput(inputImageList[i]);
-    resampler->SetTransform(intraSubjectTransforms[i]);
-
-    if( resamplerInterpolatorType == "BSpline" )
+    AtlasRegType::TransformList::iterator xfrmIt = intraSubjectTransforms[mapIt->first].begin();
+    AtlasRegType::FloatImageVector::iterator imIt = mapIt->second.begin();
+    unsigned int i(0);
+    if(mapIt == inputImageList.begin())
       {
-      typedef itk::BSplineInterpolateImageFunction<FloatImageType, double, double>
-        SplineInterpolatorType;
-
-      // Spline interpolation, only available for input images, not
-      // atlas
-      SplineInterpolatorType::Pointer splineInt
-        = SplineInterpolatorType::New();
-      splineInt->SetSplineOrder(5);
-      resampler->SetInterpolator(splineInt);
+      outputImageList[mapIt->first].push_back(CopyOutputImage(*imIt));
+      // skip first image
+      ++imIt;
+      ++xfrmIt;
+      ++i;
       }
-    else if( resamplerInterpolatorType == "WindowedSinc" )
+    for(; imIt != mapIt->second.end(); ++imIt, ++i)
       {
-      typedef itk::ConstantBoundaryCondition<FloatImageType>
-        BoundaryConditionType;
-      static const unsigned int WindowedSincHammingWindowRadius = 5;
-      typedef itk::Function::HammingWindowFunction<
-        WindowedSincHammingWindowRadius, double, double> WindowFunctionType;
-      typedef itk::WindowedSincInterpolateImageFunction
-        <FloatImageType,
-        WindowedSincHammingWindowRadius,
-        WindowFunctionType,
-        BoundaryConditionType,
-        double>    WindowedSincInterpolatorType;
-      WindowedSincInterpolatorType::Pointer windowInt
-        = WindowedSincInterpolatorType::New();
-      resampler->SetInterpolator(windowInt);
-      }
-    else // Default to m_UseNonLinearInterpolation == "Linear"
-      {
-      typedef itk::LinearInterpolateImageFunction<FloatImageType, double>
-        LinearInterpolatorType;
-      LinearInterpolatorType::Pointer linearInt
-        = LinearInterpolatorType::New();
-      resampler->SetInterpolator(linearInt);
-      }
+      muLogMacro(<< "Resampling input image " << mapIt->first << i << "." << std::endl);
+      typedef itk::ResampleImageFilter<FloatImageType, FloatImageType> ResampleType;
+      typedef ResampleType::Pointer                                    ResamplePointer;
+      ResamplePointer resampler = ResampleType::New();
+      resampler->SetInput((*imIt));
+      resampler->SetTransform((*xfrmIt));
 
-    resampler->SetDefaultPixelValue(outsideFOVCode);
-    resampler->SetOutputParametersFromImage(inputImageList[0]);
-    resampler->Update();
-
-    // Zero the mask region outside FOV and also the intensities with
-    // outside
-    // FOV code
-    typedef itk::ImageRegionIterator<FloatImageType> InternalIteratorType;
-
-    FloatImageType::Pointer tmp = resampler->GetOutput();
-    InternalIteratorType    tmpIt( tmp, tmp->GetLargestPossibleRegion() );
-
-    // HACK:  We can probably remove the mask generation from here.
-    // The FOV mask, regions where intensities in all channels do not
-    // match FOV code
-    ByteImageType::Pointer intraSubjectFOVIntersectionMask = ByteImageType::New();
-    intraSubjectFOVIntersectionMask->CopyInformation(inputImageList[0]);
-    intraSubjectFOVIntersectionMask->SetRegions( inputImageList[0]->GetLargestPossibleRegion() );
-    intraSubjectFOVIntersectionMask->Allocate();
-    intraSubjectFOVIntersectionMask->FillBuffer(1);
-    typedef itk::ImageRegionIterator<ByteImageType> MaskIteratorType;
-    MaskIteratorType maskIt( intraSubjectFOVIntersectionMask,
-                             intraSubjectFOVIntersectionMask->GetLargestPossibleRegion() );
-    maskIt.GoToBegin();
-    tmpIt.GoToBegin();
-    while( !maskIt.IsAtEnd() )
-      {
-      if( tmpIt.Get() == outsideFOVCode )  // Voxel came from outside
-        // the original FOV during
-        // registration, so
-        // invalidate it.
+      if( resamplerInterpolatorType == "BSpline" )
         {
-        maskIt.Set(0); // Set it as an invalid voxel in
-        // intraSubjectFOVIntersectionMask
-        tmpIt.Set(0);  // Set image intensity value to zero.
-        }
-      ++maskIt;
-      ++tmpIt;
-      }
+        typedef itk::BSplineInterpolateImageFunction<FloatImageType, double, double>
+          SplineInterpolatorType;
 
-    // Add the image
-    outputImageList[i] = CopyOutputImage(tmp);
+        // Spline interpolation, only available for input images, not
+        // atlas
+        SplineInterpolatorType::Pointer splineInt
+          = SplineInterpolatorType::New();
+        splineInt->SetSplineOrder(5);
+        resampler->SetInterpolator(splineInt);
+        }
+      else if( resamplerInterpolatorType == "WindowedSinc" )
+        {
+        typedef itk::ConstantBoundaryCondition<FloatImageType>
+          BoundaryConditionType;
+        static const unsigned int WindowedSincHammingWindowRadius = 5;
+        typedef itk::Function::HammingWindowFunction<
+          WindowedSincHammingWindowRadius, double, double> WindowFunctionType;
+        typedef itk::WindowedSincInterpolateImageFunction
+          <FloatImageType,
+          WindowedSincHammingWindowRadius,
+          WindowFunctionType,
+          BoundaryConditionType,
+          double>    WindowedSincInterpolatorType;
+        WindowedSincInterpolatorType::Pointer windowInt
+          = WindowedSincInterpolatorType::New();
+        resampler->SetInterpolator(windowInt);
+        }
+      else // Default to m_UseNonLinearInterpolation == "Linear"
+        {
+        typedef itk::LinearInterpolateImageFunction<FloatImageType, double>
+          LinearInterpolatorType;
+        LinearInterpolatorType::Pointer linearInt
+          = LinearInterpolatorType::New();
+        resampler->SetInterpolator(linearInt);
+        }
+
+      resampler->SetDefaultPixelValue(outsideFOVCode);
+      resampler->SetOutputParametersFromImage(firstImage);
+      resampler->Update();
+
+      // Zero the mask region outside FOV and also the intensities with
+      // outside
+      // FOV code
+      typedef itk::ImageRegionIterator<FloatImageType> InternalIteratorType;
+
+      FloatImageType::Pointer tmp = resampler->GetOutput();
+      InternalIteratorType    tmpIt( tmp, tmp->GetLargestPossibleRegion() );
+
+      // HACK:  We can probably remove the mask generation from here.
+      // The FOV mask, regions where intensities in all channels do not
+      // match FOV code
+      ByteImageType::Pointer intraSubjectFOVIntersectionMask = ByteImageType::New();
+      intraSubjectFOVIntersectionMask->CopyInformation(firstImage);
+      intraSubjectFOVIntersectionMask->SetRegions( firstImage->GetLargestPossibleRegion() );
+      intraSubjectFOVIntersectionMask->Allocate();
+      intraSubjectFOVIntersectionMask->FillBuffer(1);
+      typedef itk::ImageRegionIterator<ByteImageType> MaskIteratorType;
+      MaskIteratorType maskIt( intraSubjectFOVIntersectionMask,
+                               intraSubjectFOVIntersectionMask->GetLargestPossibleRegion() );
+      maskIt.GoToBegin();
+      tmpIt.GoToBegin();
+      while( !maskIt.IsAtEnd() )
+        {
+        if( tmpIt.Get() == outsideFOVCode )  // Voxel came from outside
+          // the original FOV during
+          // registration, so
+          // invalidate it.
+          {
+          maskIt.Set(0); // Set it as an invalid voxel in
+          // intraSubjectFOVIntersectionMask
+          tmpIt.Set(0);  // Set image intensity value to zero.
+          }
+        ++maskIt;
+        ++tmpIt;
+        }
+
+      // Add the image
+      outputImageList[mapIt->first].push_back(CopyOutputImage(tmp));
+      }
     }
   return outputImageList;
 }
 
-static void RescaleFunctionLocal( std::vector<FloatImageType::Pointer> & localList)
+static AtlasRegType::MapOfFloatImageVectors
+RescaleFunctionLocal( AtlasRegType::MapOfFloatImageVectors& localList)
 {
-  for( unsigned int i = 0; i < localList.size(); i++ )
-    {
-    typedef itk::RescaleIntensityImageFilter<FloatImageType, FloatImageType>
-      RescaleType;
-    RescaleType::Pointer rescaler = RescaleType::New();
-    rescaler->SetOutputMinimum(1);
-    rescaler->SetOutputMaximum(MAX_IMAGE_OUTPUT_VALUE);
-#define INPLACE_RESCALER 0 // HACK Test this out
-#if defined( INPLACE_RESCALER )
-    rescaler->SetInPlace(true);
-#endif
-    FloatImageType::Pointer tmp = localList[i];
-    rescaler->SetInput(tmp);
-    rescaler->Update();
-#if defined( INPLACE_RESCALER )
-    localList[i] = rescaler->GetOutput();
-#else
-    FloatImageType::SizeType size = localList[0]->GetLargestPossibleRegion().GetSize();
+  AtlasRegType::MapOfFloatImageVectors rval;
 
-    FloatImagePointer         rImg = rescaler->GetOutput();
-    FloatImageType::IndexType ind;
-    // T.O.D.O.  This could be done in-place using the -inplace flag of the
-    // rescaleImageIntensityFilter.
+  for(AtlasRegType::MapOfFloatImageVectors::iterator mapIt = localList.begin();
+      mapIt != localList.end(); ++mapIt)
     {
-#pragma omp parallel for
-    for( long kk = 0; kk < (long)size[2]; kk++ )
+    for(AtlasRegType::FloatImageVector::iterator imIt = mapIt->second.begin();
+        imIt != mapIt->second.end(); ++imIt)
       {
-      for( long jj = 0; jj < (long)size[1]; jj++ )
-        {
-        for( long ii = 0; ii < (long)size[0]; ii++ )
-          {
-          const ProbabilityImageIndexType currIndex = {{ii, jj, kk}};
-          tmp->SetPixel( currIndex, rImg->GetPixel(ind) );
-          }
-        }
+      typedef itk::RescaleIntensityImageFilter<FloatImageType, FloatImageType>
+        RescaleType;
+      RescaleType::Pointer rescaler = RescaleType::New();
+      rescaler->SetOutputMinimum(1);
+      rescaler->SetOutputMaximum(MAX_IMAGE_OUTPUT_VALUE);
+// #define INPLACE_RESCALER 0 // HACK Test this out
+// #if defined( INPLACE_RESCALER )
+//       rescaler->SetInPlace(true);
+// #endif
+      FloatImageType::Pointer tmp = (*imIt);
+      rescaler->SetInput(tmp);
+      rescaler->Update();
+      rval[mapIt->first].push_back(rescaler->GetOutput());
+// #if !defined( INPLACE_RESCALER)
+//       (*imIt)  = rescaler->GetOutput();
+// #endif
       }
     }
-#endif
-    }
+  return rval;
 }
 
 #if 0
@@ -432,6 +443,20 @@ static FloatImageType::Pointer AverageImageList(
   return averageImage;
 }
 
+AtlasRegType::MapOfStringVectors
+CreateTypedMap(const AtlasRegType::StringVector &keys, const AtlasRegType::StringVector &values)
+{
+  AtlasRegType::MapOfStringVectors rval;
+  AtlasRegType::StringVector::const_iterator keyIt(keys.begin());
+  AtlasRegType::StringVector::const_iterator valueIt(values.begin());
+  for( ; keyIt != keys.end() && valueIt != values.end(); ++keyIt, ++valueIt)
+    {
+    rval[(*keyIt)].push_back((*valueIt));
+    }
+  return rval;
+}
+
+
 int main(int argc, char * *argv)
 {
   PARSE_ARGS;
@@ -441,8 +466,9 @@ int main(int argc, char * *argv)
   // of this application:  itk::DataObject::GlobalReleaseDataFlagOn();
   itk::OutputWindow::SetInstance( itk::TextOutput::New() );
 
-  typedef EMSegmentationFilter<FloatImageType, FloatImageType> SegFilterType;
-  typedef SegFilterType::MapOfImagesByType MapOfImagesByType;
+  typedef itk::ImageFileReader<ByteImageType>                  ReaderType;
+  typedef ReaderType::Pointer                                  ReaderPointer;
+
 
   // Check the parameters for valid values
   bool AllSimpleParameterChecksValid = true;
@@ -451,21 +477,21 @@ int main(int argc, char * *argv)
     muLogMacro( <<  "Warning: "
                 << "--maxIterations set to 0, so only initialization with priors will be completed." << std::endl );
     }
-  if( inputVolumes.size() == 0 )
+  if( input_Volumes.size() == 0 )
     {
     muLogMacro( <<  "ERROR: "
                 << "Must specify --inputVolumes" << std::endl );
     AllSimpleParameterChecksValid = false;
     }
-  if( outputVolumes.size() != 1 && outputVolumes.size() != inputVolumes.size() )
+  if( output_Volumes.size() != 1 && output_Volumes.size() != input_Volumes.size() )
     {
-    std::cerr << inputVolumes.size() << " images in input volumeslist, but "
-              << outputVolumes.size() << " names in output volumes list"
+    std::cerr << input_Volumes.size() << " images in input volumeslist, but "
+              << output_Volumes.size() << " names in output volumes list"
               << "OR it must be exactly 1, and be the template for writing files."
               << std::endl;
     return EXIT_FAILURE;
     }
-  if( inputVolumeTypes.size() != inputVolumes.size() )
+  if( input_VolumeTypes.size() != input_Volumes.size() )
     {
     muLogMacro( <<  "ERROR: "
                 << "--inputVolumeTypes and --inputVolumes must"
@@ -506,6 +532,13 @@ int main(int argc, char * *argv)
   ;
   atlasDefinitionParser.DebugPrint();
 
+  AtlasRegType::MapOfStringVectors inputVolumeMap =
+    CreateTypedMap(input_VolumeTypes,input_Volumes);
+  AtlasRegType::MapOfStringVectors outputVolumeMap;
+  if(output_Volumes.size() > 1)
+    {
+    outputVolumeMap = CreateTypedMap(input_VolumeTypes,output_Volumes);
+    }
   // Create and start a new timer (for the whole process)
   //  EMSTimer* timer = new EMSTimer();
   itk::TimeProbe timer;
@@ -666,19 +699,19 @@ int main(int argc, char * *argv)
   for( unsigned int pwi = 0; pwi < PriorNames.size(); pwi++ )
     {
     std::map<std::string, AtlasDefinition::BoundsType> temp_range_List;
-    for( unsigned int tt = 0; tt < inputVolumeTypes.size(); tt++ )
+    for( unsigned int tt = 0; tt < input_VolumeTypes.size(); tt++ )
       {
-      AtlasDefTable.add(currentRow + tt * 2 + 0, 0, std::string(inputVolumeTypes[tt]) + std::string(" Lower") );
+      AtlasDefTable.add(currentRow + tt * 2 + 0, 0, std::string(input_VolumeTypes[tt]) + std::string(" Lower") );
       AtlasDefTable.add(currentRow + tt * 2 + 0, 1, ": [");
       AtlasDefTable.add(currentRow + tt * 2 + 0, PriorNames.size() + 2 + 1, "]");
 
-      AtlasDefTable.add(currentRow + tt * 2 + 1, 0, std::string(inputVolumeTypes[tt]) + std::string(" Upper") );
+      AtlasDefTable.add(currentRow + tt * 2 + 1, 0, std::string(input_VolumeTypes[tt]) + std::string(" Upper") );
       AtlasDefTable.add(currentRow + tt * 2 + 1, 1, ": [");
       AtlasDefTable.add(currentRow + tt * 2 + 1, PriorNames.size() + 2 + 1, "]");
 
-      temp_range_List[inputVolumeTypes[tt]] = atlasDefinitionParser.GetBounds(PriorNames[pwi], inputVolumeTypes[tt]);
-      AtlasDefTable.add(currentRow + tt * 2 + 0, 2 + pwi, temp_range_List[inputVolumeTypes[tt]].GetLower() );
-      AtlasDefTable.add(currentRow + tt * 2 + 1, 2 + pwi, temp_range_List[inputVolumeTypes[tt]].GetUpper() );
+      temp_range_List[input_VolumeTypes[tt]] = atlasDefinitionParser.GetBounds(PriorNames[pwi], input_VolumeTypes[tt]);
+      AtlasDefTable.add(currentRow + tt * 2 + 0, 2 + pwi, temp_range_List[input_VolumeTypes[tt]].GetLower() );
+      AtlasDefTable.add(currentRow + tt * 2 + 1, 2 + pwi, temp_range_List[input_VolumeTypes[tt]].GetUpper() );
       }
     }
   }
@@ -699,7 +732,7 @@ int main(int argc, char * *argv)
 
   GenericTransformType::Pointer atlasToSubjectPreSegmentationTransform = NULL;
 
-  std::vector<FloatImagePointer> atlasOriginalImageList;
+  AtlasRegType::MapOfFloatImageVectors atlasOriginalImageList;
   ByteImagePointer               atlasBrainMask;
   { // Read template images needed for atlas registration
   // muLogMacro(<< "Read template mask");
@@ -709,9 +742,6 @@ int main(int argc, char * *argv)
     muLogMacro( <<  "No template mask specified" << std::endl );
     return EXIT_FAILURE;
     }
-  typedef itk::ImageFileReader<ByteImageType> ReaderType;
-  typedef ReaderType::Pointer                 ReaderPointer;
-
   muLogMacro( << "Reading mask : " << templateMask << "...\n");
 
   ReaderPointer imgreader = ReaderType::New();
@@ -729,32 +759,37 @@ int main(int argc, char * *argv)
   atlasBrainMask = imgreader->GetOutput();
   }
 
-  std::vector<FloatImagePointer> intraSubjectRegisteredImageList;
-  std::vector<FloatImagePointer> intraSubjectRegisteredRawImageList;
+  AtlasRegType::MapOfFloatImageVectors intraSubjectRegisteredImageList;
+  AtlasRegType::MapOfFloatImageVectors intraSubjectRegisteredRawImageList;
   std::vector<std::string>       priorfnlist;
-  std::vector<std::string>       templateVolumes( inputVolumeTypes.size() );
-  for( unsigned int q = 0; q < inputVolumeTypes.size(); q++ )
+
+  AtlasRegType::MapOfStringVectors templateVolumes;
+  const AtlasDefinition::TemplateMap &tm = atlasDefinitionParser.GetTemplateVolumes();
+  for(AtlasRegType::MapOfStringVectors::iterator typeIt = inputVolumeMap.begin();
+      typeIt != inputVolumeMap.end(); ++typeIt)
     {
-    const AtlasDefinition::TemplateMap &         tm = atlasDefinitionParser.GetTemplateVolumes();
-    AtlasDefinition::TemplateMap::const_iterator ti = tm.find(inputVolumeTypes[q]);
+    AtlasDefinition::TemplateMap::const_iterator ti = tm.find(typeIt->first);
+    std::string temp;
     if( ti != tm.end() )
       {
-      std::string temp = ti->second;
-      std::cerr << "STATUS:  Atlas image of type: " << inputVolumeTypes[q]
+      temp = ti->second;
+      std::cerr << "STATUS:  Atlas image of type: " << typeIt->first
                 << " added with filename: " << temp << std::endl;
-      templateVolumes[q] = temp;
       }
     else
       {
-      std::cerr << "ERROR:  Atlas image of type: " << inputVolumeTypes[q]
+      std::cerr << "ERROR:  Atlas image of type: " << typeIt->first
                 << " not found in xml file." << std::endl;
       throw;
       }
+    for(AtlasRegType::StringVector::const_iterator imIt = typeIt->second.begin();
+        imIt != typeIt->second.end(); ++imIt)
+      {
+      templateVolumes[typeIt->first].push_back(temp);
+      }
     }
-
   std::vector<bool> candidateDuplicatesList;
   {
-  typedef AtlasRegistrationMethod<float, float> AtlasRegType;
   AtlasRegType::Pointer atlasreg = AtlasRegType::New();
 
   if( debuglevel > 0 )
@@ -769,18 +804,17 @@ int main(int argc, char * *argv)
     {
     priorfnlist.push_back( atlasDefinitionParser.GetPriorFilename( PriorNames[q] ) );
     }
+
   {
-  std::vector<FloatImagePointer> intraSubjectRawImageList;
-  intraSubjectRawImageList.clear();
-  intraSubjectRawImageList.resize(inputVolumes.size(), 0);
-  std::vector<FloatImagePointer> intraSubjectNoiseRemovedImageList;
-  intraSubjectNoiseRemovedImageList.clear();
-  intraSubjectNoiseRemovedImageList.resize(inputVolumes.size(), 0);
+  AtlasRegType::MapOfFloatImageVectors intraSubjectRawImageList;
+  AtlasRegType::MapOfFloatImageVectors intraSubjectNoiseRemovedImageList;
+
+
   { // StartOriginalImagesList
   const std::string suffixstr = "";
   { // Read subject images needed for atlas registration
   // muLogMacro(<< "Read subject images");
-  if( inputVolumes.size() < 1 )
+  if( input_Volumes.size() < 1 )
     {
     muLogMacro( <<  "No data images specified" << std::endl );
     return EXIT_FAILURE;
@@ -789,77 +823,85 @@ int main(int argc, char * *argv)
   typedef itk::ImageFileReader<FloatImageType> ReaderType;
   typedef ReaderType::Pointer                  ReaderPointer;
 
-  std::vector<std::string> intraSubjectTransformFileNames( inputVolumes.size() );
-  for( unsigned int i = 0; i < inputVolumes.size(); i++ )
+  AtlasRegType::MapOfStringVectors intraSubjectTransformFileNames;
+  unsigned int i = 0;
+  for(AtlasRegType::MapOfStringVectors::iterator typeIt = inputVolumeMap.begin();
+      typeIt != inputVolumeMap.end(); ++typeIt)
     {
-    muLogMacro(<< "Reading image " << i + 1 << ": " << inputVolumes[i] << "...\n");
-
-    ReaderPointer imgreader = ReaderType::New();
-    imgreader->SetFileName( inputVolumes[i].c_str() );
-
-    try
+    for( AtlasRegType::StringVector::const_iterator imIt = typeIt->second.begin();
+         imIt != typeIt->second.end(); ++imIt,++i )
       {
-      imgreader->Update();
-      }
-    catch( ... )
-      {
-      muLogMacro( << "ERROR:  Could not read image " << inputVolumes[i] << "." << std::endl );
-      return EXIT_FAILURE;
-      }
-    // Initialize with file read in
-    FloatImageType::Pointer typewiseEqualizedToFirstImage = imgreader->GetOutput();
+      muLogMacro(<< "Reading image " << ": " << (*imIt) << "...\n");
 
-    // Normalize Image Intensities:
-    muLogMacro( << "Standardizing Intensities: ...\n" );
-    intraSubjectRawImageList[i] = StandardizeMaskIntensity<FloatImageType, ByteImageType>(
-      typewiseEqualizedToFirstImage,
-      NULL,
-      0.0005, 1.0 - 0.0005,
-      1, 0.95 * MAX_IMAGE_OUTPUT_VALUE,
-      0, MAX_IMAGE_OUTPUT_VALUE);
-    muLogMacro( << "done.\n" );
-    {
-    std::vector<unsigned int> unused_gridSize;
-    double                    localFilterTimeStep = filterTimeStep;
-    if( localFilterTimeStep <= 0 )
-      {
-      FloatImageType::SpacingType::ValueType minPixelSize =
-        vcl_numeric_limits<FloatImageType::SpacingType::ValueType>::max();
-      const FloatImageType::SpacingType & imageSpacing = intraSubjectRawImageList[i]->GetSpacing();
-      for( int is = 0; is < FloatImageType::ImageDimension; ++is )
+      ReaderPointer imgreader = ReaderType::New();
+      imgreader->SetFileName( (*imIt).c_str() );
+
+      try
         {
-        minPixelSize = vcl_min( minPixelSize, imageSpacing[is]);
+        imgreader->Update();
         }
-      localFilterTimeStep =
-        ( (minPixelSize - vcl_numeric_limits<FloatImageType::SpacingType::ValueType>::epsilon() )
-          / ( vcl_pow(2.0, FloatImageType::ImageDimension + 1 ) )
-          );
-      }
-    intraSubjectNoiseRemovedImageList[i] =
-      DenoiseFiltering<FloatImageType>(intraSubjectRawImageList[i], filterMethod, filterIteration,
-                                       localFilterTimeStep,
-                                       unused_gridSize);
-    if( debuglevel > 1 )
-      {
-      // DEBUG:  This code is for debugging purposes only;
-      typedef itk::ImageFileWriter<FloatImageType> WriterType;
-      WriterType::Pointer writer = WriterType::New();
-      writer->UseCompressionOn();
+      catch( ... )
+        {
+        muLogMacro( << "ERROR:  Could not read image " << (*imIt) << "." << std::endl );
+        return EXIT_FAILURE;
+        }
+      // Initialize with file read in
+      FloatImagePointer typewiseEqualizedToFirstImage = imgreader->GetOutput();
 
-      std::stringstream template_index_stream("");
-      template_index_stream << i;
-      const std::string fn = outputDir + "/DENOISED_INDEX_" + template_index_stream.str() + ".nii.gz";
-      writer->SetInput(intraSubjectNoiseRemovedImageList[i]);
-      writer->SetFileName(fn.c_str() );
-      writer->Update();
-      muLogMacro( << "DEBUG:  Wrote image " << fn <<  std::endl);
+      // Normalize Image Intensities:
+      muLogMacro( << "Standardizing Intensities: ...\n" );
+      FloatImagePointer curImage =
+        StandardizeMaskIntensity<FloatImageType, ByteImageType>(typewiseEqualizedToFirstImage,
+                                                                NULL,
+                                                                0.0005, 1.0 - 0.0005,
+                                                                1, 0.95 * MAX_IMAGE_OUTPUT_VALUE,
+                                                                0, MAX_IMAGE_OUTPUT_VALUE);
+      intraSubjectRawImageList[typeIt->first].push_back(curImage);
+      muLogMacro( << "done.\n" );
+      {
+      std::vector<unsigned int> unused_gridSize;
+      double                    localFilterTimeStep = filterTimeStep;
+      if( localFilterTimeStep <= 0 )
+        {
+        FloatImageType::SpacingType::ValueType minPixelSize =
+          vcl_numeric_limits<FloatImageType::SpacingType::ValueType>::max();
+        const FloatImageType::SpacingType & imageSpacing = curImage->GetSpacing();
+        for( int is = 0; is < FloatImageType::ImageDimension; ++is )
+          {
+          minPixelSize = vcl_min( minPixelSize, imageSpacing[is]);
+          }
+        localFilterTimeStep =
+          ( (minPixelSize - vcl_numeric_limits<FloatImageType::SpacingType::ValueType>::epsilon() )
+            / ( vcl_pow(2.0, FloatImageType::ImageDimension + 1 ) )
+            );
+        }
+      FloatImagePointer denoisedImage =
+        DenoiseFiltering<FloatImageType>(curImage, filterMethod, filterIteration,
+                                         localFilterTimeStep,
+                                         unused_gridSize);
+      intraSubjectNoiseRemovedImageList[typeIt->first].push_back(denoisedImage);
+      if( debuglevel > 1 )
+        {
+        // DEBUG:  This code is for debugging purposes only;
+        typedef itk::ImageFileWriter<FloatImageType> WriterType;
+        WriterType::Pointer writer = WriterType::New();
+        writer->UseCompressionOn();
+
+        std::stringstream template_index_stream("");
+        template_index_stream << i;
+        const std::string fn = outputDir + "/DENOISED_INDEX_" + template_index_stream.str() + ".nii.gz";
+        writer->SetInput(denoisedImage);
+        writer->SetFileName(fn.c_str() );
+        writer->Update();
+        muLogMacro( << "DEBUG:  Wrote image " << fn <<  std::endl);
+        }
       }
-    }
-    intraSubjectTransformFileNames[i] = outputDir
-      + GetStripedImageFileNameExtension(inputVolumes[i]) + std::string(
-        "_to_")
-      + GetStripedImageFileNameExtension(inputVolumes[0]) + suffixstr
-      + std::string(".h5");
+      std::string intraSubjectTransformFileName  = outputDir
+        + GetStrippedImageFileNameExtension((*imIt).c_str()) + "_to_"
+        + GetStrippedImageFileNameExtension(*(inputVolumeMap.begin()->second.begin())) + suffixstr
+        + ".h5";
+      intraSubjectTransformFileNames[typeIt->first].push_back(intraSubjectTransformFileName);
+      }
     }
   atlasreg->SetIntraSubjectOriginalImageList(intraSubjectNoiseRemovedImageList);
   atlasreg->SetIntraSubjectTransformFileNames(intraSubjectTransformFileNames);
@@ -876,70 +918,60 @@ int main(int argc, char * *argv)
   typedef itk::ImageFileReader<FloatImageType> ReaderType;
   typedef ReaderType::Pointer                  ReaderPointer;
 
-  atlasOriginalImageList.clear();
-  atlasOriginalImageList.resize(templateVolumes.size(), 0);
-  for( unsigned int atlasIndex = 0; atlasIndex < templateVolumes.size(); atlasIndex++ )
+  for(AtlasRegType::MapOfStringVectors::iterator mapIt = templateVolumes.begin();
+      mapIt != templateVolumes.end(); ++mapIt)
     {
-    // KENT: HACK:  This currently just checks one previous location in the list to
-    //             determine if the image was already loaded,  It should check the
-    //             entire list and avoid loading duplicate images into the list
-    //             of atlas images.
-    if( ( atlasIndex > 0 ) && ( templateVolumes[atlasIndex] == templateVolumes[atlasIndex - 1] ) )
-      { // If they are the same name, then just use same reference
-      muLogMacro(<< "Referencing previous image " << atlasIndex + 1
-                 << ": " << templateVolumes[atlasIndex] << "...\n");
-      atlasOriginalImageList[atlasIndex] = atlasOriginalImageList[atlasIndex - 1];
-      }
-    else
+    std::string curAtlasName = *(mapIt->second.begin());
+    muLogMacro(<< "Reading image " << mapIt->first
+               << ": " << curAtlasName << "...\n");
+    ReaderPointer imgreader = ReaderType::New();
+    imgreader->SetFileName(curAtlasName.c_str());
+    try
       {
-      muLogMacro(<< "Reading image " << atlasIndex + 1
-                 << ": " << templateVolumes[atlasIndex] << "...\n");
+      imgreader->Update();
+      }
+    catch( ... )
+      {
+      muLogMacro( << "ERROR:  Could not read image " << curAtlasName << "." << std::endl );
+      return EXIT_FAILURE;
+      }
+    muLogMacro( << "Standardizing Intensities: ..." );
+    FloatImagePointer img_i =
+      StandardizeMaskIntensity<FloatImageType, ByteImageType>(imgreader->GetOutput(),
+                                                              atlasBrainMask,
+                                                              0.0005, 1.0 - 0.0005,
+                                                              1,
+                                                              0.95 * MAX_IMAGE_OUTPUT_VALUE,
+                                                              0, MAX_IMAGE_OUTPUT_VALUE);
+    muLogMacro( << "done." << std::endl );
+    // the atlas pointers are all the same and parallel the input
+    // image map of lists structure
+    for(AtlasRegType::StringVector::iterator nameIt = mapIt->second.begin();
+        nameIt != mapIt->second.end(); ++nameIt)
+      {
+      atlasOriginalImageList[mapIt->first].push_back(img_i);
+      }
+    if( debuglevel > 7 )
+      {
+      typedef itk::ImageFileWriter<FloatImageType> FloatWriterType;
+      FloatWriterType::Pointer writer = FloatWriterType::New();
 
-      ReaderPointer imgreader = ReaderType::New();
-      imgreader->SetFileName( templateVolumes[atlasIndex].c_str() );
+      std::stringstream write_atlas_index_stream("");
+      const std::string fn = outputDir + "RenormalizedAtlasTemplate_" + mapIt->first  + suffstr;
 
-      try
-        {
-        imgreader->Update();
-        }
-      catch( ... )
-        {
-        muLogMacro( << "ERROR:  Could not read image " << templateVolumes[atlasIndex] << "." << std::endl );
-        return EXIT_FAILURE;
-        }
-
-      muLogMacro( << "Standardizing Intensities: ..." );
-      FloatImagePointer img_i = StandardizeMaskIntensity<FloatImageType, ByteImageType>(
-        imgreader->GetOutput(),
-        atlasBrainMask,
-        0.0005, 1.0 - 0.0005,
-        1, 0.95 * MAX_IMAGE_OUTPUT_VALUE,
-        0, MAX_IMAGE_OUTPUT_VALUE);
-      muLogMacro( << "done." << std::endl );
-      atlasOriginalImageList[atlasIndex] = img_i;
-      if( debuglevel > 7 )
-        {
-        typedef itk::ImageFileWriter<FloatImageType> FloatWriterType;
-        FloatWriterType::Pointer writer = FloatWriterType::New();
-
-        std::stringstream write_atlas_index_stream("");
-        write_atlas_index_stream << atlasIndex;
-        const std::string fn
-          = outputDir + std::string("RenormalizedAtlasTemplate_") + write_atlas_index_stream.str() + suffstr;
-
-        writer->SetInput(atlasOriginalImageList[atlasIndex] );
-        writer->SetFileName( fn.c_str() );
-        writer->UseCompressionOn();
-        writer->Update();
-        }
+      writer->SetInput(img_i);
+      writer->SetFileName( fn.c_str() );
+      writer->UseCompressionOn();
+      writer->Update();
       }
     }
+
   atlasreg->SetAtlasOriginalImageList(atlasOriginalImageList);
-  atlasreg->SetInputVolumeTypes(inputVolumeTypes);
+
   const std::string atlasTransformFileName = outputDir
-    + GetStripedImageFileNameExtension(templateVolumes[0])
+    + GetStrippedImageFileNameExtension(*(templateVolumes.begin()->second.begin()))
     + std::string("_to_")
-    + GetStripedImageFileNameExtension(inputVolumes[0]) + suffixstr
+    + GetStrippedImageFileNameExtension(input_Volumes[0]) + suffixstr
     + std::string("PreSegmentation.h5");
   atlasreg->SetAtlasToSubjectTransformFileName(atlasTransformFileName);
   }
@@ -1110,7 +1142,7 @@ int main(int argc, char * *argv)
     = regtimer.GetTotal();
   muLogMacro(<< "Registration took " << elapsedTime << " " << regtimer.GetUnit() << std::endl);
 
-  std::vector<GenericTransformType::Pointer> intraSubjectTransforms = atlasreg->GetIntraSubjectTransforms();
+  AtlasRegType::MapOfTransformLists intraSubjectTransforms = atlasreg->GetIntraSubjectTransforms();
 
   // ::ResampleImages()
   {
@@ -1184,10 +1216,11 @@ int main(int argc, char * *argv)
       typedef ResampleType::Pointer                                    ResamplePointer;
       ResamplePointer resampler = ResampleType::New();
 
-      resampler->SetInput(atlasOriginalImageList[0]);
+      resampler->SetInput(*(atlasOriginalImageList.begin()->second.begin()));
       resampler->SetTransform(atlasToSubjectPreSegmentationTransform);
 
-      resampler->SetOutputParametersFromImage(intraSubjectRegisteredRawImageList[0]);
+      resampler->SetOutputParametersFromImage
+        (*(intraSubjectRegisteredRawImageList[atlasOriginalImageList.begin()->first].begin()));
       resampler->SetDefaultPixelValue(0);
       resampler->Update();
       typedef itk::CastImageFilter<FloatImageType, ShortImageType>
@@ -1207,28 +1240,37 @@ int main(int argc, char * *argv)
       writer->UseCompressionOn();
       writer->Update();
       }
-    for( unsigned int i = 0; i < intraSubjectRegisteredRawImageList.size(); i++ )
+    for(AtlasRegType::MapOfFloatImageVectors::iterator mapIt
+          = intraSubjectRegisteredRawImageList.begin();
+        mapIt != intraSubjectRegisteredRawImageList.end(); ++mapIt)
       {
-      typedef itk::RescaleIntensityImageFilter<FloatImageType, ShortImageType>
-        ShortRescaleType;
+      AtlasRegType::StringVector::iterator inputNameIt =
+        inputVolumeMap[mapIt->first].begin();
 
-      ShortRescaleType::Pointer rescaler = ShortRescaleType::New();
-      rescaler->SetOutputMinimum(0);
-      rescaler->SetOutputMaximum(MAX_IMAGE_OUTPUT_VALUE);
-      rescaler->SetInput(intraSubjectRegisteredRawImageList[i]);
-      rescaler->Update();
+      for(AtlasRegType::FloatImageVector::iterator imIt = mapIt->second.begin();
+          imIt != mapIt->second.end(); ++imIt, ++inputNameIt)
+        {
+        typedef itk::RescaleIntensityImageFilter<FloatImageType, ShortImageType>
+          ShortRescaleType;
 
-      std::string fn
-        = outputDir + GetStripedImageFileNameExtension( ( inputVolumes[i] ) )
-        + std::string("_registered") + suffstr;
+        ShortRescaleType::Pointer rescaler = ShortRescaleType::New();
+        rescaler->SetOutputMinimum(0);
+        rescaler->SetOutputMaximum(MAX_IMAGE_OUTPUT_VALUE);
+        rescaler->SetInput((*imIt));
+        rescaler->Update();
 
-      typedef itk::ImageFileWriter<ShortImageType> ShortWriterType;
-      ShortWriterType::Pointer writer = ShortWriterType::New();
+        std::string fn
+          = outputDir + GetStrippedImageFileNameExtension( ( *inputNameIt ) )
+          + std::string("_registered") + suffstr;
 
-      writer->SetInput( rescaler->GetOutput() );
-      writer->SetFileName( fn.c_str() );
-      writer->UseCompressionOn();
-      writer->Update();
+        typedef itk::ImageFileWriter<ShortImageType> ShortWriterType;
+        ShortWriterType::Pointer writer = ShortWriterType::New();
+
+        writer->SetInput( rescaler->GetOutput() );
+        writer->SetFileName( fn.c_str() );
+        writer->UseCompressionOn();
+        writer->Update();
+        }
       }
     }
   }
@@ -1246,10 +1288,12 @@ int main(int argc, char * *argv)
   }
 #endif
 
+  std::cerr<< "Before RescaleFunctionLocal" << std::endl;
+  PrintMapOfImageVectors(intraSubjectRegisteredImageList);
   muLogMacro(<< "Rescale intensity of filtered images...\n");
   {
-  RescaleFunctionLocal(intraSubjectRegisteredImageList);
-  RescaleFunctionLocal(intraSubjectRegisteredRawImageList);
+  intraSubjectRegisteredImageList = RescaleFunctionLocal(intraSubjectRegisteredImageList);
+  intraSubjectRegisteredRawImageList = RescaleFunctionLocal(intraSubjectRegisteredRawImageList);
   }
   // Start the segmentation process.
   for( unsigned int segmentationLevel = 0; segmentationLevel < 1; segmentationLevel++ )
@@ -1283,9 +1327,9 @@ int main(int argc, char * *argv)
     for( unsigned int q = 0; q < PriorNames.size(); q++ )
       {
       std::map<std::string, AtlasDefinition::BoundsType> temp_range_List;
-      for( unsigned int tt = 0; tt < inputVolumeTypes.size(); tt++ )
+      for( unsigned int tt = 0; tt < input_VolumeTypes.size(); tt++ )
         {
-        temp_range_List[inputVolumeTypes[tt]] = atlasDefinitionParser.GetBounds(PriorNames[q], inputVolumeTypes[tt]);
+        temp_range_List[input_VolumeTypes[tt]] = atlasDefinitionParser.GetBounds(PriorNames[q], input_VolumeTypes[tt]);
         }
       myRanges[PriorNames[q]] = temp_range_List;
       }
@@ -1302,9 +1346,9 @@ int main(int argc, char * *argv)
       segfilter->SetDebugLevel(debuglevel);
       }
 
+    PrintMapOfImageVectors(intraSubjectRegisteredImageList);
     segfilter->SetInputImages(intraSubjectRegisteredImageList);
     segfilter->SetRawInputImages(intraSubjectRegisteredRawImageList);
-    segfilter->SetInputVolumeTypes(inputVolumeTypes);
 
     segfilter->SetMaximumIterations( maxIterations );
     segfilter->SetOriginalAtlasImages(atlasOriginalImageList);
@@ -1335,74 +1379,71 @@ int main(int argc, char * *argv)
 
     segfilter->Update();
 
-    std::vector<std::string> names = inputVolumes;
     // Write the secondary outputs
     if( !writeLess )
       {
       muLogMacro(<< "Writing filtered and bias corrected images...\n");
       // std::vector<FloatImagePointer> imgset = segfilter->GetCorrected();
-      std::vector<FloatImagePointer> imgset = segfilter->GetRawCorrected();
-      std::vector<std::string>       outFileNames;
-      if( outputVolumes.size() == 1 )
+      AtlasRegType::MapOfFloatImageVectors imgset = segfilter->GetRawCorrected();
+      AtlasRegType::MapOfStringVectors outFileNames;
+
+      if( output_Volumes.size() == 1 )
         {
-        outFileNames.resize(imgset.size() );
-        for( unsigned i = 0; i < imgset.size(); i++ )
+        for(AtlasRegType::MapOfFloatImageVectors::const_iterator mapIt = imgset.begin();
+            mapIt != imgset.end(); ++mapIt)
           {
-          char buf[8192];
-          sprintf(buf, outputVolumes[0].c_str(), inputVolumeTypes[i].c_str(), i);
-          outFileNames[i] = buf;
+          for( unsigned i = 0; i < mapIt->second.size(); i++ )
+            {
+            char buf[8192];
+            sprintf(buf, output_Volumes[0].c_str(), mapIt->first.c_str(), i);
+            outFileNames[mapIt->first].push_back(buf);
+            }
           }
         }
-      else if( outputVolumes.size() != imgset.size() )
+      else if( TotalMapSize(imgset) != TotalMapSize(outputVolumeMap))
         {
-        std::cerr << imgset.size() << " images in filter output, but "
-                  << outputVolumes.size() << " names in output volumes list"
+        std::cerr << TotalMapSize(imgset) << " images in filter output, but "
+                  << TotalMapSize(outputVolumeMap) << " names in output volumes list"
                   << std::endl;
         return EXIT_FAILURE;
         }
       else
         {
-        outFileNames = outputVolumes;
+        outFileNames = outputVolumeMap;
         }
-      for( unsigned i = 0; i < imgset.size(); i++ )
+      for(AtlasRegType::MapOfFloatImageVectors::const_iterator mapIt = imgset.begin();
+          mapIt != imgset.end(); ++mapIt)
         {
-        // typedef itk::RescaleIntensityImageFilter<FloatImageType,
-        // ShortImageType> ShortRescaleType;
-        typedef itk::CastImageFilter<FloatImageType, ShortImageType> CasterType;
-        CasterType::Pointer caster = CasterType::New();
+        for( unsigned i = 0; i < mapIt->second.size(); i++ )
+          {
+          // typedef itk::RescaleIntensityImageFilter<FloatImageType,
+          // ShortImageType> ShortRescaleType;
+          typedef itk::CastImageFilter<FloatImageType, ShortImageType> CasterType;
+          CasterType::Pointer caster = CasterType::New();
 
-        caster->SetInput(imgset[i]);
-        caster->Update();
-        // std::string fn
-        //  = outputDir + GetStripedImageFileNameExtension(names[i]) + std::string("_corrected")
-        //    + suffstr;
+          caster->SetInput(mapIt->second[i]);
+          caster->Update();
+          // std::string fn
+          //  = outputDir + GetStrippedImageFileNameExtension(names[i]) + std::string("_corrected")
+          //    + suffstr;
 
-        typedef itk::ImageFileWriter<ShortImageType> ShortWriterType;
-        ShortWriterType::Pointer writer = ShortWriterType::New();
+          typedef itk::ImageFileWriter<ShortImageType> ShortWriterType;
+          ShortWriterType::Pointer writer = ShortWriterType::New();
 
-        writer->SetInput( caster->GetOutput() );
-        writer->SetFileName(outFileNames[i]);
-        writer->UseCompressionOn();
-        writer->Update();
+          writer->SetInput( caster->GetOutput() );
+          writer->SetFileName(outFileNames[mapIt->first][i]);
+          writer->UseCompressionOn();
+          writer->Update();
+          }
         }
       }
 
+    AtlasRegType::MapOfFloatImageVectors imgset = segfilter->GetRawCorrected();
     // Average together all the input images of a given type
-    typedef std::map<std::string, std::vector<FloatImageType::Pointer> > imgTypeMapType;
-    imgTypeMapType volumesByImgType;
-
-    std::vector<FloatImagePointer> imgset = segfilter->GetRawCorrected();
-    for( unsigned int k = 0; k < inputVolumeTypes.size(); ++k )
+    for(AtlasRegType::MapOfFloatImageVectors::iterator mapIt = imgset.begin();
+        mapIt != imgset.end(); ++mapIt)
       {
-      volumesByImgType[inputVolumeTypes[k]].push_back(imgset[k]);
-      }
-
-    imgTypeMapType::const_iterator mapItr;
-    for( mapItr = volumesByImgType.begin();
-         mapItr != volumesByImgType.end();
-         ++mapItr )
-      {
-      std::string volumeType = mapItr->first;
+      std::string volumeType = mapIt->first;
       // Can't average images of type other since it's really a mix of types.
       std::transform(volumeType.begin(), volumeType.end(), volumeType.begin(), tolower);
       if( volumeType == "other" )
@@ -1410,7 +1451,7 @@ int main(int argc, char * *argv)
         continue;
         }
 
-      FloatImageType::Pointer avgImage = AverageImageList(mapItr->second);
+      FloatImageType::Pointer avgImage = AverageImageList(mapIt->second);
       // Write out average image.
       typedef itk::CastImageFilter<FloatImageType, ShortImageType> CasterType;
       CasterType::Pointer caster = CasterType::New();
@@ -1434,39 +1475,43 @@ int main(int argc, char * *argv)
     // Write warped template and bspline trafo
     if( !atlasWarpingOff )
       {
-      std::vector<SegFilterType::InputImagePointer> WarpedAtlasList = segfilter->GenerateWarpedAtlasImages();
-      for( unsigned int index = 0; index < WarpedAtlasList.size(); index++ )
+      SegFilterType::MapOfInputImageVectors WarpedAtlasList = segfilter->GenerateWarpedAtlasImages();
+      for(SegFilterType::MapOfInputImageVectors::iterator mapIt = WarpedAtlasList.begin();
+          mapIt != WarpedAtlasList.end(); ++mapIt)
         {
-        typedef itk::RescaleIntensityImageFilter<FloatImageType, ByteImageType>
-          ByteRescaleType;
+        for( unsigned int index = 0; index < mapIt->second.size(); index++ )
+          {
+          typedef itk::RescaleIntensityImageFilter<FloatImageType, ByteImageType>
+            ByteRescaleType;
 
-        ByteRescaleType::Pointer rescaler = ByteRescaleType::New();
-        rescaler->SetOutputMinimum(0);
-        rescaler->SetOutputMaximum(255);
-        rescaler->SetInput(WarpedAtlasList[index]);
-        rescaler->Update();
+          ByteRescaleType::Pointer rescaler = ByteRescaleType::New();
+          rescaler->SetOutputMinimum(0);
+          rescaler->SetOutputMaximum(255);
+          rescaler->SetInput(mapIt->second[index]);
+          rescaler->Update();
 
-        typedef itk::ImageFileWriter<ByteImageType> ByteWriterType;
-        ByteWriterType::Pointer writer = ByteWriterType::New();
+          typedef itk::ImageFileWriter<ByteImageType> ByteWriterType;
+          ByteWriterType::Pointer writer = ByteWriterType::New();
 
-        const std::string fn = outputDir
-          + GetStripedImageFileNameExtension(templateVolumes[index]) + std::string("_to_")
-          + GetStripedImageFileNameExtension( ( inputVolumes[0] ) )
-          + std::string("_warped") + std::string(".nii.gz");
+          const std::string fn = outputDir
+            + GetStrippedImageFileNameExtension(templateVolumes[mapIt->first][index]) + std::string("_to_")
+            + GetStrippedImageFileNameExtension( ( inputVolumeMap[mapIt->first][index] ) )
+            + std::string("_warped") + std::string(".nii.gz");
 
-        muLogMacro(<< "Writing warped template images... " << fn << std::endl );
-        writer->SetInput( rescaler->GetOutput() );
-        writer->SetFileName( fn.c_str() );
-        writer->UseCompressionOn();
-        writer->Update();
+          muLogMacro(<< "Writing warped template images... " << fn << std::endl );
+          writer->SetInput( rescaler->GetOutput() );
+          writer->SetFileName( fn.c_str() );
+          writer->UseCompressionOn();
+          writer->Update();
+          }
         }
       if( atlasToSubjectTransform != "" )
         {
         /* HACK Remove this completely
       const std::string postSegmentationTransformFileName = outputDir
-        + GetStripedImageFileNameExtension(templateVolumes[0])
+        + GetStrippedImageFileNameExtension(templateVolumes[0])
         + std::string("_to_")
-        + GetStripedImageFileNameExtension( ( inputVolumes[0] ) )
+        + GetStrippedImageFileNameExtension( ( inputVolumes[0] ) )
         + std::string("_") + defaultSuffix + "_PostSegmentation.h5";
         */
         const std::string postSegmentationTransformFileName = atlasToSubjectTransform;
@@ -1495,7 +1540,7 @@ int main(int argc, char * *argv)
     if( outputLabels == "" )
       {
       fn = outputDir;
-      fn += GetStripedImageFileNameExtension(names[0]);
+      fn += GetStrippedImageFileNameExtension(inputVolumeMap.begin()->second[0]);
       fn += std::string("_DirtyLabels");
       fn += suffstr;
       }
@@ -1515,7 +1560,7 @@ int main(int argc, char * *argv)
     if( outputLabels == "" )
       {
       fn = outputDir;
-      fn += GetStripedImageFileNameExtension(names[0]);
+      fn += GetStrippedImageFileNameExtension(inputVolumeMap.begin()->second[0]);
       fn += std::string("_labels");
       fn += suffstr;
       }
@@ -1571,7 +1616,7 @@ int main(int argc, char * *argv)
       if( posteriorTemplate == "" )
         {
         fn = outputDir;
-        fn += GetStripedImageFileNameExtension(names[0]);
+        fn += GetStrippedImageFileNameExtension(inputVolumeMap.begin()->second[0]);
         fn += "_POSTERIOR_";
         fn += PriorNames[probabilityIndex];
         fn += suffstr;

--- a/BRAINSABC/brainseg/BRAINSABC.xml
+++ b/BRAINSABC/brainseg/BRAINSABC.xml
@@ -12,7 +12,7 @@
     <description>Input parameters</description>
 
     <image multiple="true">
-      <name>inputVolumes</name>
+      <name>input_Volumes</name>
       <label>Image Files</label>
       <longflag>inputVolumes</longflag>
       <flag>i</flag>
@@ -30,7 +30,7 @@
 
     <!-- TODO:  Would rather have a string-enumeration  muliple="true" -->
     <string-vector>
-      <name>inputVolumeTypes</name>
+      <name>input_VolumeTypes</name>
       <label>Image Types</label>
       <description>The list of input image types corresponding to the inputVolumes.</description>
       <longflag>inputVolumeTypes</longflag>
@@ -88,7 +88,7 @@
     <label>Output</label>
     <description>Output filename specifications</description>
     <image multiple="true" fileExtensions=".nii.gz,.nrrd">
-      <name>outputVolumes</name>
+      <name>output_Volumes</name>
       <label>Output Volumes</label>
       <longflag>outputVolumes</longflag>
       <channel>output</channel>

--- a/BRAINSABC/brainseg/BRAINSABCUtilities.cxx
+++ b/BRAINSABC/brainseg/BRAINSABCUtilities.cxx
@@ -89,9 +89,10 @@ std::vector<CorrectIntensityImageType::Pointer> CorrectBias(
     {
     biascorr->DebugOn();
     }
-
-  biascorr->SetInputImages(inputImages);
-  correctedImages = biascorr->CorrectImages(CurrentEMIteration);
+  BiasCorrectorType::MapOfInputImageVectors bcInput;
+  bcInput["first"] = inputImages;
+  biascorr->SetInputImages(bcInput);
+  correctedImages = biascorr->CorrectImages(CurrentEMIteration)["first"];
 
   BiasCorrectorTimer.Stop();
   itk::RealTimeClock::TimeStampType elapsedTime = BiasCorrectorTimer.GetTotal();

--- a/BRAINSABC/brainseg/BRAINSABCUtilities.h
+++ b/BRAINSABC/brainseg/BRAINSABCUtilities.h
@@ -66,7 +66,7 @@ public:
   typedef vnl_matrix<FloatingPrecision>         MatrixType;
   typedef vnl_matrix_inverse<FloatingPrecision> MatrixInverseType;
   typedef vnl_vector<FloatingPrecision>         VectorType;
-
+  typedef std::map<std::string,VectorType>      MapOfVectors;
   RegionStats() : m_Means(), m_Covariance(), m_Weighting(0.0)
   {
   }
@@ -74,10 +74,10 @@ public:
   void resize(const unsigned int numChannels)
   {
     this->m_Covariance = MatrixType(numChannels, numChannels);
-    this->m_Means.set_size(numChannels);
+    this->m_Means.clear();
   }
 
-  VectorType m_Means;             // One measure per image channel type;
+  MapOfVectors m_Means;             // One measure per image channel type;
   MatrixType m_Covariance;        // Matrix of covariances of class by image
                                   // channel
   FloatingPrecision m_Weighting;  // The strength of this class.
@@ -86,10 +86,17 @@ public:
 #include "BRAINSABCUtilities.hxx"
 
 // External Templates to improve compilation times.
-extern std::vector<CorrectIntensityImageType::Pointer> CorrectBias(const unsigned int degree,
-                                                                   const unsigned int CurrentEMIteration,
-                                                                   const std::vector<ByteImageType::Pointer> & CandidateRegions, const std::vector<CorrectIntensityImageType::Pointer> & inputImages, const ByteImageType::Pointer currentBrainMask, const ByteImageType::Pointer currentForegroundMask, const std::vector<FloatImageType::Pointer> & probImages, const std::vector<bool> & probUseForBias, const FloatingPrecision sampleSpacing, const int DebugLevel,
-                                                                   const std::string& OutputDebugDir);
+extern std::vector<CorrectIntensityImageType::Pointer>
+CorrectBias(const unsigned int degree,
+            const unsigned int CurrentEMIteration,
+            const std::vector<ByteImageType::Pointer> & CandidateRegions,
+            const std::vector<CorrectIntensityImageType::Pointer> & inputImages,
+            const ByteImageType::Pointer currentBrainMask,
+            const ByteImageType::Pointer currentForegroundMask,
+            const std::vector<FloatImageType::Pointer> & probImages,
+            const std::vector<bool> & probUseForBias,
+            const FloatingPrecision sampleSpacing, const int DebugLevel,
+            const std::string& OutputDebugDir);
 
 extern template std::vector<FloatImagePointerType> DuplicateImageList<FloatImageType>(
   const std::vector<FloatImagePointerType> & );
@@ -108,5 +115,21 @@ extern template void ComputeLabels<FloatImageType,
 extern template void NormalizeProbListInPlace<FloatImageType>(std::vector<FloatImageType::Pointer> & );
 
 extern template void ZeroNegativeValuesInPlace<FloatImageType>(  std::vector<FloatImageType::Pointer> & );
+
+template <class TMap>
+unsigned int TotalMapSize(const TMap &map)
+{
+  unsigned int rval = 0;
+  for(typename TMap::const_iterator mapIt = map.begin();
+      mapIt != map.end(); ++mapIt)
+    {
+    for(typename TMap::mapped_type::const_iterator listIt =
+          mapIt->second.begin(); listIt != mapIt->second.end(); ++listIt)
+      {
+      ++rval;
+      }
+    }
+  return rval;
+}
 
 #endif // __BRAINSABCUtilities__h__

--- a/BRAINSABC/brainseg/EMSegmentationFilter.hxx
+++ b/BRAINSABC/brainseg/EMSegmentationFilter.hxx
@@ -37,6 +37,8 @@
 #include "BRAINSFitBSpline.h"
 #include "BRAINSFitUtils.h"
 #include "BRAINSFitSyN.h"
+#include "BRAINSABCUtilities.h"
+#include "LLSBiasCorrector.h"
 
 // #include "QHullMSTClusteringProcess.h"
 #include "AtlasDefinition.h"
@@ -91,7 +93,6 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
   m_RawInputImages.clear();
   m_CorrectedImages.clear();
   m_RawCorrectedImages.clear();
-  m_InputVolumeTypes.clear();
 
   m_TemplateBrainMask = NULL;
   m_OriginalAtlasImages.clear();
@@ -184,19 +185,29 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
     itkExceptionMacro(<< "No input images" << std::endl );
     }
 
-  {
-  const InputImageSizeType size = m_InputImages[0]->GetLargestPossibleRegion().GetSize();
-  for( unsigned i = 1; i < m_InputImages.size(); i++ )
+  const InputImageSizeType size =
+    this->GetFirstInputImage()->GetLargestPossibleRegion().GetSize();
+
+  for(typename MapOfInputImageVectors::iterator mapIt = this->m_InputImages.begin();
+      mapIt != this->m_InputImages.end(); ++mapIt)
     {
-    if( m_InputImages[i]->GetImageDimension() != 3 )
+    for(typename InputImageVector::iterator imIt = mapIt->second.begin();
+        imIt != mapIt->second.end(); ++imIt)
       {
-      itkExceptionMacro(<< "InputImage [" << i << "] has invalid dimension: only supports 3D images" << std::endl );
-      }
-    const InputImageSizeType isize = m_InputImages[i]->GetLargestPossibleRegion().GetSize();
-    if( size != isize )
-      {
-      itkExceptionMacro(<< "Image data [" << i << "] 3D size mismatch "
-                        << size << " != " << isize << "." << std::endl );
+      if( (*imIt)->GetImageDimension() != 3 )
+        {
+        itkExceptionMacro(<< "InputImage ["
+                          << mapIt->first << " " << std::distance(mapIt->second.begin(),imIt)
+                          << "] has invalid dimension: only supports 3D images" << std::endl );
+        }
+      const InputImageSizeType isize = (*imIt)->GetLargestPossibleRegion().GetSize();
+      if( size != isize )
+        {
+        itkExceptionMacro(<< "Image data ["
+                          << mapIt->first << " " << std::distance(mapIt->second.begin(),imIt)
+                          << "] 3D size mismatch "
+                          << size << " != " << isize << "." << std::endl );
+        }
       }
     }
   for( unsigned i = 0; i < m_WarpedPriors.size(); i++ )
@@ -213,44 +224,59 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
                         << std::endl );
       }
     }
-  }
 
-  {
-  const InputImageSizeType atlasSize = m_OriginalAtlasImages[0]->GetLargestPossibleRegion().GetSize();
-  for( unsigned i = 1; i < m_OriginalAtlasImages.size(); i++ )
+  const InputImageSizeType atlasSize =
+    this->GetFirstOriginalAtlasImage()->GetLargestPossibleRegion().GetSize();
+  for(typename MapOfInputImageVectors::iterator mapIt = this->m_OriginalAtlasImages.begin();
+      mapIt != this->m_OriginalAtlasImages.end(); ++mapIt)
     {
-    if( m_OriginalAtlasImages[i]->GetImageDimension() != 3 )
+    for(typename InputImageVector::iterator imIt = mapIt->second.begin();
+        imIt != mapIt->second.end(); ++imIt)
       {
-      itkExceptionMacro(<< "Atlas Image [" << i << "] has invalid dimension: only supports 3D images" << std::endl );
-      }
-    const InputImageSizeType asize = m_OriginalAtlasImages[i]->GetLargestPossibleRegion().GetSize();
-    if( atlasSize != asize )
-      {
-      itkExceptionMacro(<< "Image data [" << i << "] 3D size mismatch "
-                        << atlasSize << " != " << asize << "." << std::endl );
+      if( (*imIt)->GetImageDimension() != 3 )
+        {
+        itkExceptionMacro(<< "Atlas Image ["
+                          << mapIt->first << " "
+                          << std::distance(mapIt->second.begin(),imIt)
+                          << "] has invalid dimension: only supports 3D images" << std::endl );
+        }
+      const InputImageSizeType asize = (*imIt)->GetLargestPossibleRegion().GetSize();
+      if( atlasSize != asize )
+        {
+        itkExceptionMacro(<< "Image data ["
+                          << mapIt->first << " "
+                          << std::distance(mapIt->second.begin(),imIt)
+                          << "] 3D size mismatch "
+                          << atlasSize << " != " << asize << "." << std::endl );
+        }
       }
     }
-  for( unsigned i = 0; i < m_OriginalSpacePriors.size(); i++ )
+
+  for(typename ProbabilityImageVectorType::iterator imIt = this->m_OriginalSpacePriors.begin();
+      imIt != this->m_OriginalSpacePriors.end(); ++imIt)
     {
-    if( m_OriginalSpacePriors[i]->GetImageDimension() != 3 )
+    if( (*imIt)->GetImageDimension() != 3 )
       {
-      itkExceptionMacro(<< "Prior [" << i << "] has invalid dimension: only supports 3D images" << std::endl );
+      itkExceptionMacro(<< "Prior ["
+                        << std::distance(this->m_OriginalSpacePriors.begin(),imIt)
+                        << "] has invalid dimension: only supports 3D images" << std::endl );
       }
-    const ProbabilityImageSizeType psize = m_OriginalSpacePriors[i]->GetLargestPossibleRegion().GetSize();
+    const ProbabilityImageSizeType psize = (*imIt)->GetLargestPossibleRegion().GetSize();
     if( atlasSize != psize )
       {
-      itkExceptionMacro(<< "Normalized prior [" << i << "] and atlas 3D size mismatch"
+      itkExceptionMacro(<< "Normalized prior ["
+                        << std::distance(this->m_OriginalSpacePriors.begin(),imIt)
+                        << "] and atlas 3D size mismatch"
                         << atlasSize << " != " << psize << "."
                         << std::endl );
       }
     }
-  }
 }
 
 template <class TInputImage, class TProbabilityImage>
 void
 EMSegmentationFilter<TInputImage, TProbabilityImage>
-::SetInputImages(const InputImageVector & newInputImages)
+::SetInputImages(const MapOfInputImageVectors newInputImages)
 {
   muLogMacro(<< "SetInputImages" << std::endl);
 
@@ -268,7 +294,7 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
 template <class TInputImage, class TProbabilityImage>
 void
 EMSegmentationFilter<TInputImage, TProbabilityImage>
-::SetRawInputImages(const InputImageVector & newInputImages)
+::SetRawInputImages(const MapOfInputImageVectors newInputImages)
 {
   muLogMacro(<< "SetRawInputImages" << std::endl);
 
@@ -286,7 +312,7 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
 template <class TInputImage, class TProbabilityImage>
 void
 EMSegmentationFilter<TInputImage, TProbabilityImage>
-::SetOriginalAtlasImages(const InputImageVector & newAtlasImages)
+::SetOriginalAtlasImages(const MapOfInputImageVectors newAtlasImages)
 {
   muLogMacro(<< "SetAtlasImages" << std::endl);
 
@@ -492,7 +518,7 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
 }
 
 template <class TInputImage, class TProbabilityImage>
-std::vector<typename EMSegmentationFilter<TInputImage, TProbabilityImage>::InputImagePointer>
+typename EMSegmentationFilter<TInputImage, TProbabilityImage>::MapOfInputImageVectors
 EMSegmentationFilter<TInputImage, TProbabilityImage>
 ::GetCorrected()
 {
@@ -500,7 +526,7 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
 }
 
 template <class TInputImage, class TProbabilityImage>
-std::vector<typename EMSegmentationFilter<TInputImage, TProbabilityImage>::InputImagePointer>
+typename EMSegmentationFilter<TInputImage, TProbabilityImage>::MapOfInputImageVectors
 EMSegmentationFilter<TInputImage, TProbabilityImage>
 ::GetRawCorrected()
 {
@@ -568,7 +594,8 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
   // LLSBiasCorrector which unfortunately does NOT keep track of the
   // types of input images.  So there may need to be a custom version
   // of this method that groups by image type
-  CombinedComputeDistributions<TInputImage, TProbabilityImage, MatrixType>(SubjectCandidateRegions, this->m_CorrectedImages,
+  CombinedComputeDistributions<TInputImage, TProbabilityImage, MatrixType>(SubjectCandidateRegions,
+                                                                           this->m_CorrectedImages,
                                                                            probabilityMaps,
                                                                            outputStats,
                                                                            this->m_DebugLevel,
@@ -602,14 +629,27 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
   const FloatingPrecision priorScale,
   const typename TProbabilityImage::Pointer prior,
   const vnl_matrix<FloatingPrecision> currCovariance,
-  const vnl_vector<FloatingPrecision> currMeans,
-  const std::vector<typename TInputImage::Pointer> & intensityImages
+  const typename RegionStats::MapOfVectors currMeans,
+  const MapOfInputImageVectors & intensityImages
   )
 {
   typedef vnl_matrix<FloatingPrecision>         MatrixType;
   typedef vnl_matrix_inverse<FloatingPrecision> MatrixInverseType;
 
-  const unsigned          numChannels = currMeans.size();
+  unsigned          numChannels = 0;
+  // FOR IPEK & GARY -- this is a stopgap -- even though we use a map
+  // of image lists instead of an image list, we're still computing
+  // ImageList.size() * ImageList.size() covariance.
+  for(typename RegionStats::MapOfVectors::const_iterator mapIt = currMeans.begin();
+      mapIt != currMeans.end(); ++mapIt)
+    {
+    for(typename RegionStats::VectorType::const_iterator vecIt = mapIt->second.begin();
+        vecIt != mapIt->second.end(); ++vecIt)
+      {
+      ++numChannels;
+      }
+    }
+
   const FloatingPrecision detcov = ComputeCovarianceDeterminant(currCovariance);
 
   // Normalizing constant for the Gaussian
@@ -625,7 +665,21 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
   post->Allocate();
 
   const typename TProbabilityImage::SizeType size = post->GetLargestPossibleRegion().GetSize();
-  {
+
+  //
+  // HACK HACK HACK HACK -- FIX -- this code expects
+  // a flat list of intensityImages
+  std::vector<InputImagePointer> tmpIntensityImages;
+  for(typename MapOfInputImageVectors::const_iterator mapIt = intensityImages.begin();
+      mapIt != intensityImages.end(); ++mapIt)
+    {
+    for(typename InputImageVector::const_iterator imIt = mapIt->second.begin();
+        imIt != mapIt->second.end(); ++imIt)
+      {
+      tmpIntensityImages.push_back((*imIt));
+      }
+    }
+
 #if defined(LOCAL_USE_OPEN_MP)
 #pragma omp parallel for
 #endif
@@ -645,17 +699,23 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
         // the desired class is significantly higher than 1%.
         const typename TProbabilityImage::PixelType minPriorValue = 0.0;
         const typename TProbabilityImage::PixelType priorValue = (prior->GetPixel(currIndex) + minPriorValue);
-        {
         MatrixType X(numChannels, 1);
-        for( unsigned int ichan = 0; ichan < numChannels; ichan++ )
+        {
+        unsigned int ichan = 0;
+        for(typename RegionStats::MapOfVectors::const_iterator mapIt = currMeans.begin();
+            mapIt != currMeans.end(); ++mapIt)
           {
-          X(ichan, 0) =
-            intensityImages[ichan]->GetPixel(currIndex) - currMeans[ichan];
+          for(typename RegionStats::VectorType::const_iterator vecIt = mapIt->second.begin();
+              vecIt != mapIt->second.end(); ++vecIt, ++ichan)
+            {
+            X(ichan, 0) =
+              tmpIntensityImages[ichan]->GetPixel(currIndex) - (*vecIt);
+            }
           }
-
+        }
         const MatrixType  Y = invcov * X;
         FloatingPrecision mahalo = 0.0;
-        for( unsigned int ichan = 0; ichan < numChannels; ichan++ )
+        for(unsigned int ichan = 0; ichan < numChannels; ichan++ )
           {
           const FloatingPrecision & currVal = X(ichan, 0) * Y(ichan, 0);
           CHECK_NAN(currVal, __FILE__, __LINE__, "\n  currIndex: " << currIndex
@@ -683,10 +743,8 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
                   << "\n  Y:  " << Y );
         post->SetPixel(currIndex, currentPosterior);
         }
-        }
       }
     }
-  }
   return post;
 }
 
@@ -695,7 +753,7 @@ typename EMSegmentationFilter<TInputImage, TProbabilityImage>::ProbabilityImageV
 EMSegmentationFilter<TInputImage, TProbabilityImage>
 ::ComputePosteriors(const ProbabilityImageVectorType & Priors,
                     const vnl_vector<FloatingPrecision> & PriorWeights,
-                    const std::vector<typename TInputImage::Pointer> & IntensityImages,
+                    const MapOfInputImageVectors & IntensityImages,
                     std::vector<RegionStats> & ListOfClassStatistics)
 {
   // Compute initial distribution parameters
@@ -774,29 +832,37 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
 template <class TInputImage, class TProbabilityImage>
 void
 EMSegmentationFilter<TInputImage, TProbabilityImage>
-::WriteDebugCorrectedImages(const std::vector<typename TInputImage::Pointer> & correctImageList,
+::WriteDebugCorrectedImages(const MapOfInputImageVectors &correctImageList,
                             const unsigned int CurrentEMIteration ) const
 {
-  if( this->m_DebugLevel > 8 )
-    { // DEBUG:  This code is for debugging purposes only;
-    std::stringstream CurrentEMIteration_stream("");
-    CurrentEMIteration_stream << CurrentEMIteration;
-    for( unsigned int vIndex = 0; vIndex < correctImageList.size(); vIndex++ )
+  if(this->m_DebugLevel <= 8)
+    {
+    return;
+    }
+  std::stringstream CurrentEMIteration_stream("");
+  CurrentEMIteration_stream << CurrentEMIteration;
+  for(typename MapOfInputImageVectors::const_iterator mapIt = correctImageList.begin();
+      mapIt != correctImageList.end(); ++mapIt)
+    {
+    for(typename InputImageVector::const_iterator imIt = mapIt->second.begin();
+        imIt != mapIt->second.end(); ++imIt)
       {
-      { // DEBUG:  This code is for debugging purposes only;
       typedef itk::ImageFileWriter<InputImageType> WriterType;
       typename WriterType::Pointer writer = WriterType::New();
       writer->UseCompressionOn();
-
       std::stringstream template_index_stream("");
-      template_index_stream << vIndex;
-      const std::string fn = this->m_OutputDebugDir + "/CORRECTED_INDEX_" + template_index_stream.str() + "_LEVEL_"
-        + CurrentEMIteration_stream.str() + ".nii.gz";
-      writer->SetInput(correctImageList[vIndex]);
+      template_index_stream << std::distance(mapIt->second.begin(),imIt);
+      const std::string fn = this->m_OutputDebugDir
+        + "/CORRECTED_INDEX_"
+        + mapIt->first
+        + template_index_stream.str()
+        + "_LEVEL_"
+        + CurrentEMIteration_stream.str()
+        + ".nii.gz";
+      writer->SetInput((*imIt));
       writer->SetFileName(fn.c_str() );
       writer->Update();
       muLogMacro( << "DEBUG:  Wrote image " << fn <<  std::endl);
-      }
       }
     }
 }
@@ -883,12 +949,13 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
     }
 }
 
-template <class TInputImage>
-std::vector<typename TInputImage::Pointer>
-WarpImageList(const std::vector<typename TInputImage::Pointer> & originalList,
-              const typename TInputImage::Pointer referenceOutput,
-              const std::vector<typename TInputImage::PixelType> & backgroundValues,
-              const GenericTransformType::Pointer warpTransform)
+template <class TInputImage, class TProbabilityImage>
+typename EMSegmentationFilter<TInputImage, TProbabilityImage>::ProbabilityImageVectorType
+EMSegmentationFilter<TInputImage, TProbabilityImage>
+::WarpImageList(ProbabilityImageVectorType &originalList,
+                const InputImagePointer  referenceOutput,
+                const BackgroundValueVector & backgroundValues,
+                const GenericTransformType::Pointer warpTransform)
 {
   if( originalList.size() != backgroundValues.size() )
     {
@@ -897,7 +964,6 @@ WarpImageList(const std::vector<typename TInputImage::Pointer> & originalList,
   std::vector<typename TInputImage::Pointer> warpedList(originalList.size() );
 
   typedef itk::ResampleImageFilter<TInputImage, TInputImage> ResamplerType;
-  {
   for( unsigned int vIndex = 0; vIndex < originalList.size(); vIndex++ )
     {
     typename ResamplerType::Pointer warper = ResamplerType::New();
@@ -910,7 +976,37 @@ WarpImageList(const std::vector<typename TInputImage::Pointer> & originalList,
     warper->Update();
     warpedList[vIndex] = warper->GetOutput();
     }
-  }
+  return warpedList;
+}
+
+template <class TInputImage, class TProbabilityImage>
+typename EMSegmentationFilter<TInputImage, TProbabilityImage>::MapOfInputImageVectors
+EMSegmentationFilter<TInputImage, TProbabilityImage>
+::WarpImageList(MapOfInputImageVectors &originalList,
+                const InputImagePointer referenceOutput,
+                const GenericTransformType::Pointer warpTransform)
+{
+  typedef itk::ResampleImageFilter<TInputImage, TInputImage> ResamplerType;
+
+  MapOfInputImageVectors warpedList;
+
+  for(typename MapOfInputImageVectors::iterator mapIt = originalList.begin();
+      mapIt != originalList.end(); ++mapIt)
+    {
+    for(typename InputImageVector::iterator imIt = mapIt->second.begin();
+        imIt != mapIt->second.end(); ++imIt)
+      {
+      typename ResamplerType::Pointer warper = ResamplerType::New();
+      warper->SetInput(*imIt);
+      warper->SetTransform(warpTransform);
+
+      // warper->SetInterpolator(linearInt); // Default is linear
+      warper->SetOutputParametersFromImage(referenceOutput);
+      warper->SetDefaultPixelValue(0);
+      warper->Update();
+      warpedList[mapIt->first].push_back(warper->GetOutput());
+      }
+    }
   return warpedList;
 }
 
@@ -924,46 +1020,50 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
   CurrentEMIteration_stream << CurrentEMIteration;
   if( this->m_DebugLevel > 9 )
     {
-    for( unsigned int vIndex = 0; vIndex < this->m_WarpedAtlasImages.size(); vIndex++ )
+    for(typename MapOfInputImageVectors::const_iterator mapIt =
+          this->m_WarpedAtlasImages.begin();
+        mapIt != this->m_WarpedAtlasImages.end(); ++mapIt)
       {
-      typedef itk::ImageFileWriter<InputImageType> WriterType;
-      typename WriterType::Pointer writer = WriterType::New();
-      writer->UseCompressionOn();
+      for(typename InputImageVector::const_iterator imIt = mapIt->second.begin();
+          imIt != mapIt->second.end(); ++imIt)
+        {
+        typedef itk::ImageFileWriter<InputImageType> WriterType;
+        typename WriterType::Pointer writer = WriterType::New();
+        writer->UseCompressionOn();
 
-      std::stringstream template_index_stream("");
-      template_index_stream << vIndex;
-      const std::string fn = this->m_OutputDebugDir + "/WARPED_ATLAS_INDEX_" + template_index_stream.str()
-        + "_LEVEL_" + CurrentEMIteration_stream.str() + ".nii.gz";
-      writer->SetInput(m_WarpedAtlasImages[vIndex]);
-      writer->SetFileName(fn.c_str() );
-      writer->Update();
-      muLogMacro( << "DEBUG:  Wrote image " << fn <<  std::endl);
+        std::stringstream template_index_stream("");
+        template_index_stream << mapIt->first
+                              << std::distance(mapIt->second.begin(),imIt);
+        const std::string fn = this->m_OutputDebugDir + "/WARPED_ATLAS_INDEX_" + template_index_stream.str()
+          + "_LEVEL_" + CurrentEMIteration_stream.str() + ".nii.gz";
+        writer->SetInput((*imIt));
+        writer->SetFileName(fn.c_str() );
+        writer->Update();
+        muLogMacro( << "DEBUG:  Wrote image " << fn <<  std::endl);
+        }
       }
     }
 }
 
 template <class TInputImage, class TProbabilityImage>
-std::vector<typename TInputImage::Pointer>
+typename EMSegmentationFilter<TInputImage, TProbabilityImage>::MapOfInputImageVectors
 EMSegmentationFilter<TInputImage, TProbabilityImage>
 ::GenerateWarpedAtlasImages(void)
 {
-  // TODO:  Need to make this cleaner.
-  std::vector<typename TInputImage::PixelType> backgroundValues(m_OriginalAtlasImages.size() );
-  std::fill(backgroundValues.begin(), backgroundValues.end(), 0);
-
   this->m_WarpedAtlasImages =
-    WarpImageList<TProbabilityImage>(this->m_OriginalAtlasImages, this->m_InputImages[0], backgroundValues,
-                                     this->m_TemplateGenericTransform);
+    this->WarpImageList(this->m_OriginalAtlasImages,
+                        *(this->m_InputImages.begin()->second.begin()),
+                        this->m_TemplateGenericTransform);
   return m_WarpedAtlasImages;
 }
 
 template <class TInputImage, class TProbabilityImage>
-std::vector<typename ByteImageType::Pointer>
+typename EMSegmentationFilter<TInputImage, TProbabilityImage>::ByteImageVectorType
 EMSegmentationFilter<TInputImage, TProbabilityImage>
 ::UpdateIntensityBasedClippingOfPriors(const unsigned int CurrentEMIteration,
-                                       const std::vector<typename TInputImage::Pointer> & intensityList,
-                                       ProbabilityImageVectorType & WarpedPriorsList,
-                                       typename ByteImageType::Pointer ForegroundBrainRegion)
+                                       const MapOfInputImageVectors &intensityList,
+                                       const ProbabilityImageVectorType &WarpedPriorsList,
+                                       typename ByteImageType::Pointer &ForegroundBrainRegion)
 {
   // #################################################################
   // #################################################################
@@ -984,7 +1084,7 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
   for( LOOPITERTYPE i = 0; i < (LOOPITERTYPE)WarpedPriorsList.size(); i++ )
     {
     typename ByteImageType::Pointer probThreshImage = NULL;
-    {
+
     typedef itk::BinaryThresholdImageFilter<TProbabilityImage, ByteImageType> ProbThresholdType;
     typename ProbThresholdType::Pointer probThresh = ProbThresholdType::New();
     probThresh->SetInput(  WarpedPriorsList[i] );
@@ -1018,38 +1118,44 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
       writer->UseCompressionOn();
       writer->Update();
       }
-    }
+
 
     const unsigned int numberOfModes = intensityList.size();
     typedef typename itk::MultiModeHistogramThresholdBinaryImageFilter<InputImageType,
-                                                                       ByteImageType> ThresholdRegionFinderType;
+      ByteImageType> ThresholdRegionFinderType;
     typename ThresholdRegionFinderType::ThresholdArrayType QuantileLowerThreshold(numberOfModes);
     typename ThresholdRegionFinderType::ThresholdArrayType QuantileUpperThreshold(numberOfModes);
     typename ThresholdRegionFinderType::Pointer thresholdRegionFinder = ThresholdRegionFinderType::New();
     // TODO:  Need to define PortionMaskImage from deformed probspace
     thresholdRegionFinder->SetBinaryPortionImage(ForegroundBrainRegion);
-    for( LOOPITERTYPE modeIndex = 0; modeIndex < (LOOPITERTYPE)numberOfModes; modeIndex++ )
+    unsigned int modeIndex = 0;
+    for(typename MapOfInputImageVectors::const_iterator mapIt = intensityList.begin();
+        mapIt != intensityList.end(); ++mapIt)
       {
-      thresholdRegionFinder->SetInput(modeIndex, intensityList[modeIndex]);
-      const std::string imageType = this->m_InputVolumeTypes[modeIndex];
-      const std::string priorType = this->m_PriorNames[i];
-      if( m_TissueTypeThresholdMapsRange[priorType].find(imageType) ==
-          m_TissueTypeThresholdMapsRange[priorType].end() )
+      for(typename InputImageVector::const_iterator imIt = mapIt->second.begin();
+          imIt != mapIt->second.end(); ++imIt, ++modeIndex)
         {
-        muLogMacro(<< "NOT FOUND:" << "[" << priorType << "," << imageType
-                   << "]: [" << 0.00 << "," << 1.00 << "]"
-                   <<  std::endl);
-        QuantileLowerThreshold.SetElement(modeIndex, 0.00);
-        QuantileUpperThreshold.SetElement(modeIndex, 1.00);
-        }
-      else
-        {
-        const float lower = m_TissueTypeThresholdMapsRange[priorType][imageType].GetLower();
-        const float upper = m_TissueTypeThresholdMapsRange[priorType][imageType].GetUpper();
-        muLogMacro( <<  "[" << priorType << "," << imageType << "]: [" << lower << "," << upper << "]" <<  std::endl);
-        QuantileLowerThreshold.SetElement(modeIndex, lower);
-        QuantileUpperThreshold.SetElement(modeIndex, upper);
-        m_TissueTypeThresholdMapsRange[priorType][imageType].Print();
+        thresholdRegionFinder->SetInput(modeIndex, (*imIt));
+        const std::string imageType = mapIt->first;
+        const std::string priorType = this->m_PriorNames[i];
+        if( m_TissueTypeThresholdMapsRange[priorType].find(imageType) ==
+            m_TissueTypeThresholdMapsRange[priorType].end() )
+          {
+          muLogMacro(<< "NOT FOUND:" << "[" << priorType << "," << imageType
+                     << "]: [" << 0.00 << "," << 1.00 << "]"
+                     <<  std::endl);
+          QuantileLowerThreshold.SetElement(modeIndex, 0.00);
+          QuantileUpperThreshold.SetElement(modeIndex, 1.00);
+          }
+        else
+          {
+          const float lower = m_TissueTypeThresholdMapsRange[priorType][imageType].GetLower();
+          const float upper = m_TissueTypeThresholdMapsRange[priorType][imageType].GetUpper();
+          muLogMacro( <<  "[" << priorType << "," << imageType << "]: [" << lower << "," << upper << "]" <<  std::endl);
+          QuantileLowerThreshold.SetElement(modeIndex, lower);
+          QuantileUpperThreshold.SetElement(modeIndex, upper);
+          m_TissueTypeThresholdMapsRange[priorType][imageType].Print();
+          }
         }
       }
     // Assume upto (2*0.025)% of intensities are noise that corrupts the image
@@ -1178,11 +1284,12 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
 }
 
 template <class TInputImage, class TProbabilityImage>
-std::vector<typename ByteImageType::Pointer>
+typename EMSegmentationFilter<TInputImage, TProbabilityImage>::ByteImageVectorType
 EMSegmentationFilter<TInputImage, TProbabilityImage>
-::ForceToOne(const unsigned int, const std::vector<typename TInputImage::Pointer> &,
-             ProbabilityImageVectorType & WarpedPriorsList,
-             typename ByteImageType::Pointer )
+::ForceToOne(const unsigned int /* CurrentEMIteration */,
+             // const MapOfInputImageVectors &intensityList,
+             ProbabilityImageVectorType &WarpedPriorsList,
+             typename ByteImageType::Pointer /* NonAirRegion */)
 {
   // #################################################################
   // #################################################################
@@ -1193,7 +1300,7 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
   // For each intensityList, get it's type, and then create an "anded mask of
   // candidate regions"
   // using the table from BRAINSMultiModeHistogramThresholder.
-  std::vector<typename ByteImageType::Pointer> subjectCandidateRegions;
+  ByteImageVectorType subjectCandidateRegions;
 
   subjectCandidateRegions.resize(WarpedPriorsList.size() );
   { // StartValid Regions Section
@@ -1353,146 +1460,157 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
       << "WARNING: WARNING: WARNING: WARNING:  Doing warping even though it was turned off from the command line"
       << std::endl);
     }
-  for( unsigned int vIndex = 0; vIndex < m_OriginalAtlasImages.size() && vIndex < m_CorrectedImages.size(); vIndex++ )
+  for(typename MapOfInputImageVectors::iterator imMapIt =
+        this->m_CorrectedImages.begin();
+      imMapIt != this->m_CorrectedImages.end(); ++imMapIt)
     {
-    typedef itk::BRAINSFitHelper HelperType;
-    HelperType::Pointer atlasToSubjectRegistrationHelper = HelperType::New();
-    atlasToSubjectRegistrationHelper->SetNumberOfSamples(500000);
-    atlasToSubjectRegistrationHelper->SetNumberOfHistogramBins(50);
-    std::vector<int> numberOfIterations(1);
-    numberOfIterations[0] = 1500;
-    atlasToSubjectRegistrationHelper->SetNumberOfIterations(numberOfIterations);
-    //  atlasToSubjectRegistrationHelper->SetMaximumStepLength(maximumStepSize);
-    atlasToSubjectRegistrationHelper->SetTranslationScale(1000);
-    atlasToSubjectRegistrationHelper->SetReproportionScale(1.0);
-    atlasToSubjectRegistrationHelper->SetSkewScale(1.0);
-
-    // atlasToSubjectRegistrationHelper->SetMaskInferiorCutOffFromCenter(maskInferiorCutOffFromCenter);
-    //  atlasToSubjectRegistrationHelper->SetUseWindowedSinc(useWindowedSinc);
-
-    // Register each intrasubject image mode to first image
-    atlasToSubjectRegistrationHelper->SetFixedVolume(m_CorrectedImages[vIndex]);
-    // Register all atlas images to first image
-    {
-    if( false /* m_AtlasTransformType == ID_TRANSFORM */ )
+    typename InputImageVector::iterator imIt = imMapIt->second.begin();
+    typename InputImageVector::iterator atIt =
+      this->m_OriginalAtlasImages[imMapIt->first].begin();
+    for(; imIt != imMapIt->second.end()
+          && atIt != this->m_OriginalAtlasImages[imMapIt->first].end();
+        ++imIt, ++atIt)
       {
-      muLogMacro(<< "Registering (Identity) atlas to first image." << std::endl);
-      // TODO: m_AtlasToSubjectTransform = MakeRigidIdentity();
-      }
-    else // continue;
-      {
-      std::string preprocessMovingString("");
-      // const bool histogramMatch=true;//Setting histogram matching to true
+      typedef itk::BRAINSFitHelper HelperType;
+      HelperType::Pointer atlasToSubjectRegistrationHelper = HelperType::New();
+      atlasToSubjectRegistrationHelper->SetNumberOfSamples(500000);
+      atlasToSubjectRegistrationHelper->SetNumberOfHistogramBins(50);
+      std::vector<int> numberOfIterations(1);
+      numberOfIterations[0] = 1500;
+      atlasToSubjectRegistrationHelper->SetNumberOfIterations(numberOfIterations);
+      //  atlasToSubjectRegistrationHelper->SetMaximumStepLength(maximumStepSize);
+      atlasToSubjectRegistrationHelper->SetTranslationScale(1000);
+      atlasToSubjectRegistrationHelper->SetReproportionScale(1.0);
+      atlasToSubjectRegistrationHelper->SetSkewScale(1.0);
 
-      // Setting histogram matching to false because it appears to have been
-      // causing problems for some images.
-      const bool histogramMatch = false;
-      if( histogramMatch )
-        {
-        typedef itk::HistogramMatchingImageFilter<InputImageType,
-                                                  InputImageType> HistogramMatchingFilterType;
-        typename HistogramMatchingFilterType::Pointer histogramfilter
-          = HistogramMatchingFilterType::New();
+      // atlasToSubjectRegistrationHelper->SetMaskInferiorCutOffFromCenter(maskInferiorCutOffFromCenter);
+      //  atlasToSubjectRegistrationHelper->SetUseWindowedSinc(useWindowedSinc);
 
-        histogramfilter->SetInput( m_OriginalAtlasImages[vIndex]  );
-        histogramfilter->SetReferenceImage( m_CorrectedImages[vIndex] );
+      // Register each intrasubject image mode to first image
+      atlasToSubjectRegistrationHelper->SetFixedVolume((*imIt));
+      // Register all atlas images to first image
+      if( false /* m_AtlasTransformType == ID_TRANSFORM */ )
+        {
+        muLogMacro(<< "Registering (Identity) atlas to first image." << std::endl);
+        // TODO: m_AtlasToSubjectTransform = MakeRigidIdentity();
+        }
+      else // continue;
+        {
+        std::string preprocessMovingString("");
+        // const bool histogramMatch=true;//Setting histogram matching to true
 
-        histogramfilter->SetNumberOfHistogramLevels( 50 );
-        histogramfilter->SetNumberOfMatchPoints( 10 );
-        histogramfilter->ThresholdAtMeanIntensityOn();
-        histogramfilter->Update();
-        typename InputImageType::Pointer equalizedMovingImage = histogramfilter->GetOutput();
-        atlasToSubjectRegistrationHelper->SetMovingVolume(equalizedMovingImage);
-        preprocessMovingString = "histogram equalized ";
+        // Setting histogram matching to false because it appears to have been
+        // causing problems for some images.
+        const bool histogramMatch = false;
+        if( histogramMatch )
+          {
+          typedef itk::HistogramMatchingImageFilter<InputImageType,
+            InputImageType> HistogramMatchingFilterType;
+          typename HistogramMatchingFilterType::Pointer histogramfilter
+            = HistogramMatchingFilterType::New();
+
+          histogramfilter->SetInput( (*atIt) );
+          histogramfilter->SetReferenceImage( (*imIt) );
+
+          histogramfilter->SetNumberOfHistogramLevels( 50 );
+          histogramfilter->SetNumberOfMatchPoints( 10 );
+          histogramfilter->ThresholdAtMeanIntensityOn();
+          histogramfilter->Update();
+          typename InputImageType::Pointer equalizedMovingImage = histogramfilter->GetOutput();
+          atlasToSubjectRegistrationHelper->SetMovingVolume(equalizedMovingImage);
+          preprocessMovingString = "histogram equalized ";
+          }
+        else
+          {
+          atlasToSubjectRegistrationHelper->SetMovingVolume((*atIt));
+          preprocessMovingString = "";
+          }
+        typedef itk::BRAINSROIAutoImageFilter<InputImageType, itk::Image<unsigned char, 3> > ROIAutoType;
+        typename ROIAutoType::Pointer  ROIFilter = ROIAutoType::New();
+        ROIFilter->SetInput((*atIt));
+        ROIFilter->SetDilateSize(10);
+        ROIFilter->Update();
+        atlasToSubjectRegistrationHelper->SetMovingBinaryVolume(ROIFilter->GetSpatialObjectROI() );
+
+        typedef itk::BRAINSROIAutoImageFilter<InputImageType, itk::Image<unsigned char, 3> > ROIAutoType;
+        ROIFilter = ROIAutoType::New();
+        ROIFilter->SetInput((*imIt));
+        ROIFilter->SetDilateSize(10);
+        ROIFilter->Update();
+        atlasToSubjectRegistrationHelper->SetFixedBinaryVolume(ROIFilter->GetSpatialObjectROI() );
+
+        if( m_AtlasTransformType == "Rigid" )
+          {
+          muLogMacro(<< "Registering (Rigid) " << preprocessMovingString << "atlas("
+                     << imMapIt->first << std::distance(imMapIt->second.begin(),imIt)
+                     << ") to template("
+                     << imMapIt->first << std::distance(imMapIt->second.begin(),imIt)
+                     << ") image." << std::endl);
+          std::vector<double> minimumStepSize(1);
+          minimumStepSize[0] = 0.005; // NOTE: 0.005 for between subject
+          // registration is probably about the
+          // limit.
+          atlasToSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
+          std::vector<std::string> transformType(1);
+          transformType[0] = "Rigid";
+          atlasToSubjectRegistrationHelper->SetTransformType(transformType);
+          }
+        else if( m_AtlasTransformType == "Affine" )
+          {
+          muLogMacro(
+            << "Registering (Affine) " << preprocessMovingString << "atlas("
+            << imMapIt->first << std::distance(imMapIt->second.begin(),imIt)
+            << ") to template("
+            << imMapIt->first << std::distance(imMapIt->second.begin(),imIt)
+            << ") image." << std::endl);
+          std::vector<double> minimumStepSize(1);
+          minimumStepSize[0] = 0.0025;
+          atlasToSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
+          std::vector<std::string> transformType(1);
+          transformType[0] = "Affine";
+          atlasToSubjectRegistrationHelper->SetTransformType(transformType);
+          }
+        else if( m_AtlasTransformType == "BSpline" )
+          {
+          muLogMacro(<< "Registering (BSpline) " << preprocessMovingString << "atlas("
+                     << imMapIt->first << std::distance(imMapIt->second.begin(),imIt)
+                     << ") to template("
+                     << imMapIt->first << std::distance(imMapIt->second.begin(),imIt)
+                     << ") image." << std::endl);
+          std::vector<double> minimumStepSize(1);
+          minimumStepSize[0] = 0.0025;
+          atlasToSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
+          std::vector<std::string> transformType(1);
+          transformType[0] = "BSpline";
+          atlasToSubjectRegistrationHelper->SetTransformType(transformType);
+          std::vector<int> splineGridSize(3);
+          splineGridSize[0] = m_WarpGrid[0];
+          splineGridSize[1] = m_WarpGrid[1];
+          splineGridSize[2] = m_WarpGrid[2];
+          atlasToSubjectRegistrationHelper->SetSplineGridSize(splineGridSize);
+          // Setting max displace
+          atlasToSubjectRegistrationHelper->SetMaxBSplineDisplacement(6.0);
+          }
+        else if( m_AtlasTransformType == "SyN" )
+          {
+          std::cerr << "ERROR:  NOT PROPERLY IMPLEMENTED YET HACK:" << std::endl;
+          }
+        atlasToSubjectRegistrationHelper->SetCurrentGenericTransform(m_TemplateGenericTransform);
+        if( this->m_DebugLevel > 9 )
+          {
+          static unsigned int atlasToSubjectCounter = 0;
+          std::stringstream   ss;
+          ss << std::setw(3) << std::setfill('0') << atlasToSubjectCounter;
+          atlasToSubjectRegistrationHelper->PrintCommandLine(true, std::string("AtlasToSubjectUpdate") + ss.str() );
+          muLogMacro( << __FILE__ << " " << __LINE__ << " "  <<   std::endl );
+          atlasToSubjectCounter++;
+          }
+        atlasToSubjectRegistrationHelper->Update();
+        unsigned int actualIterations = atlasToSubjectRegistrationHelper->GetActualNumberOfIterations();
+        muLogMacro( << "Registration tool " << actualIterations << " iterations." << std::endl );
+        m_TemplateGenericTransform = atlasToSubjectRegistrationHelper->GetCurrentGenericTransform();
         }
-      else
-        {
-        atlasToSubjectRegistrationHelper->SetMovingVolume(m_OriginalAtlasImages[vIndex]);
-        preprocessMovingString = "";
-        }
-      {
-      typedef itk::BRAINSROIAutoImageFilter<InputImageType, itk::Image<unsigned char, 3> > ROIAutoType;
-      typename ROIAutoType::Pointer  ROIFilter = ROIAutoType::New();
-      ROIFilter->SetInput(m_OriginalAtlasImages[vIndex]);
-      ROIFilter->SetDilateSize(10);
-      ROIFilter->Update();
-      atlasToSubjectRegistrationHelper->SetMovingBinaryVolume(ROIFilter->GetSpatialObjectROI() );
       }
-      {
-      typedef itk::BRAINSROIAutoImageFilter<InputImageType, itk::Image<unsigned char, 3> > ROIAutoType;
-      typename ROIAutoType::Pointer  ROIFilter = ROIAutoType::New();
-      ROIFilter->SetInput(m_CorrectedImages[vIndex]);
-      ROIFilter->SetDilateSize(10);
-      ROIFilter->Update();
-      atlasToSubjectRegistrationHelper->SetFixedBinaryVolume(ROIFilter->GetSpatialObjectROI() );
-      }
-      // KENT TODO:  Need to expose the transform type to the command line
-      // --AtlasTransformType [Rigid|Affine|BSpline|SyN], defaults to SyN.
-      if( m_AtlasTransformType == "Rigid" )
-        {
-        muLogMacro(<< "Registering (Rigid) " << preprocessMovingString << "atlas("
-                   << vIndex << ") to template(" << vIndex
-                   << ") image." << std::endl);
-        std::vector<double> minimumStepSize(1);
-        minimumStepSize[0] = 0.005; // NOTE: 0.005 for between subject
-        // registration is probably about the
-        // limit.
-        atlasToSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
-        std::vector<std::string> transformType(1);
-        transformType[0] = "Rigid";
-        atlasToSubjectRegistrationHelper->SetTransformType(transformType);
-        }
-      else if( m_AtlasTransformType == "Affine" )
-        {
-        muLogMacro(
-          << "Registering (Affine) " << preprocessMovingString << "atlas(" << vIndex << ") to template(" << vIndex
-          << ") image." << std::endl);
-        std::vector<double> minimumStepSize(1);
-        minimumStepSize[0] = 0.0025;
-        atlasToSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
-        std::vector<std::string> transformType(1);
-        transformType[0] = "Affine";
-        atlasToSubjectRegistrationHelper->SetTransformType(transformType);
-        }
-      else if( m_AtlasTransformType == "BSpline" )
-        {
-        muLogMacro(<< "Registering (BSpline) " << preprocessMovingString << "atlas("
-                   << vIndex << ") to template(" << vIndex
-                   << ") image." << std::endl);
-        std::vector<double> minimumStepSize(1);
-        minimumStepSize[0] = 0.0025;
-        atlasToSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);
-        std::vector<std::string> transformType(1);
-        transformType[0] = "BSpline";
-        atlasToSubjectRegistrationHelper->SetTransformType(transformType);
-        std::vector<int> splineGridSize(3);
-        splineGridSize[0] = m_WarpGrid[0];
-        splineGridSize[1] = m_WarpGrid[1];
-        splineGridSize[2] = m_WarpGrid[2];
-        atlasToSubjectRegistrationHelper->SetSplineGridSize(splineGridSize);
-        // Setting max displace
-        atlasToSubjectRegistrationHelper->SetMaxBSplineDisplacement(6.0);
-        }
-      else if( m_AtlasTransformType == "SyN" )
-        {
-        std::cerr << "ERROR:  NOT PROPERLY IMPLEMENTED YET HACK:" << std::endl;
-        }
-      atlasToSubjectRegistrationHelper->SetCurrentGenericTransform(m_TemplateGenericTransform);
-      if( this->m_DebugLevel > 9 )
-        {
-        static unsigned int atlasToSubjectCounter = 0;
-        std::stringstream   ss;
-        ss << std::setw(3) << std::setfill('0') << atlasToSubjectCounter;
-        atlasToSubjectRegistrationHelper->PrintCommandLine(true, std::string("AtlasToSubjectUpdate") + ss.str() );
-        muLogMacro( << __FILE__ << " " << __LINE__ << " "  <<   std::endl );
-        atlasToSubjectCounter++;
-        }
-      atlasToSubjectRegistrationHelper->Update();
-      unsigned int actualIterations = atlasToSubjectRegistrationHelper->GetActualNumberOfIterations();
-      muLogMacro( << "Registration tool " << actualIterations << " iterations." << std::endl );
-      m_TemplateGenericTransform = atlasToSubjectRegistrationHelper->GetCurrentGenericTransform();
-      }
-    }
     }
 }
 
@@ -1501,30 +1619,42 @@ void
 EMSegmentationFilter<TInputImage, TProbabilityImage>
 ::WritePartitionTable(const unsigned int CurrentEMIteration) const
 {
-  const unsigned int numChannels = this->m_CorrectedImages.size();
   const unsigned int numPriors = this->m_WarpedPriors.size();
 
   muLogMacro(<< "\n\nEM iteration " << CurrentEMIteration <<  std::endl);
   muLogMacro(<< "---------------------" << std::endl);
   PrettyPrintTable EMIterationTable;
-  for( unsigned int ichan = 0; ichan < numChannels; ichan++ )
-    {
-    EMIterationTable.add(0, ichan + 2, this->m_InputVolumeTypes[ichan]);
-    }
+  {
+  unsigned int ichan = 0;
+  for(typename MapOfInputImageVectors::const_iterator mapIt = this->m_InputImages.begin();
+      mapIt != this->m_InputImages.end(); ++mapIt)
+    for(typename InputImageVector::const_iterator imIt = mapIt->second.begin();
+        imIt != mapIt->second.end(); ++imIt,++ichan)
+      {
+      EMIterationTable.add(0, ichan + 2, mapIt->first);
+      }
+  }
   for( unsigned int iclass = 0; iclass < numPriors; iclass++ )
     {
+    unsigned int ichan = 0;
     EMIterationTable.add(iclass + 1, 0, std::string("Class ") + this->m_PriorNames[iclass] + " mean ");
     EMIterationTable.add(iclass + 1, 1, std::string(": ") );
-    for( unsigned int ichan = 0; ichan < numChannels; ichan++ )
+    for(typename RegionStats::MapOfVectors::const_iterator classIt =
+          this->m_ListOfClassStatistics[iclass].m_Means.begin();
+        classIt != this->m_ListOfClassStatistics[iclass].m_Means.end();
+        ++classIt)
       {
-      EMIterationTable.add(iclass + 1, ichan + 2, this->m_ListOfClassStatistics[iclass].m_Means[ichan]);
+      for(typename RegionStats::VectorType::const_iterator chanIt =
+            classIt->second.begin(); chanIt != classIt->second.end(); ++chanIt,++ichan)
+        {
+        EMIterationTable.add(iclass + 1, ichan + 2, (*chanIt));
+        }
       }
     }
-  {
+
   std::ostringstream oss;
   EMIterationTable.Print(oss);
   muLogMacro( << oss.str() );
-  }
 }
 
 template <class TInputImage, class TProbabilityImage>
@@ -1590,24 +1720,23 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
     itkExceptionMacro( << "ERROR:  Must suppply an intial transformation!" );
     }
 
-  this->m_NonAirRegion = ComputeTissueRegion<TInputImage, ByteImageType>(this->m_InputImages[0], 3);
+  this->m_NonAirRegion = ComputeTissueRegion<TInputImage, ByteImageType>(this->GetFirstInputImage(), 3);
   if( this->m_DebugLevel > 9 )
     {
     this->WriteDebugHeadRegion(0);
     }
 
   this->m_WarpedPriors =
-    WarpImageList<TProbabilityImage>(this->m_OriginalSpacePriors, this->m_InputImages[0],
-                                     this->m_PriorsBackgroundValues,
-                                     this->m_TemplateGenericTransform);
+    WarpImageList(this->m_OriginalSpacePriors, this->GetFirstInputImage(),
+                  this->m_PriorsBackgroundValues,
+                  this->m_TemplateGenericTransform);
   if( this->m_DebugLevel > 9 )
     {
     this->WriteDebugWarpedAtlasPriors(0);
-    std::vector<typename TInputImage::PixelType> backgroundValues(m_OriginalAtlasImages.size() );
-    std::fill(backgroundValues.begin(), backgroundValues.end(), 0);
     this->m_WarpedAtlasImages =
-      WarpImageList<TProbabilityImage>(this->m_OriginalAtlasImages, this->m_InputImages[0], backgroundValues,
-                                       this->m_TemplateGenericTransform);
+      WarpImageList(this->m_OriginalAtlasImages,
+                    this->GetFirstInputImage(),
+                    this->m_TemplateGenericTransform);
     this->WriteDebugWarpedAtlasImages(0);
     }
   typename ByteImageType::Pointer
@@ -1618,8 +1747,11 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
     WriteDebugForegroundMask(currForgroundBrainMask, 0);
     }
 
-  std::vector<ByteImagePointer> SubjectCandidateRegions = this->UpdateIntensityBasedClippingOfPriors(
-    0, this->m_InputImages, this->m_WarpedPriors, currForgroundBrainMask);
+  std::vector<ByteImagePointer> SubjectCandidateRegions =
+    this->UpdateIntensityBasedClippingOfPriors(0,
+                                               this->m_InputImages,
+                                               this->m_WarpedPriors,
+                                               currForgroundBrainMask);
   {
   this->BlendPosteriorsAndPriors(0.0, this->m_WarpedPriors, this->m_WarpedPriors, this->m_WarpedPriors);
   NormalizeProbListInPlace<TProbabilityImage>(this->m_WarpedPriors);
@@ -1659,6 +1791,12 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
     try
       {
       ComputeCovarianceDeterminant( this->m_ListOfClassStatistics[q].m_Covariance );
+      }
+    catch( itk::ExceptionObject &excp)
+      {
+      std::cerr << "Error computing covariance " << std::endl;
+      std::cerr << excp << std::endl;
+      throw;
       }
     catch( ... )
       {
@@ -1718,20 +1856,22 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
     //
     // m_TemplateGenericTransform.
     this->m_WarpedPriors =
-      WarpImageList<TProbabilityImage>(this->m_OriginalSpacePriors, this->m_InputImages[0],
-                                       this->m_PriorsBackgroundValues,
-                                       this->m_TemplateGenericTransform);
+      WarpImageList(this->m_OriginalSpacePriors,
+                    this->GetFirstInputImage(),
+                    this->m_PriorsBackgroundValues,
+                    this->m_TemplateGenericTransform);
     if( this->m_DebugLevel > 9 )
       {
       this->WriteDebugWarpedAtlasPriors(CurrentEMIteration);
-      std::vector<typename TInputImage::PixelType> backgroundValues(m_OriginalAtlasImages.size() );
-      std::fill(backgroundValues.begin(), backgroundValues.end(), 0);
       this->m_WarpedAtlasImages =
-        WarpImageList<TProbabilityImage>(this->m_OriginalAtlasImages, this->m_InputImages[0], backgroundValues,
-                                         this->m_TemplateGenericTransform);
+        WarpImageList(this->m_OriginalAtlasImages,
+                      this->GetFirstInputImage(),
+                      this->m_TemplateGenericTransform);
       this->WriteDebugWarpedAtlasImages(CurrentEMIteration);
       }
-    SubjectCandidateRegions = this->ForceToOne(CurrentEMIteration, this->m_CorrectedImages, this->m_WarpedPriors,
+    SubjectCandidateRegions = this->ForceToOne(CurrentEMIteration,
+                                               // this->m_CorrectedImages,
+                                               this->m_WarpedPriors,
                                                this->m_CleanedLabels);
     {
     this->BlendPosteriorsAndPriors(1.0 - priorWeighting, this->m_Posteriors, this->m_WarpedPriors,
@@ -1829,4 +1969,75 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
   this->WritePartitionTable(0 + 100);
 }
 
+template <class TInputImage, class TProbabilityImage>
+typename EMSegmentationFilter<TInputImage, TProbabilityImage>::MapOfInputImageVectors
+EMSegmentationFilter<TInputImage, TProbabilityImage>
+::CorrectBias(const unsigned int degree,
+              const unsigned int CurrentEMIteration,
+              const ByteImageVectorType & CandidateRegions,
+              MapOfInputImageVectors & inputImages,
+              const ByteImageType::Pointer currentBrainMask,
+              const ByteImageType::Pointer currentForegroundMask,
+              const ProbabilityImageVectorType & probImages,
+              const BoolVectorType & probUseForBias,
+              const FloatingPrecision sampleSpacing,
+              const int DebugLevel,
+              const std::string& OutputDebugDir)
+{
+
+  if( degree == 0 )
+    {
+    muLogMacro(<< "Skipping Bias correction, polynomial degree = " << degree <<  std::endl);
+    return inputImages;
+    }
+  muLogMacro(<< "Bias correction, polynomial degree = " << degree <<  std::endl);
+
+  // Perform bias correction
+  const unsigned int                   numClasses = probImages.size();
+  std::vector<FloatImageType::Pointer> biasPosteriors;
+  std::vector<ByteImageType::Pointer>  biasCandidateRegions;
+
+  for( unsigned int iclass = 0; iclass < numClasses; iclass++ )
+    {
+    const unsigned iprior = iclass;
+    if( probUseForBias[iprior] == 1 )
+      {
+      // Focus only on FG classes, more accurate if bg classification is bad
+      // but sacrifices accuracy in border regions (tend to overcorrect)
+      biasPosteriors.push_back(probImages[iclass]);
+      biasCandidateRegions.push_back(CandidateRegions[iclass]);
+      }
+    }
+
+  itk::TimeProbe BiasCorrectorTimer;
+  BiasCorrectorTimer.Start();
+  typedef LLSBiasCorrector<CorrectIntensityImageType, FloatImageType> BiasCorrectorType;
+  typedef BiasCorrectorType::Pointer                                  BiasCorrectorPointer;
+
+  BiasCorrectorPointer biascorr = BiasCorrectorType::New();
+  biascorr->SetMaxDegree(degree);
+  // biascorr->SetMaximumBiasMagnitude(5.0);
+  // biascorr->SetSampleSpacing(2.0*SampleSpacing);
+  biascorr->SetSampleSpacing(1);
+  biascorr->SetWorkingSpacing(sampleSpacing);
+  biascorr->SetForegroundBrainMask(currentBrainMask);
+  biascorr->SetAllTissueMask(currentForegroundMask);
+  biascorr->SetProbabilities(biasPosteriors, biasCandidateRegions);
+  biascorr->SetDebugLevel(DebugLevel);
+  biascorr->SetOutputDebugDir(OutputDebugDir);
+
+  if( DebugLevel > 0 )
+    {
+    biascorr->DebugOn();
+    }
+
+  biascorr->SetInputImages(inputImages);
+  MapOfInputImageVectors correctedImages = biascorr->CorrectImages(CurrentEMIteration);
+
+  BiasCorrectorTimer.Stop();
+  itk::RealTimeClock::TimeStampType elapsedTime = BiasCorrectorTimer.GetTotal();
+  muLogMacro(<< "Computing BiasCorrection took " << elapsedTime << " " << BiasCorrectorTimer.GetUnit() << std::endl);
+
+  return correctedImages;
+}
 #endif

--- a/BRAINSABC/brainseg/EMSegmentationFilter_float+float.cxx
+++ b/BRAINSABC/brainseg/EMSegmentationFilter_float+float.cxx
@@ -1,4 +1,4 @@
-#include "EMSegmentationFilter.hxx"
+#include "EMSegmentationFilter.h"
 
 #include "itkImage.h"
 

--- a/BRAINSABC/brainseg/LLSBiasCorrector.h
+++ b/BRAINSABC/brainseg/LLSBiasCorrector.h
@@ -32,6 +32,8 @@
 #include "vnl/algo/vnl_svd.h"
 
 #include <vector>
+#include <list>
+#include <map>
 /** \class LLSBiasCorrector
  */
 template <class TInputImage, class TProbabilityImage>
@@ -59,6 +61,10 @@ public:
   typedef typename TInputImage::RegionType  InputImageRegionType;
   typedef typename TInputImage::SizeType    InputImageSizeType;
   typedef typename TInputImage::SpacingType InputImageSpacingType;
+
+  typedef std::vector<InputImagePointer> InputImageVector;
+  typedef std::map<std::string,InputImageVector> MapOfInputImageVectors;
+
 
   typedef itk::Image<unsigned char, itkGetStaticConstMacro(ImageDimension)> ByteImageType;
   typedef typename ByteImageType::Pointer                                   ByteImagePointer;
@@ -117,7 +123,7 @@ public:
 
   void SetForegroundBrainMask(ByteImageType *mask);
 
-  void SetInputImages(const std::vector<InputImagePointer> & inputs)
+  void SetInputImages(MapOfInputImageVectors inputs)
   {
     this->m_InputImages = inputs;
     this->Modified();
@@ -138,7 +144,7 @@ public:
   // Correct input images and write it to the designated output
   // fullRes flag selects whether to correct whole image or just grid points
   // defined by WorkingSpacing
-  std::vector<InputImagePointer> CorrectImages(const unsigned int CurrentIterationID);
+  MapOfInputImageVectors CorrectImages(const unsigned int CurrentIterationID);
 
 protected:
 
@@ -150,8 +156,11 @@ protected:
   void ComputeDistributions();
 
 private:
-
-  std::vector<InputImagePointer>         m_InputImages;
+  InputImagePointer GetFirstInputImage()
+    {
+      return *(this->m_InputImages.begin()->second.begin());
+    }
+  MapOfInputImageVectors                   m_InputImages;
   std::vector<ProbabilityImageIndexType> m_ValidIndicies;
   ByteImagePointer                       m_ForegroundBrainMask;
   ByteImagePointer                       m_AllTissueMask;


### PR DESCRIPTION
In order to re-do the algorithm to use covariance between
image types, first we need to change the datastructure for
input images & derivatives from a simple vector to a collection
of vectors organized by type.

This is in preparation for re-writing ComputeDistributions.h such
that the covariance is computed between types of images instead of
between individual images. This will, it is hoped, remove the
error condition when for example 2 T1 images are given as input
that have very small differences.
