### PR TITLE
WIP: convert double precision type transform to single type

### DIFF
--- a/BRAINSTransformConvert/BRAINSTransformConvert.xml
+++ b/BRAINSTransformConvert/BRAINSTransformConvert.xml
@@ -38,6 +38,7 @@
       <element>ScaleSkewVersor</element>
       <element>DisplacementField</element>
       <element>Same</element>
+      <element>Float</element>
     </string-enumeration>
 
     <image>


### PR DESCRIPTION
I enhanced BRAINSTransformConvert tool, so it can convert a double precision transform to another transform with the same type but in single precision.
To do this task, option "Float" is added to "outputTransformType" Flag.

All the BRAINSTool tests are passed successfully after above changes.
