### PR TITLE
WIP: input/output precision type is added to BRAINSTransformConvert

### DIFF
--- a/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
+++ b/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
@@ -354,7 +354,7 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
         this->m_IntraSubjectTransforms[mapIt->first].push_back(p);
         // Write out intermodal matricies
         muLogMacro(<< "Writing " << (*isNamesIt) << "." << std::endl);
-        WriteTransformToDisk(p, (*isNamesIt));
+        itk::WriteTransformToDisk<double>(p, (*isNamesIt));
         }
       }
     }
@@ -620,7 +620,7 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
       }
     // End generating the best initial transform for atlas T1 to subject T1
     muLogMacro(<< "Writing " << this->m_AtlasToSubjectTransformFileName << "." << std::endl);
-    WriteTransformToDisk(m_AtlasToSubjectTransform, this->m_AtlasToSubjectTransformFileName);
+    itk::WriteTransformToDisk<double>(m_AtlasToSubjectTransform, this->m_AtlasToSubjectTransformFileName);
     }
 }
 

--- a/BRAINSABC/brainseg/BRAINSABC.cxx
+++ b/BRAINSABC/brainseg/BRAINSABC.cxx
@@ -1319,7 +1319,7 @@ int main(int argc, char * *argv)
         muLogMacro(<< "Writing final atlas to subject template... " << postSegmentationTransformFileName << std::endl );
         GenericTransformType::Pointer atlasToSubjectPostSegmentationTransform =
           segfilter->GetTemplateGenericTransform();
-        WriteTransformToDisk(atlasToSubjectPostSegmentationTransform, postSegmentationTransformFileName);
+        itk::WriteTransformToDisk<double>(atlasToSubjectPostSegmentationTransform, postSegmentationTransformFileName);
         // TODO:  Need to write a short circuit so that if this final transform
         // filename exists, it will just read it in and use it directly
         // without doing all the iterations.

--- a/BRAINSCommonLib/GenericTransformImage.cxx
+++ b/BRAINSCommonLib/GenericTransformImage.cxx
@@ -143,28 +143,28 @@ int WriteBothTransformsToDisk(const GenericTransformType::ConstPointer genericTr
       {
       if( outputTransform.size() > 0 )  // Write out the transform
         {
-        itk::WriteTransformToDisk(genericTransformToWrite, outputTransform);
+        itk::WriteTransformToDisk<double>(genericTransformToWrite, outputTransform);
         }
       }
     else if( transformFileType == "ScaleVersor3DTransform" )
       {
       if( outputTransform.size() > 0 )  // Write out the transform
         {
-        itk::WriteTransformToDisk(genericTransformToWrite, outputTransform);
+        itk::WriteTransformToDisk<double>(genericTransformToWrite, outputTransform);
         }
       }
     else if( transformFileType == "ScaleSkewVersor3DTransform" )
       {
       if( outputTransform.size() > 0 )  // Write out the transform
         {
-        itk::WriteTransformToDisk(genericTransformToWrite, outputTransform);
+        itk::WriteTransformToDisk<double>(genericTransformToWrite, outputTransform);
         }
       }
     else if( transformFileType == "AffineTransform" )
       {
       if( outputTransform.size() > 0 )  // Write out the transform
         {
-        itk::WriteTransformToDisk(genericTransformToWrite, outputTransform);
+        itk::WriteTransformToDisk<double>(genericTransformToWrite, outputTransform);
         }
       }
     else if( transformFileType == "BSplineDeformableTransform" )
@@ -181,7 +181,7 @@ int WriteBothTransformsToDisk(const GenericTransformType::ConstPointer genericTr
         }
       if( outputTransform.size() > 0 )
         {
-        itk::WriteTransformToDisk(genericTransformToWrite, outputTransform);
+        itk::WriteTransformToDisk<double>(genericTransformToWrite, outputTransform);
         }
       }
     else      //  NO SUCH CASE!!
@@ -200,7 +200,7 @@ int WriteBothTransformsToDisk(const GenericTransformType::ConstPointer genericTr
       VersorRigidTransformType::Pointer versorRigid = itk::ComputeRigidTransformFromGeneric(genericTransformToWrite);
       if( versorRigid.IsNotNull() )
         {
-        itk::WriteTransformToDisk(versorRigid.GetPointer(), strippedOutputTransform);
+        itk::WriteTransformToDisk<double>(versorRigid.GetPointer(), strippedOutputTransform);
         }
       }
     }
@@ -445,29 +445,34 @@ GenericTransformType::Pointer ReadTransformFromDisk(const std::string & initialT
   return genericTransform;
 }
 
-void WriteTransformToDisk(GenericTransformType const *const MyTransform, const std::string & TransformFilename)
+template<class TScalarType>
+void WriteTransformToDisk( itk::Transform<TScalarType, 3, 3> const *const MyTransform, const std::string & TransformFilename )
 {
   /*
     *  Convert the transform to the appropriate assumptions and write it out as
     *requested.
     */
     {
-    typedef itk::TransformFileWriter TransformWriterType;
-    TransformWriterType::Pointer transformWriter =  TransformWriterType::New();
+    typedef itk::TransformFileWriterTemplate<TScalarType> TransformWriterType;
+    typename TransformWriterType::Pointer transformWriter =  TransformWriterType::New();
     transformWriter->SetFileName( TransformFilename.c_str() );
 
     const std::string extension = itksys::SystemTools::GetFilenameLastExtension(TransformFilename);
     std::string       inverseTransformFileName(TransformFilename);
     inverseTransformFileName.replace(inverseTransformFileName.end() - extension.size(),
                                      inverseTransformFileName.end(), "_Inverse.h5");
-    TransformWriterType::Pointer inverseTransformWriter =  TransformWriterType::New();
+    typename TransformWriterType::Pointer inverseTransformWriter =  TransformWriterType::New();
     inverseTransformWriter->SetFileName( inverseTransformFileName.c_str() );
     const std::string transformFileType = MyTransform->GetNameOfClass();
     bool              inverseTransformExists = true;
     if( transformFileType == "BSplineDeformableTransform" )
       {
-      const BSplineTransformType::ConstPointer tempInitializerITKTransform =
-        dynamic_cast<BSplineTransformType const *>( MyTransform );
+      typedef itk::BSplineDeformableTransform< TScalarType,
+                                               GenericTransformImageNS::SpaceDimension,
+                                               GenericTransformImageNS::SplineOrder> BSplineTransformType;
+
+      const typename BSplineTransformType::ConstPointer tempInitializerITKTransform = dynamic_cast<BSplineTransformType const *>( MyTransform );
+
       if( tempInitializerITKTransform.IsNull() )
         {
         itkGenericExceptionMacro(<< "Error in type conversion");
@@ -540,5 +545,8 @@ void WriteTransformToDisk(GenericTransformType const *const MyTransform, const s
       }
     }
 }
+
+template void WriteTransformToDisk<double>( itk::Transform<double, 3, 3> const *const MyTransform, const std::string & TransformFilename );
+template void WriteTransformToDisk<float>( itk::Transform<float, 3, 3> const *const MyTransform, const std::string & TransformFilename );
 
 } // end namespace itk

--- a/BRAINSCommonLib/GenericTransformImage.h
+++ b/BRAINSCommonLib/GenericTransformImage.h
@@ -79,10 +79,11 @@ namespace itk
   *ConstPointer up the class tree, use the GetPointer
   * AffineTransformType::Pointer myAffine=AffineTransformType::New(); //NOTE:
   * This is not a const smart pointer
-  * WriteTransformToDisk(myAffine.GetPointer(), "myAffineFile.mat");
+  * WriteTransformToDisk<TScalarType>(myAffine.GetPointer(), "myAffineFile.mat");
   * \endcode
   */
-extern void WriteTransformToDisk(GenericTransformType const *const genericTransformToWrite,
+template<class TScalarType>
+extern void WriteTransformToDisk( itk::Transform<TScalarType, 3, 3> const *const genericTransformToWrite,
                                  const std::string & outputTransform);
 
 /**
@@ -134,7 +135,7 @@ extern GenericTransformType::Pointer ReadTransformFromDisk(const std::string & i
   *ConstPointer up the class tree, use the GetPointer
   * AffineTransformType::Pointer myAffine=AffineTransformType::New(); //NOTE:
   * This is not a const smart pointer
-  * WriteTransformToDisk(myAffine.GetPointer(), "myAffineFile.mat");
+  * WriteTransformToDisk<TScalarType>(myAffine.GetPointer(), "myAffineFile.mat");
   * \endcode
   */
 extern VersorRigid3DTransformType::Pointer ComputeRigidTransformFromGeneric(

--- a/BRAINSConstellationDetector/src/BRAINSTransformFromFiducials.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSTransformFromFiducials.cxx
@@ -263,7 +263,7 @@ int main(int argc, char* argv[])
     return EXIT_FAILURE;
     }
 
-  WriteTransformToDisk(genericTransform.GetPointer(), saveTransform);
+  itk::WriteTransformToDisk<double>(genericTransform.GetPointer(), saveTransform);
 
   return EXIT_SUCCESS;
 }

--- a/BRAINSConstellationDetector/src/landmarksConstellationCommon.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationCommon.cxx
@@ -793,9 +793,10 @@ SImageType::Pointer MakeIsoTropicReferenceImage(void)
   return isotropicReferenceVolume;
 }
 
-void WriteTransformToDisk( GenericTransformType * myTransform , const std::string & filename  )
+template<class TScalarType>
+void WriteTransformToDisk( itk::Transform<TScalarType, 3, 3> * myTransform , const std::string & filename  )
 {
-  itk::TransformFileWriter::Pointer writer = itk::TransformFileWriter::New();
+  typename itk::TransformFileWriterTemplate<TScalarType>::Pointer writer = itk::TransformFileWriterTemplate<TScalarType>::New();
   writer->SetInput( myTransform );
   writer->SetFileName( filename );
   try
@@ -809,3 +810,5 @@ void WriteTransformToDisk( GenericTransformType * myTransform , const std::strin
     }
   std::cout << "The output rigid transform file is written." << std::endl;
 }
+
+template void WriteTransformToDisk<double>( itk::Transform<double, 3, 3> * myTransform , const std::string & filename );

--- a/BRAINSConstellationDetector/src/landmarksConstellationCommon.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationCommon.h
@@ -643,6 +643,6 @@ paired_samples_t(DType *x1, DType *x2, int n, int *df, double *meandiff)
 }
 #endif
 
-
-extern void WriteTransformToDisk( GenericTransformType * myTransform , const std::string & filename  );
+template<class TScalarType>
+extern void WriteTransformToDisk( itk::Transform<TScalarType, 3, 3> * myTransform , const std::string & filename  );
 #endif

--- a/BRAINSCut/BRAINSCutGenerateRegistrations.cxx
+++ b/BRAINSCut/BRAINSCutGenerateRegistrations.cxx
@@ -287,7 +287,7 @@ BRAINSCutGenerateRegistrations
               << " :: " << OutputRegName
               << std::endl;
     }
-  WriteTransformToDisk( BSplineRegistrationHelper->GetCurrentGenericTransform(),
+  itk::WriteTransformToDisk<double>( BSplineRegistrationHelper->GetCurrentGenericTransform(),
                         OutputRegName );
   // Write out Transformed Output As Well
   // - EX. from GenericTransformImage.hxx

--- a/BRAINSLandmarkInitializer/BRAINSLandmarkInitializer.cxx
+++ b/BRAINSLandmarkInitializer/BRAINSLandmarkInitializer.cxx
@@ -135,7 +135,7 @@ main(int argc, char *argv[])
   landmarkBasedInitializer->SetTransform( affineTransform );
   landmarkBasedInitializer->InitializeTransform();
 
-  WriteTransformToDisk( affineTransform, outputTransformFilename);
+  itk::WriteTransformToDisk<double>( affineTransform, outputTransformFilename);
 
   return EXIT_SUCCESS;
 }

--- a/BRAINSTransformConvert/BRAINSTransformConvert.cxx
+++ b/BRAINSTransformConvert/BRAINSTransformConvert.cxx
@@ -19,83 +19,315 @@
 // BSpline 5
 // BSplineROI 5
 
+template<class TInputScalarType, class TOutputScalarType>
 inline
 bool
-IsSameClass(const GenericTransformType *result,
-            const GenericTransformType *source)
+IsSameClass(const itk::Transform< TOutputScalarType, 3, 3 > *result,
+            const itk::Transform< TInputScalarType, 3, 3 > *source)
 {
   return strcmp(result->GetNameOfClass(), source->GetNameOfClass() ) == 0;
 }
 
+template<class TInputScalarType>
 inline
 bool
-IsClass(const GenericTransformType *xfrm, const char *className)
+IsClass(const itk::Transform< TInputScalarType, 3, 3 > *xfrm, const char *className)
 {
   return strcmp(xfrm->GetNameOfClass(), className) == 0;
+}
+
+template<class TInputScalarType>
+void
+TransformConvertError(const itk::Transform< TInputScalarType, 3, 3 > *inputXfrm,
+                      const std::string & targetClassName)
+{
+  std::cerr << "Can't convert transform of type "
+  << inputXfrm->GetTransformTypeAsString()
+  << " to "
+  << targetClassName
+  << std::endl;
+}
+
+//
+// Type Conversions //
+//
+// converts double precision type parameters to single precision type
+template<class TInputScalarType, class TOutputScalarType>
+itk::OptimizerParameters< TOutputScalarType >
+ParametersTypeConvertor(const itk::OptimizerParameters< TInputScalarType >  &sourceParams)
+{
+  itk::OptimizerParameters< TOutputScalarType > outputParams;
+  outputParams.SetSize( sourceParams.GetSize() );
+  outputParams.Fill(0);
+  for( itk::SizeValueType i = 0; i < sourceParams.GetSize(); ++i )
+    {
+    outputParams[i] = (TOutputScalarType)( sourceParams[i] );
+    }
+  return outputParams;
+}
+
+// two specializations when both in/output types are the same. No casting needed.
+template<>
+itk::OptimizerParameters<double>
+ParametersTypeConvertor<double, double>(const itk::OptimizerParameters<double> &sourceParams)
+{
+  return sourceParams;
+}
+
+template<>
+itk::OptimizerParameters<float>
+ParametersTypeConvertor<float, float>(const itk::OptimizerParameters<float> &sourceParams)
+{
+  return sourceParams;
+}
+
+// converts double precision type points to single precision type
+template<class TInputScalarType, class TOutputScalarType>
+itk::Point<TOutputScalarType, 3>
+PointTypeConvertor(const itk::Point<TInputScalarType, 3> &sourcePoint)
+{
+  itk::Point<TOutputScalarType, 3> outputPoint;
+  outputPoint[0] = (TOutputScalarType)( sourcePoint[0] );
+  outputPoint[1] = (TOutputScalarType)( sourcePoint[1] );
+  outputPoint[2] = (TOutputScalarType)( sourcePoint[2] );
+  return outputPoint;
+}
+
+template<>
+itk::Point<double, 3>
+PointTypeConvertor<double, double>(const itk::Point<double, 3> &sourcePoint)
+{
+  return sourcePoint;
+}
+
+template<>
+itk::Point<float, 3>
+PointTypeConvertor<float, float>(const itk::Point<float, 3> &sourcePoint)
+{
+  return sourcePoint;
+}
+
+// converts double precision type vectors to single precision type
+template<class TInputScalarType, class TOutputScalarType>
+itk::Vector<TOutputScalarType, 3>
+VectorTypeConvertor(const itk::Vector<TInputScalarType, 3> &sourceVector)
+{
+  itk::Vector<TOutputScalarType, 3> OutputVector;
+  OutputVector[0] = (TOutputScalarType)( sourceVector[0] );
+  OutputVector[1] = (TOutputScalarType)( sourceVector[1] );
+  OutputVector[2] = (TOutputScalarType)( sourceVector[2] );
+  return OutputVector;
+}
+
+template<>
+itk::Vector<double, 3>
+VectorTypeConvertor<double, double>(const itk::Vector<double, 3> &sourceVector)
+{
+  return sourceVector;
+}
+
+template<>
+itk::Vector<float, 3>
+VectorTypeConvertor<float, float>(const itk::Vector<float, 3> &sourceVector)
+{
+  return sourceVector;
+}
+
+// converts double precision type versors to single precision type
+template<class TInputScalarType, class TOutputScalarType>
+itk::Versor<TOutputScalarType>
+VersorTypeConvertor(const itk::Versor<TInputScalarType> &sourceVersor)
+{
+  itk::Versor<TOutputScalarType> OutputVersor;
+  TOutputScalarType x_value, y_value, z_value, w_value;
+  x_value = (TOutputScalarType)( sourceVersor.GetX() );
+  y_value = (TOutputScalarType)( sourceVersor.GetY() );
+  z_value = (TOutputScalarType)( sourceVersor.GetZ() );
+  w_value = (TOutputScalarType)( sourceVersor.GetW() );
+  OutputVersor.Set(x_value, y_value, z_value, w_value);
+  return OutputVersor;
+}
+
+template<>
+itk::Versor<double>
+VersorTypeConvertor<double, double>(const itk::Versor<double> &sourceVersor)
+{
+  return sourceVersor;
+}
+
+template<>
+itk::Versor<float>
+VersorTypeConvertor<float, float>(const itk::Versor<float> &sourceVersor)
+{
+  return sourceVersor;
+}
+
+// converts double precision type matrices to single precision type
+template<class TInputScalarType, class TOutputScalarType>
+itk::Matrix<TOutputScalarType, 3, 3>
+MatrixTypeConvertor(const itk::Matrix<TInputScalarType, 3, 3> &sourceMatix)
+{
+  itk::Matrix<TOutputScalarType, 3, 3> outputMatrix;
+  for( itk::SizeValueType i=0; i<3; ++i )
+    {
+    for( itk::SizeValueType j=0; j<3; ++j )
+      {
+      outputMatrix(i,j) = (TOutputScalarType)( sourceMatix(i,j) );
+      }
+    }
+  return outputMatrix;
+}
+
+template<>
+itk::Matrix<double, 3, 3>
+MatrixTypeConvertor<double, double>(const itk::Matrix<double, 3, 3> &sourceMatix)
+{
+  return sourceMatix;
+}
+
+template<>
+itk::Matrix<float, 3, 3>
+MatrixTypeConvertor<float, float>(const itk::Matrix<float, 3, 3> &sourceMatix)
+{
+  return sourceMatix;
+}
+
+// conversion between the precision type for two transforms that are in the same class.
+template<class TInputScalarType, class TOutputScalarType>
+bool
+PrecisionConvertor( typename itk::Transform< TOutputScalarType, 3, 3 >::Pointer &outXfrm,
+                   const itk::Transform< TInputScalarType, 3, 3 > *source )
+{
+  if( IsClass(source, "TranslationTransform") )
+    {
+    typedef itk::TranslationTransform<TOutputScalarType, 3> TransTransformType;
+    typename TransTransformType::Pointer transXfrm = TransTransformType::New();
+    outXfrm = transXfrm.GetPointer();
+    }
+  else if( IsClass(source, "AffineTransform") )
+    {
+    typedef itk::AffineTransform<TOutputScalarType, 3>  AffineTransformType;
+    typename AffineTransformType::Pointer affineXfrm = AffineTransformType::New();
+    outXfrm = affineXfrm.GetPointer();
+    }
+  else if( IsClass(source, "VersorTransform") )
+    {
+    typedef itk::VersorTransform<TOutputScalarType> VersorTransformType;
+    typename VersorTransformType::Pointer versorXfrm = VersorTransformType::New();
+    outXfrm = versorXfrm.GetPointer();
+    }
+  else if( IsClass(source, "VersorRigid3DTransform") )
+    {
+    typedef itk::VersorRigid3DTransform<TOutputScalarType>  VersorRigid3DTransformType;
+    typename VersorRigid3DTransformType::Pointer versorRigid3DXfrm = VersorRigid3DTransformType::New();
+    outXfrm = versorRigid3DXfrm.GetPointer();
+    }
+  else if( IsClass(source, "ScaleVersor3DTransform") )
+    {
+    typedef itk::ScaleVersor3DTransform<TOutputScalarType>  ScaleVersor3DTransformType;
+    typename ScaleVersor3DTransformType::Pointer scaleVersor3DXfrm = ScaleVersor3DTransformType::New();
+    outXfrm = scaleVersor3DXfrm.GetPointer();
+    }
+  else if( IsClass(source, "ScaleSkewVersor3DTransform") )
+    {
+    typedef itk::ScaleSkewVersor3DTransform<TOutputScalarType> ScaleVersor3DTransformType;
+    typename ScaleVersor3DTransformType::Pointer scaleSkewVersor3DXfrm = ScaleVersor3DTransformType::New();
+    outXfrm = scaleSkewVersor3DXfrm.GetPointer();
+    }
+  else
+    {
+    TransformConvertError<TInputScalarType>( source, "Different Precision Type");
+    return false;
+    }
+  outXfrm->SetParameters( ParametersTypeConvertor<TInputScalarType, TOutputScalarType>( source->GetParameters() ) );
+  outXfrm->SetFixedParameters( ParametersTypeConvertor<TInputScalarType, TOutputScalarType>( source->GetFixedParameters() ) );
+  return true;
 }
 
 //
 // Convert from any type derived from MatrixOffsetTransformType to
 // AffineTransform.
+template<class TInputScalarType, class TOutputScalarType>
 bool
-ExtractTransform(AffineTransformType::Pointer & result,
-                 const GenericTransformType *source)
+ExtractTransform(typename itk::AffineTransform< TOutputScalarType, 3 >::Pointer &result,
+                 const itk::Transform< TInputScalarType, 3, 3 > *source)
 {
   result->SetIdentity();
   // always able to convert to same type
+  typedef itk::Transform< TOutputScalarType, 3, 3 > OutputGenericTransformType;
+  typename OutputGenericTransformType::Pointer resultXfrm = dynamic_cast<OutputGenericTransformType *>( result.GetPointer() );
   if( IsSameClass(result.GetPointer(), source) )
     {
-    result->SetParameters( source->GetParameters() );
-    result->SetFixedParameters( source->GetFixedParameters() );
-    return true;
+     if( PrecisionConvertor<TInputScalarType, TOutputScalarType>(resultXfrm, source) )
+       {
+       result = dynamic_cast<typename itk::AffineTransform< TOutputScalarType, 3 > *>(resultXfrm.GetPointer());
+       return true;
+       }
+     else
+       {
+       std::cerr << "Can't convert the precision type of the input transform to the output precision type." << std::endl;
+       return false;
+       }
     }
 
-  typedef AffineTransformType::Superclass MatrixOffsetTransformType;
-  const MatrixOffsetTransformType *matBasePtr =
-    dynamic_cast<const MatrixOffsetTransformType *>(source);
+  typedef itk::AffineTransform< TInputScalarType, 3 > InputAffineTransformType;
+  typedef typename InputAffineTransformType::Superclass MatrixOffsetTransformType;
+  const MatrixOffsetTransformType *matBasePtr = dynamic_cast<const MatrixOffsetTransformType *>(source);
   if( matBasePtr == 0 )
     {
     return false;
     }
 
-  result->SetCenter(matBasePtr->GetCenter() );
-  result->SetMatrix(matBasePtr->GetMatrix() );
-  result->SetTranslation(matBasePtr->GetTranslation() );
+  result->SetCenter( PointTypeConvertor<TInputScalarType, TOutputScalarType>( matBasePtr->GetCenter() ) );
+  result->SetMatrix( MatrixTypeConvertor<TInputScalarType, TOutputScalarType>( matBasePtr->GetMatrix() ) );
+  result->SetTranslation( VectorTypeConvertor<TInputScalarType, TOutputScalarType>( matBasePtr->GetTranslation() ) );
   return true;
 }
 
 //
 // versor rigid 3d case.
+template<class TInputScalarType, class TOutputScalarType>
 bool
-ExtractTransform(VersorRigid3DTransformType::Pointer & result,
-                 const GenericTransformType *source)
+ExtractTransform(typename itk::VersorRigid3DTransform<TOutputScalarType>::Pointer & result,
+                 const itk::Transform< TInputScalarType, 3, 3 > *source)
 {
   result->SetIdentity();
   // always able to convert to same type
+  typedef itk::Transform< TOutputScalarType, 3, 3 > OutputGenericTransformType;
+  typename OutputGenericTransformType::Pointer resultXfrm = dynamic_cast<OutputGenericTransformType *>( result.GetPointer() );
   if( IsSameClass(result.GetPointer(), source) )
     {
-    result->SetParameters( source->GetParameters() );
-    result->SetFixedParameters( source->GetFixedParameters() );
-    return true;
+    if( PrecisionConvertor<TInputScalarType, TOutputScalarType>(resultXfrm, source) )
+      {
+      result = dynamic_cast<typename itk::VersorRigid3DTransform< TOutputScalarType > *>(resultXfrm.GetPointer());
+      return true;
+      }
+    else
+      {
+      std::cerr << "Can't convert the precision type of the input transform to the output precision type." << std::endl;
+      return false;
+      }
     }
+
   // this looks like it should be a convertible transform but
   // I'm not sure.
-  typedef itk::TranslationTransform<double, 3> TransTransformType;
+  typedef itk::TranslationTransform<TInputScalarType, 3> TransTransformType;
   if( IsClass(source, "TranslationTransform") )
     {
-    const TransTransformType *translationXfrm =
-      dynamic_cast<const TransTransformType *>(source);
-    TransTransformType::OutputVectorType offset = translationXfrm->GetOffset();
-    result->SetOffset(offset);
+    const TransTransformType *translationXfrm = dynamic_cast<const TransTransformType *>(source);
+    typename TransTransformType::OutputVectorType offset = translationXfrm->GetOffset();
+
+    result->SetOffset( VectorTypeConvertor<TInputScalarType, TOutputScalarType>(offset) );
     return true;
     }
   // versor == rotation only
   if( IsClass(source, "VersorTransform") )
     {
-    typedef itk::VersorTransform<double> VersorTransformType;
+    typedef itk::VersorTransform<TInputScalarType> VersorTransformType;
     const VersorTransformType *versorXfrm = dynamic_cast<const VersorTransformType *>(source);
-    result->SetRotation(versorXfrm->GetVersor() );
-    result->SetCenter(versorXfrm->GetCenter() );
+
+    result->SetRotation( VersorTypeConvertor<TInputScalarType, TOutputScalarType>( versorXfrm->GetVersor() ) );
+    result->SetCenter( PointTypeConvertor<TInputScalarType, TOutputScalarType>( versorXfrm->GetCenter() ) );
     return true;
     }
   return false;
@@ -103,114 +335,115 @@ ExtractTransform(VersorRigid3DTransformType::Pointer & result,
 
 //
 // scale versor case
+template<class TInputScalarType, class TOutputScalarType>
 bool
-ExtractTransform(ScaleVersor3DTransformType::Pointer & result,
-                 const GenericTransformType *source)
+ExtractTransform(typename itk::ScaleVersor3DTransform<TOutputScalarType>::Pointer & result,
+                 const itk::Transform< TInputScalarType, 3, 3 > *source)
 {
   result->SetIdentity();
   // always able to convert to same type
+  typedef itk::Transform< TInputScalarType, 3, 3 >  InputGenericTransformType;
+  typedef itk::Transform< TOutputScalarType, 3, 3 > OutputGenericTransformType;
+  typename OutputGenericTransformType::Pointer resultXfrm = dynamic_cast<OutputGenericTransformType *>( result.GetPointer() );
   if( IsSameClass(result.GetPointer(), source) )
     {
-    result->SetParameters( source->GetParameters() );
-    result->SetFixedParameters( source->GetFixedParameters() );
-    return true;
+    if( PrecisionConvertor<TInputScalarType, TOutputScalarType>(resultXfrm, source) )
+      {
+      result = dynamic_cast<typename itk::ScaleVersor3DTransform<TOutputScalarType> *>(resultXfrm.GetPointer());
+      return true;
+      }
+    else
+      {
+      std::cerr << "Can't convert the precision type of the input transform to the output precision type." << std::endl;
+      return false;
+      }
     }
+
+  typedef itk::VersorRigid3DTransform<TInputScalarType>  InputVersorRigid3DTransformType;
+  typedef itk::VersorRigid3DTransform<TOutputScalarType> OutputVersorRigid3DTransformType;
   if( IsClass(source, "VersorRigid3DTransform") )
     {
-    const VersorRigid3DTransformType *versorRigidXfrm =
-      dynamic_cast<const VersorRigid3DTransformType *>(source);
-    result->SetRotation(versorRigidXfrm->GetVersor() );
-    result->SetTranslation(versorRigidXfrm->GetTranslation() );
-    result->SetCenter(versorRigidXfrm->GetCenter() );
+    const InputVersorRigid3DTransformType *versorRigidXfrm = dynamic_cast<const InputVersorRigid3DTransformType *>(source);
+
+    result->SetRotation( VersorTypeConvertor<TInputScalarType, TOutputScalarType>( versorRigidXfrm->GetVersor() ) );
+    result->SetTranslation( VectorTypeConvertor<TInputScalarType, TOutputScalarType>( versorRigidXfrm->GetTranslation() ) );
+    result->SetCenter( PointTypeConvertor<TInputScalarType, TOutputScalarType>( versorRigidXfrm->GetCenter() ) );
     return true;
     }
   // otherwise try VersorRigidTransform
-  VersorRigid3DTransformType::Pointer vrx = VersorRigid3DTransformType::New();
-  if( ExtractTransform(vrx, source) ) // of VersorRigid3D conversion
-                                      // works
+  typename OutputVersorRigid3DTransformType::Pointer vrx_out = OutputVersorRigid3DTransformType::New();
+  if( ExtractTransform<TInputScalarType, TOutputScalarType>(vrx_out, source) ) // of VersorRigid3D conversion
+                                                                               // works
     {
-    // recurse to do this conversion
-    return ExtractTransform(result, vrx.GetPointer() );
+    // Now "vrx_out" has the output precision type. It should be converted to input precision type (vrx_in) before
+    // passing that again to "ExtractTransform" function.
+    typename InputVersorRigid3DTransformType::Pointer vrx_in = InputVersorRigid3DTransformType::New();
+    typename InputGenericTransformType::Pointer vrxInXfrm = dynamic_cast<InputGenericTransformType *>( vrx_in.GetPointer() );
+    if( PrecisionConvertor<TOutputScalarType, TInputScalarType>( vrxInXfrm, vrx_out.GetPointer() ) ) // precision type conversion
+      {
+      vrx_in = dynamic_cast< InputVersorRigid3DTransformType *>(vrxInXfrm.GetPointer());
+        // recurse to do this conversion
+      return ExtractTransform<TInputScalarType, TOutputScalarType>( result, vrx_in.GetPointer() );
+      }
     }
   return false;
 }
 
 //
 // scale skew versor case
+template<class TInputScalarType, class TOutputScalarType>
 bool
-ExtractTransform(ScaleSkewVersor3DTransformType::Pointer & result,
-                 const GenericTransformType *source)
+ExtractTransform(typename itk::ScaleSkewVersor3DTransform< TOutputScalarType >::Pointer & result,
+                 const itk::Transform< TInputScalarType, 3, 3 > *source)
 {
   // always able to convert to same type
+  typedef itk::Transform< TInputScalarType, 3, 3 >  InputGenericTransformType;
+  typedef itk::Transform< TOutputScalarType, 3, 3 > OutputGenericTransformType;
+  typename OutputGenericTransformType::Pointer resultXfrm = dynamic_cast<OutputGenericTransformType *>( result.GetPointer() );
   if( IsSameClass(result.GetPointer(), source) )
     {
-    result->SetParameters( source->GetParameters() );
-    result->SetFixedParameters( source->GetFixedParameters() );
-    return true;
+    if( PrecisionConvertor<TInputScalarType, TOutputScalarType>(resultXfrm, source) )
+      {
+      result = dynamic_cast< typename itk::ScaleSkewVersor3DTransform< TOutputScalarType > *>(resultXfrm.GetPointer());
+      return true;
+      }
+    else
+      {
+      std::cerr << "Can't convert the precision type of the input transform to the output precision type." << std::endl;
+      return false;
+      }
     }
+
   // is it the parent?
+  typedef itk::ScaleVersor3DTransform<TInputScalarType>  InputScaleVersor3DTransformType;
+  typedef itk::ScaleVersor3DTransform<TOutputScalarType> OutputScaleVersor3DTransformType;
   if( IsClass(source, "ScaleVersor3DTransform") )
     {
-    const ScaleVersor3DTransformType *scaleVersorXfrm =
-      dynamic_cast<const ScaleVersor3DTransformType *>(source);
-    result->SetRotation(scaleVersorXfrm->GetVersor() );
-    result->SetTranslation(scaleVersorXfrm->GetTranslation() );
-    result->SetCenter(scaleVersorXfrm->GetCenter() );
-    result->SetScale(scaleVersorXfrm->GetScale() );
+    const InputScaleVersor3DTransformType *scaleVersorXfrm = dynamic_cast<const InputScaleVersor3DTransformType *>(source);
+
+    result->SetRotation( VersorTypeConvertor<TInputScalarType, TOutputScalarType>( scaleVersorXfrm->GetVersor() ) );
+    result->SetTranslation( VectorTypeConvertor<TInputScalarType, TOutputScalarType>( scaleVersorXfrm->GetTranslation() ) );
+    result->SetCenter( PointTypeConvertor<TInputScalarType, TOutputScalarType>( scaleVersorXfrm->GetCenter() ) );
+    result->SetScale( VectorTypeConvertor<TInputScalarType, TOutputScalarType>( scaleVersorXfrm->GetScale() ) );
     return true;
     }
   // otherwise try ScaleVersor conversion
-  ScaleVersor3DTransformType::Pointer svx = ScaleVersor3DTransformType::New();
-  if( ExtractTransform(svx, source) ) // of VersorRigid3D conversion
-                                      // works
+  typename OutputScaleVersor3DTransformType::Pointer svx_out = OutputScaleVersor3DTransformType::New();
+  if( ExtractTransform<TInputScalarType, TOutputScalarType>(svx_out, source) ) // of VersorRigid3D conversion
+                                                                               // works
     {
-    // recurse to do this conversion
-    return ExtractTransform(result, svx.GetPointer() );
+    // Now "svx_out" has the output precision type. It should be converted to input precision type (svx_in) before
+    // passing that again to "ExtractTransform" function.
+    typename InputScaleVersor3DTransformType::Pointer svx_in = InputScaleVersor3DTransformType::New();
+    typename InputGenericTransformType::Pointer svxInXfrm = dynamic_cast<InputGenericTransformType *>( svx_in.GetPointer() );
+    if( PrecisionConvertor<TOutputScalarType, TInputScalarType>( svxInXfrm, svx_out.GetPointer() ) )
+      {
+      svx_in = dynamic_cast< InputScaleVersor3DTransformType *>(svxInXfrm.GetPointer());
+      // recurse to do this conversion
+      return ExtractTransform<TInputScalarType, TOutputScalarType>( result, svx_in.GetPointer() );
+      }
     }
   return false;
-}
-
-//
-// scale skew versor case
-bool
-ExtractTransform(BSplineTransformType::Pointer & result,
-                 const GenericTransformType *source)
-{
-  if( IsSameClass(result.GetPointer(), source) )
-    {
-    const BSplineTransformType *sourceBSpline =
-      dynamic_cast<const BSplineTransformType *>(source);
-    result->SetFixedParameters(sourceBSpline->GetFixedParameters() );
-    result->SetIdentity();
-    result->SetParametersByValue(sourceBSpline->GetParameters() );
-    result->SetBulkTransform(sourceBSpline->GetBulkTransform() );
-    return true;
-    }
-  else
-    {
-    result->SetIdentity();
-    }
-  typedef BSplineTransformType::BulkTransformType BulkXfrmType;
-
-  const BulkXfrmType *bulkXfrm =
-    dynamic_cast<const BulkXfrmType *>(source);
-  if( bulkXfrm == 0 )
-    {
-    return false;
-    }
-  result->SetBulkTransform(bulkXfrm);
-  return true;
-}
-
-void
-TransformConvertError(GenericTransformType *inputXfrm,
-                      const std::string & targetClassName)
-{
-  std::cerr << "Can't convert transform of type "
-            << inputXfrm->GetTransformTypeAsString()
-            << " to "
-            << targetClassName
-            << std::endl;
 }
 
 #define CHECK_PARAMETER_IS_SET(parameter, message) \
@@ -220,27 +453,39 @@ TransformConvertError(GenericTransformType *inputXfrm,
     return EXIT_FAILURE;                          \
     }
 
-int main(int argc, char *argv[])
+template<class TInputScalarType, class TOutputScalarType>
+int
+DoConversion( int argc, char *argv[] )
 {
   PARSE_ARGS;
 
-  CHECK_PARAMETER_IS_SET(inputTransform,
-                         "Missing inputTransform parameter");
-  CHECK_PARAMETER_IS_SET(outputTransformType,
-                         "Missing outpuTransformType");
+  typedef itk::Transform< TInputScalarType, 3, 3 >                                   InputGenericTransformType;
+  typedef itk::BSplineDeformableTransform< TInputScalarType,
+                                           GenericTransformImageNS::SpaceDimension,
+                                           GenericTransformImageNS::SplineOrder>     BSplineTransformType;
+
+  typedef itk::Transform< TOutputScalarType, 3, 3 >               OutputGenericTransformType;
+  typedef itk::AffineTransform< TOutputScalarType, 3 >            AffineTransformType;
+  typedef itk::VersorRigid3DTransform< TOutputScalarType >        VersorRigid3DTransformType;
+  typedef itk::ScaleVersor3DTransform< TOutputScalarType >        ScaleVersor3DTransformType;
+  typedef itk::ScaleSkewVersor3DTransform< TOutputScalarType >    ScaleSkewVersor3DTransformType;
 
   // read the input transform
-  itk::TransformFileReader::Pointer reader =
-    itk::TransformFileReader::New();
+  typedef itk::TransformFileReaderTemplate<TInputScalarType>  TransformFileReaderType;
+  typename TransformFileReaderType::Pointer reader = TransformFileReaderType::New();
   reader->SetFileName(inputTransform.c_str() );
   reader->Update();
-  itk::TransformFileReader::TransformListType *transformList =
-    reader->GetTransformList();
-  GenericTransformType::Pointer inputXfrm = dynamic_cast<GenericTransformType *>(transformList->front().GetPointer() );
+  typename TransformFileReaderType::TransformListType *transformList = reader->GetTransformList();
+  typename InputGenericTransformType::Pointer inputXfrm = dynamic_cast<InputGenericTransformType *>( transformList->front().GetPointer() );
+
+  std::cout << "------------------------ " << std::endl;
+  std::cout << "Input Transform Type ==> " << inputXfrm->GetTransformTypeAsString() << std::endl;
+  std::cout << "* Input transform parameters: " << inputXfrm->GetParameters() << std::endl;
+  std::cout << "* Input transform fixed parameters: " << inputXfrm->GetFixedParameters() << std::endl;
+  std::cout << "------------------------ " << std::endl;
 
   // Handle BSpline type
-  BSplineTransformType::Pointer bsplineInputXfrm =
-    dynamic_cast<BSplineTransformType *>(inputXfrm.GetPointer() );
+  typename BSplineTransformType::Pointer bsplineInputXfrm = dynamic_cast<BSplineTransformType *>( inputXfrm.GetPointer() );
   if( bsplineInputXfrm.IsNotNull() )
     {
     transformList->pop_front();
@@ -249,8 +494,8 @@ int main(int argc, char *argv[])
       std::cerr << "Error, the second transform needed for BSplineDeformableTransform is missing." << std::endl;
       return EXIT_FAILURE;
       }
-    BSplineTransformType::BulkTransformType::Pointer bulkXfrm =
-      dynamic_cast<BSplineTransformType::BulkTransformType *>(transformList->front().GetPointer() );
+    typename BSplineTransformType::BulkTransformType::Pointer bulkXfrm =
+      dynamic_cast<typename BSplineTransformType::BulkTransformType *>(transformList->front().GetPointer() );
     if( bulkXfrm.IsNull() )
       {
       std::cerr << "Error, the second transform is not a bulk transform" << std::endl;
@@ -303,65 +548,75 @@ int main(int argc, char *argv[])
     return EXIT_SUCCESS;
     }
 
-  CHECK_PARAMETER_IS_SET(outputTransform,
-                         "Missing outputTransform parameter");
-
-  GenericTransformType::Pointer outputXfrm;
+  //output transform processing
+  typename OutputGenericTransformType::Pointer outputXfrm;
 
   if( outputTransformType == "Affine" )
     {
-    AffineTransformType::Pointer affineXfrm = AffineTransformType::New();
-    if( ExtractTransform(affineXfrm, inputXfrm.GetPointer() ) == false )
+    typename AffineTransformType::Pointer affineXfrm = AffineTransformType::New();
+    if( ExtractTransform<TInputScalarType, TOutputScalarType>(affineXfrm, inputXfrm.GetPointer() ) == false )
       {
-      TransformConvertError(inputXfrm, "Affine Transform");
+      TransformConvertError<TInputScalarType>(inputXfrm, "Affine Transform");
       return EXIT_FAILURE;
       }
     outputXfrm = affineXfrm.GetPointer();
     }
   else if( outputTransformType == "VersorRigid" )
     {
-    VersorRigid3DTransformType::Pointer versorRigidXfrm =
-      VersorRigid3DTransformType::New();
-    if( ExtractTransform(versorRigidXfrm, inputXfrm.GetPointer() ) == false )
+    typename VersorRigid3DTransformType::Pointer versorRigidXfrm = VersorRigid3DTransformType::New();
+    if( ExtractTransform<TInputScalarType, TOutputScalarType>(versorRigidXfrm, inputXfrm.GetPointer() ) == false )
       {
-      TransformConvertError(inputXfrm, "VersorRigid3D Transform");
+      TransformConvertError<TInputScalarType>(inputXfrm, "VersorRigid3D Transform");
       return EXIT_FAILURE;
       }
     outputXfrm = versorRigidXfrm.GetPointer();
     }
   else if( outputTransformType == "ScaleVersor" )
     {
-    ScaleVersor3DTransformType::Pointer scaleVersorXfrm =
-      ScaleVersor3DTransformType::New();
-    if( ExtractTransform(scaleVersorXfrm, inputXfrm.GetPointer() ) == false )
+    typename ScaleVersor3DTransformType::Pointer scaleVersorXfrm = ScaleVersor3DTransformType::New();
+    if( ExtractTransform<TInputScalarType, TOutputScalarType>( scaleVersorXfrm, inputXfrm.GetPointer() ) == false )
       {
-      TransformConvertError(inputXfrm, "ScaleVersor Transform");
+      TransformConvertError<TInputScalarType>(inputXfrm, "ScaleVersor Transform");
       return EXIT_FAILURE;
       }
     outputXfrm = scaleVersorXfrm.GetPointer();
     }
   else if( outputTransformType == "ScaleSkewVersor" )
     {
-    ScaleSkewVersor3DTransformType::Pointer scaleSkewVersorXfrm =
-      ScaleSkewVersor3DTransformType::New();
-    if( ExtractTransform(scaleSkewVersorXfrm, inputXfrm.GetPointer() ) == false )
+    typename ScaleSkewVersor3DTransformType::Pointer scaleSkewVersorXfrm = ScaleSkewVersor3DTransformType::New();
+    if( ExtractTransform<TInputScalarType, TOutputScalarType>( scaleSkewVersorXfrm, inputXfrm.GetPointer() ) == false )
       {
-      TransformConvertError(inputXfrm, "ScaleSkewVersor Transform");
+      TransformConvertError<TInputScalarType>(inputXfrm, "ScaleSkewVersor Transform");
       return EXIT_FAILURE;
       }
     outputXfrm = scaleSkewVersorXfrm.GetPointer();
     }
+
   if( outputTransformType == "Same" )
     {
-    typedef itk::TransformFileWriter TransformWriterType;
-    TransformWriterType::Pointer transformWriter = TransformWriterType::New();
+    typedef typename itk::TransformFileWriterTemplate<TOutputScalarType> TransformWriterType;
+    typename TransformWriterType::Pointer transformWriter = TransformWriterType::New();
     transformWriter->SetFileName(outputTransform);
-    for( itk::TransformFileReader::TransformListType::iterator it = transformList->begin();
+    for( typename itk::TransformFileReaderTemplate<TInputScalarType>::TransformListType::iterator it = transformList->begin();
          it != transformList->end(); ++it )
       {
-      transformWriter->AddTransform( (*it).GetPointer() );
+      typename InputGenericTransformType::Pointer inXfrm = dynamic_cast<InputGenericTransformType *>( (*it).GetPointer() );
+      typename OutputGenericTransformType::Pointer outXfrm;
+      if( PrecisionConvertor<TInputScalarType, TOutputScalarType>(outXfrm, inXfrm) )
+        {
+        transformWriter->AddTransform( outXfrm );
+        //
+        std::cout << "Output Transform Type ==> " << outXfrm->GetTransformTypeAsString() << std::endl;
+        std::cout << "* Output transform parameters: " << outXfrm->GetParameters() << std::endl;
+        std::cout << "* Output transform fixed parameters: " << outXfrm->GetFixedParameters() << std::endl;
+        std::cout << "------------------------ " << std::endl;
+        }
+      else
+        {
+        std::cerr << "Can't convert the input transform to the same transform but different precision type." << std::endl;
+        return EXIT_FAILURE;
+        }
       }
-
     try
       {
       transformWriter->Update();
@@ -375,7 +630,53 @@ int main(int argc, char *argv[])
   else
     {
     // write the resulting transform.
-    itk::WriteTransformToDisk(outputXfrm.GetPointer(), outputTransform);
+    std::cout << "Output Transform Type ==> " << outputXfrm->GetTransformTypeAsString() << std::endl;
+    std::cout << "* Output transform parameters: " << outputXfrm->GetParameters() << std::endl;
+    std::cout << "* Output transform fixed parameters: " << outputXfrm->GetFixedParameters() << std::endl;
+    std::cout << "------------------------ " << std::endl;
+    //
+    itk::WriteTransformToDisk<TOutputScalarType>(outputXfrm.GetPointer(), outputTransform);
     }
+  return EXIT_SUCCESS;
+}
+
+
+int main(int argc, char *argv[])
+{
+  PARSE_ARGS;
+
+  CHECK_PARAMETER_IS_SET(inputTransform,
+                         "Missing inputTransform parameter");
+  CHECK_PARAMETER_IS_SET(outputTransform,
+                         "Missing outputTransform parameter");
+  CHECK_PARAMETER_IS_SET(outputTransformType,
+                         "Missing outpuTransformType");
+  CHECK_PARAMETER_IS_SET(inputPrecisionType,
+                         "Missing inputPrecisionType");
+  CHECK_PARAMETER_IS_SET(outputPrecisionType,
+                         "Missing outputPrecisionType");
+
+  if( inputPrecisionType == "double" && outputPrecisionType == "double" )
+    {
+    return DoConversion<double, double>( argc, argv );
+    }
+  else if( inputPrecisionType == "double" && outputPrecisionType == "float" )
+    {
+    return DoConversion<double, float>( argc, argv );
+    }
+  else if( inputPrecisionType == "float" && outputPrecisionType == "double" )
+    {
+    return DoConversion<float, double>( argc, argv );
+    }
+  else if( inputPrecisionType == "float" && outputPrecisionType == "float" )
+    {
+    return DoConversion<float, float>( argc, argv );
+    }
+  else
+    {
+    std::cerr << "Error: Invalid parameters for input and output precision type." << std::endl;
+    return EXIT_FAILURE;
+    }
+
   return EXIT_SUCCESS;
 }

--- a/BRAINSTransformConvert/BRAINSTransformConvert.xml
+++ b/BRAINSTransformConvert/BRAINSTransformConvert.xml
@@ -6,7 +6,7 @@
   <version>1.0</version>
   <documentation-url>A utility to convert between transform file formats.</documentation-url>
   <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt</license>
-  <contributor>Hans J. Johnson,Kent Williams</contributor>
+  <contributor>Hans J. Johnson,Kent Williams, Ali Ghayoor</contributor>
   <acknowledgements>
   </acknowledgements>
 
@@ -38,6 +38,24 @@
       <element>ScaleSkewVersor</element>
       <element>DisplacementField</element>
       <element>Same</element>
+    </string-enumeration>
+
+    <string-enumeration>
+      <name>inputPrecisionType</name>
+      <longflag>--inputPrecisionType</longflag>
+      <description>Precision type of the input transform. It can be either single precision or double precision</description>
+      <default>double</default>
+      <element>double</element>
+      <element>float</element>
+    </string-enumeration>
+
+    <string-enumeration>
+      <name>outputPrecisionType</name>
+      <longflag>--outputPrecisionType</longflag>
+      <description>Precision type of the output transform. It can be either single precision or double precision</description>
+      <default>double</default>
+      <element>double</element>
+      <element>float</element>
     </string-enumeration>
 
     <image>

--- a/BRAINSTransformConvert/TestSuite/BRAINSTransformConvertMakeTestFiles.cxx
+++ b/BRAINSTransformConvert/TestSuite/BRAINSTransformConvertMakeTestFiles.cxx
@@ -51,7 +51,7 @@ int main(int argc, char * *argv)
 
   std::string versorRigidName(argv[1]);
   versorRigidName += "/VersorRigidTransform.txt";
-  itk::WriteTransformToDisk(versorRigidTransform.GetPointer(), versorRigidName);
+  itk::WriteTransformToDisk<double>(versorRigidTransform.GetPointer(), versorRigidName);
 
   ScaleVersor3DTransformType::Pointer scaleVersorTransform =
     CreateTransform<ScaleVersor3DTransformType>();
@@ -72,7 +72,7 @@ int main(int argc, char * *argv)
 
   std::string scaleVersorName(argv[1]);
   scaleVersorName += "/ScaleVersorTransform.txt";
-  itk::WriteTransformToDisk(scaleVersorTransform, scaleVersorName);
+  itk::WriteTransformToDisk<double>(scaleVersorTransform, scaleVersorName);
 
   ScaleSkewVersor3DTransformType::Pointer scaleSkewVersorTransform =
     CreateTransform<ScaleSkewVersor3DTransformType>();
@@ -90,7 +90,7 @@ int main(int argc, char * *argv)
 
   std::string scaleSkewVersorName(argv[1]);
   scaleSkewVersorName += "/ScaleSkewVersorTransform.txt";
-  itk::WriteTransformToDisk(scaleSkewVersorTransform, scaleSkewVersorName);
+  itk::WriteTransformToDisk<double>(scaleSkewVersorTransform, scaleSkewVersorName);
 
   AffineTransformType::Pointer affineTransform =
     CreateTransform<AffineTransformType>();
@@ -113,7 +113,7 @@ int main(int argc, char * *argv)
 
   std::string affineName(argv[1]);
   affineName += "/AffineTransform.txt";
-  itk::WriteTransformToDisk(affineTransform, affineName);
+  itk::WriteTransformToDisk<double>(affineTransform, affineName);
 
   typedef itk::Image<signed short, 3> ImageType;
   ImageType::RegionType            region;
@@ -184,7 +184,7 @@ int main(int argc, char * *argv)
 
   std::string bsplineName(argv[1]);
   bsplineName += "/BSplineDeformableTransform.txt";
-  itk::WriteTransformToDisk(bsplineTransform, bsplineName);
+  itk::WriteTransformToDisk<double>(bsplineTransform, bsplineName);
 
   return EXIT_SUCCESS;
 }

--- a/GTRACT/Cmdline/future_work/gtractCoRegAnatomyRigid.cxx
+++ b/GTRACT/Cmdline/future_work/gtractCoRegAnatomyRigid.cxx
@@ -175,5 +175,5 @@ int main(int argc, char * *argv)
     }
   GenericTransformType::Pointer versor3DTransform = registerImageFilter->GetCurrentGenericTransform();
 
-  WriteTransformToDisk(versor3DTransform, outputRigidTransform);
+  itk::WriteTransformToDisk<double>(versor3DTransform, outputRigidTransform);
 }

--- a/GTRACT/Cmdline/gtractCoRegAnatomy.cxx
+++ b/GTRACT/Cmdline/gtractCoRegAnatomy.cxx
@@ -266,7 +266,6 @@ int main(int argc, char *argv[])
     }
 
   GenericTransformType::Pointer outputTransform = registerImageFilter->GetCurrentGenericTransform();
-  // WriteTransformToDisk(outputTransform.GetPointer(), outputTransformName);
-  WriteTransformToDisk(outputTransform, outputTransformName);
+  itk::WriteTransformToDisk<double>(outputTransform, outputTransformName);
   return EXIT_SUCCESS;
 }

--- a/GTRACT/Cmdline/gtractCoRegAnatomyBspline.cxx
+++ b/GTRACT/Cmdline/gtractCoRegAnatomyBspline.cxx
@@ -209,6 +209,6 @@ int main(int argc, char *argv[])
     }
 
   GenericTransformType::Pointer bsplineTransform = registerImageFilter->GetCurrentGenericTransform();
-  WriteTransformToDisk(bsplineTransform.GetPointer(), outputBsplineTransform);
+  itk::WriteTransformToDisk<double>(bsplineTransform.GetPointer(), outputBsplineTransform);
   return EXIT_SUCCESS;
 }

--- a/GTRACT/Cmdline/gtractInvertBSplineTransform.cxx
+++ b/GTRACT/Cmdline/gtractInvertBSplineTransform.cxx
@@ -99,6 +99,6 @@ int main(int argc, char *argv[])
   invertTransformFilter->Update();
   std::cout << "TPS Inversion Complete" << std::endl;
 
-  itk::WriteTransformToDisk(invertTransformFilter->GetOutput(), outputTransform);
+  itk::WriteTransformToDisk<double>(invertTransformFilter->GetOutput(), outputTransform);
   return EXIT_SUCCESS;
 }

--- a/GTRACT/Cmdline/gtractInvertRigidTransform.cxx
+++ b/GTRACT/Cmdline/gtractInvertRigidTransform.cxx
@@ -50,6 +50,6 @@ int main(int argc, char *argv[])
   GenericTransformType::Pointer forwardTransform = itk::ReadTransformFromDisk(inputTransform);
   RigidTransformType::Pointer   reverseTransform = RigidTransformType::New();
   forwardTransform->GetInverse(reverseTransform);
-  itk::WriteTransformToDisk(reverseTransform, outputTransform);
+  itk::WriteTransformToDisk<double>(reverseTransform, outputTransform);
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Two new flags are added to BRAINSTransformConvert tool:
--inputPrecisionType
--outputPrecisionType

These flags can be set as float or double, and they can work well with
other options like outputTransformType.

This patch is tested and works properly now. However, it is not
finalized yet. First, ITK transform file reader/ writer should be fixed
in a way that they can convert their input transforms to the requested
output precision type automatically. Then, this program can be simplified
a lot based on the new version of ITK.
