### PR TITLE
ENH: Output precision type is added to BRAINSTransformConvert

### DIFF
--- a/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
+++ b/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
@@ -334,7 +334,7 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
         this->m_IntraSubjectTransforms[mapOfModalImageListsIt->first].push_back(p);
         // Write out intermodal matricies
         muLogMacro(<< "Writing " << (*isNamesIt) << "." << std::endl);
-        WriteTransformToDisk(p, (*isNamesIt));
+        itk::WriteTransformToDisk<double>(p, (*isNamesIt));
         }
       ++currModeImageListIt;
       ++isNamesIt;
@@ -631,7 +631,7 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
       }
     // End generating the best initial transform for atlas T1 to subject T1
     muLogMacro(<< "Writing " << this->m_AtlasToSubjectTransformFileName << "." << std::endl);
-    WriteTransformToDisk(m_AtlasToSubjectTransform, this->m_AtlasToSubjectTransformFileName);
+    itk::WriteTransformToDisk<double>(m_AtlasToSubjectTransform, this->m_AtlasToSubjectTransformFileName);
     }
 }
 

--- a/BRAINSABC/brainseg/BRAINSABC.cxx
+++ b/BRAINSABC/brainseg/BRAINSABC.cxx
@@ -1320,7 +1320,7 @@ int main(int argc, char * *argv)
         muLogMacro(<< "Writing final atlas to subject template... " << postSegmentationTransformFileName << std::endl );
         GenericTransformType::Pointer atlasToSubjectPostSegmentationTransform =
           segfilter->GetTemplateGenericTransform();
-        WriteTransformToDisk(atlasToSubjectPostSegmentationTransform, postSegmentationTransformFileName);
+        itk::WriteTransformToDisk<double>(atlasToSubjectPostSegmentationTransform, postSegmentationTransformFileName);
         // TODO:  Need to write a short circuit so that if this final transform
         // filename exists, it will just read it in and use it directly
         // without doing all the iterations.

--- a/BRAINSCommonLib/GenericTransformImage.h
+++ b/BRAINSCommonLib/GenericTransformImage.h
@@ -79,10 +79,11 @@ namespace itk
   *ConstPointer up the class tree, use the GetPointer
   * AffineTransformType::Pointer myAffine=AffineTransformType::New(); //NOTE:
   * This is not a const smart pointer
-  * WriteTransformToDisk(myAffine.GetPointer(), "myAffineFile.mat");
+  * WriteTransformToDisk<TScalarType>(myAffine.GetPointer(), "myAffineFile.mat");
   * \endcode
   */
-extern void WriteTransformToDisk(GenericTransformType const *const genericTransformToWrite,
+template<class TScalarType>
+extern void WriteTransformToDisk( itk::Transform<TScalarType, 3, 3> const *const genericTransformToWrite,
                                  const std::string & outputTransform);
 
 /**
@@ -134,7 +135,7 @@ extern GenericTransformType::Pointer ReadTransformFromDisk(const std::string & i
   *ConstPointer up the class tree, use the GetPointer
   * AffineTransformType::Pointer myAffine=AffineTransformType::New(); //NOTE:
   * This is not a const smart pointer
-  * WriteTransformToDisk(myAffine.GetPointer(), "myAffineFile.mat");
+  * WriteTransformToDisk<TScalarType>(myAffine.GetPointer(), "myAffineFile.mat");
   * \endcode
   */
 extern VersorRigid3DTransformType::Pointer ComputeRigidTransformFromGeneric(

--- a/BRAINSConstellationDetector/src/BRAINSTransformFromFiducials.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSTransformFromFiducials.cxx
@@ -263,7 +263,7 @@ int main(int argc, char* argv[])
     return EXIT_FAILURE;
     }
 
-  WriteTransformToDisk(genericTransform.GetPointer(), saveTransform);
+  itk::WriteTransformToDisk<double>(genericTransform.GetPointer(), saveTransform);
 
   return EXIT_SUCCESS;
 }

--- a/BRAINSConstellationDetector/src/landmarksConstellationCommon.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationCommon.cxx
@@ -793,9 +793,10 @@ SImageType::Pointer MakeIsoTropicReferenceImage(void)
   return isotropicReferenceVolume;
 }
 
-void WriteTransformToDisk( GenericTransformType * myTransform , const std::string & filename  )
+template<class TScalarType>
+void WriteTransformToDisk( itk::Transform<TScalarType, 3, 3> * myTransform , const std::string & filename  )
 {
-  itk::TransformFileWriter::Pointer writer = itk::TransformFileWriter::New();
+  typename itk::TransformFileWriterTemplate<TScalarType>::Pointer writer = itk::TransformFileWriterTemplate<TScalarType>::New();
   writer->SetInput( myTransform );
   writer->SetFileName( filename );
   try
@@ -809,3 +810,5 @@ void WriteTransformToDisk( GenericTransformType * myTransform , const std::strin
     }
   std::cout << "The output rigid transform file is written." << std::endl;
 }
+
+template void WriteTransformToDisk<double>( itk::Transform<double, 3, 3> * myTransform , const std::string & filename );

--- a/BRAINSConstellationDetector/src/landmarksConstellationCommon.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationCommon.h
@@ -643,6 +643,6 @@ paired_samples_t(DType *x1, DType *x2, int n, int *df, double *meandiff)
 }
 #endif
 
-
-extern void WriteTransformToDisk( GenericTransformType * myTransform , const std::string & filename  );
+template<class TScalarType>
+extern void WriteTransformToDisk( itk::Transform<TScalarType, 3, 3> * myTransform , const std::string & filename  );
 #endif

--- a/BRAINSCut/BRAINSCutGenerateRegistrations.cxx
+++ b/BRAINSCut/BRAINSCutGenerateRegistrations.cxx
@@ -287,7 +287,7 @@ BRAINSCutGenerateRegistrations
               << " :: " << OutputRegName
               << std::endl;
     }
-  WriteTransformToDisk( BSplineRegistrationHelper->GetCurrentGenericTransform(),
+  itk::WriteTransformToDisk<double>( BSplineRegistrationHelper->GetCurrentGenericTransform(),
                         OutputRegName );
   // Write out Transformed Output As Well
   // - EX. from GenericTransformImage.hxx

--- a/BRAINSLandmarkInitializer/BRAINSLandmarkInitializer.cxx
+++ b/BRAINSLandmarkInitializer/BRAINSLandmarkInitializer.cxx
@@ -135,7 +135,7 @@ main(int argc, char *argv[])
   landmarkBasedInitializer->SetTransform( affineTransform );
   landmarkBasedInitializer->InitializeTransform();
 
-  WriteTransformToDisk( affineTransform, outputTransformFilename);
+  itk::WriteTransformToDisk<double>( affineTransform, outputTransformFilename);
 
   return EXIT_SUCCESS;
 }

--- a/BRAINSTransformConvert/BRAINSTransformConvert.cxx
+++ b/BRAINSTransformConvert/BRAINSTransformConvert.cxx
@@ -19,27 +19,42 @@
 // BSpline 5
 // BSplineROI 5
 
+template<class TScalarType>
 inline
 bool
-IsSameClass(const GenericTransformType *result,
-            const GenericTransformType *source)
+IsSameClass(const itk::Transform< TScalarType, 3, 3 > *result,
+            const itk::Transform< TScalarType, 3, 3 > *source)
 {
   return strcmp(result->GetNameOfClass(), source->GetNameOfClass() ) == 0;
 }
 
+template<class TScalarType>
 inline
 bool
-IsClass(const GenericTransformType *xfrm, const char *className)
+IsClass(const itk::Transform< TScalarType, 3, 3 > *xfrm, const char *className)
 {
   return strcmp(xfrm->GetNameOfClass(), className) == 0;
+}
+
+template<class TScalarType>
+void
+TransformConvertError(const itk::Transform< TScalarType, 3, 3 > *inputXfrm,
+                      const std::string & targetClassName)
+{
+  std::cerr << "Can't convert transform of type "
+  << inputXfrm->GetTransformTypeAsString()
+  << " to "
+  << targetClassName
+  << std::endl;
 }
 
 //
 // Convert from any type derived from MatrixOffsetTransformType to
 // AffineTransform.
+template<class TScalarType>
 bool
-ExtractTransform(AffineTransformType::Pointer & result,
-                 const GenericTransformType *source)
+ExtractTransform(typename itk::AffineTransform< TScalarType, 3 >::Pointer &result,
+                 const itk::Transform< TScalarType, 3, 3 > *source)
 {
   result->SetIdentity();
   // always able to convert to same type
@@ -50,25 +65,26 @@ ExtractTransform(AffineTransformType::Pointer & result,
     return true;
     }
 
-  typedef AffineTransformType::Superclass MatrixOffsetTransformType;
-  const MatrixOffsetTransformType *matBasePtr =
-    dynamic_cast<const MatrixOffsetTransformType *>(source);
+  typedef itk::AffineTransform< TScalarType, 3 > AffineTransformType;
+  typedef typename AffineTransformType::Superclass MatrixOffsetTransformType;
+  const MatrixOffsetTransformType *matBasePtr = dynamic_cast<const MatrixOffsetTransformType *>(source);
   if( matBasePtr == 0 )
     {
     return false;
     }
 
-  result->SetCenter(matBasePtr->GetCenter() );
-  result->SetMatrix(matBasePtr->GetMatrix() );
-  result->SetTranslation(matBasePtr->GetTranslation() );
+  result->SetCenter( matBasePtr->GetCenter() );
+  result->SetMatrix( matBasePtr->GetMatrix() );
+  result->SetTranslation( matBasePtr->GetTranslation() );
   return true;
 }
 
 //
 // versor rigid 3d case.
+template<class TScalarType>
 bool
-ExtractTransform(VersorRigid3DTransformType::Pointer & result,
-                 const GenericTransformType *source)
+ExtractTransform(typename itk::VersorRigid3DTransform<TScalarType>::Pointer & result,
+                 const itk::Transform< TScalarType, 3, 3 > *source)
 {
   result->SetIdentity();
   // always able to convert to same type
@@ -78,24 +94,25 @@ ExtractTransform(VersorRigid3DTransformType::Pointer & result,
     result->SetFixedParameters( source->GetFixedParameters() );
     return true;
     }
+
   // this looks like it should be a convertible transform but
   // I'm not sure.
-  typedef itk::TranslationTransform<double, 3> TransTransformType;
+  typedef itk::TranslationTransform<TScalarType, 3> TransTransformType;
   if( IsClass(source, "TranslationTransform") )
     {
-    const TransTransformType *translationXfrm =
-      dynamic_cast<const TransTransformType *>(source);
-    TransTransformType::OutputVectorType offset = translationXfrm->GetOffset();
-    result->SetOffset(offset);
+    const TransTransformType *translationXfrm = dynamic_cast<const TransTransformType *>(source);
+    typename TransTransformType::OutputVectorType offset = translationXfrm->GetOffset();
+    result->SetOffset( offset );
     return true;
     }
   // versor == rotation only
   if( IsClass(source, "VersorTransform") )
     {
-    typedef itk::VersorTransform<double> VersorTransformType;
+    typedef itk::VersorTransform<TScalarType> VersorTransformType;
     const VersorTransformType *versorXfrm = dynamic_cast<const VersorTransformType *>(source);
-    result->SetRotation(versorXfrm->GetVersor() );
-    result->SetCenter(versorXfrm->GetCenter() );
+
+    result->SetRotation( versorXfrm->GetVersor() );
+    result->SetCenter( versorXfrm->GetCenter() );
     return true;
     }
   return false;
@@ -103,9 +120,10 @@ ExtractTransform(VersorRigid3DTransformType::Pointer & result,
 
 //
 // scale versor case
+template<class TScalarType>
 bool
-ExtractTransform(ScaleVersor3DTransformType::Pointer & result,
-                 const GenericTransformType *source)
+ExtractTransform(typename itk::ScaleVersor3DTransform<TScalarType>::Pointer & result,
+                 const itk::Transform< TScalarType, 3, 3 > *source)
 {
   result->SetIdentity();
   // always able to convert to same type
@@ -115,31 +133,34 @@ ExtractTransform(ScaleVersor3DTransformType::Pointer & result,
     result->SetFixedParameters( source->GetFixedParameters() );
     return true;
     }
+
+  typedef itk::VersorRigid3DTransform<TScalarType> VersorRigid3DTransformType;
   if( IsClass(source, "VersorRigid3DTransform") )
     {
     const VersorRigid3DTransformType *versorRigidXfrm =
-      dynamic_cast<const VersorRigid3DTransformType *>(source);
+    dynamic_cast<const VersorRigid3DTransformType *>(source);
     result->SetRotation(versorRigidXfrm->GetVersor() );
     result->SetTranslation(versorRigidXfrm->GetTranslation() );
     result->SetCenter(versorRigidXfrm->GetCenter() );
     return true;
     }
   // otherwise try VersorRigidTransform
-  VersorRigid3DTransformType::Pointer vrx = VersorRigid3DTransformType::New();
-  if( ExtractTransform(vrx, source) ) // of VersorRigid3D conversion
+  typename VersorRigid3DTransformType::Pointer vrx = VersorRigid3DTransformType::New();
+  if( ExtractTransform<TScalarType>(vrx, source) ) // of VersorRigid3D conversion
                                       // works
     {
     // recurse to do this conversion
-    return ExtractTransform(result, vrx.GetPointer() );
+    return ExtractTransform<TScalarType>(result, vrx.GetPointer() );
     }
   return false;
 }
 
 //
 // scale skew versor case
+template<class TScalarType>
 bool
-ExtractTransform(ScaleSkewVersor3DTransformType::Pointer & result,
-                 const GenericTransformType *source)
+ExtractTransform(typename itk::ScaleSkewVersor3DTransform< TScalarType >::Pointer & result,
+                 const itk::Transform< TScalarType, 3, 3 > *source)
 {
   // always able to convert to same type
   if( IsSameClass(result.GetPointer(), source) )
@@ -148,11 +169,12 @@ ExtractTransform(ScaleSkewVersor3DTransformType::Pointer & result,
     result->SetFixedParameters( source->GetFixedParameters() );
     return true;
     }
+
   // is it the parent?
+  typedef itk::ScaleVersor3DTransform<TScalarType> ScaleVersor3DTransformType;
   if( IsClass(source, "ScaleVersor3DTransform") )
     {
-    const ScaleVersor3DTransformType *scaleVersorXfrm =
-      dynamic_cast<const ScaleVersor3DTransformType *>(source);
+    const ScaleVersor3DTransformType *scaleVersorXfrm = dynamic_cast<const ScaleVersor3DTransformType *>(source);
     result->SetRotation(scaleVersorXfrm->GetVersor() );
     result->SetTranslation(scaleVersorXfrm->GetTranslation() );
     result->SetCenter(scaleVersorXfrm->GetCenter() );
@@ -160,57 +182,14 @@ ExtractTransform(ScaleSkewVersor3DTransformType::Pointer & result,
     return true;
     }
   // otherwise try ScaleVersor conversion
-  ScaleVersor3DTransformType::Pointer svx = ScaleVersor3DTransformType::New();
-  if( ExtractTransform(svx, source) ) // of VersorRigid3D conversion
-                                      // works
+  typename ScaleVersor3DTransformType::Pointer svx = ScaleVersor3DTransformType::New();
+  if( ExtractTransform<TScalarType>(svx, source) ) // of VersorRigid3D conversion
+                                                                               // works
     {
     // recurse to do this conversion
-    return ExtractTransform(result, svx.GetPointer() );
+    return ExtractTransform<TScalarType>(result, svx.GetPointer() );
     }
   return false;
-}
-
-//
-// scale skew versor case
-bool
-ExtractTransform(BSplineTransformType::Pointer & result,
-                 const GenericTransformType *source)
-{
-  if( IsSameClass(result.GetPointer(), source) )
-    {
-    const BSplineTransformType *sourceBSpline =
-      dynamic_cast<const BSplineTransformType *>(source);
-    result->SetFixedParameters(sourceBSpline->GetFixedParameters() );
-    result->SetIdentity();
-    result->SetParametersByValue(sourceBSpline->GetParameters() );
-    result->SetBulkTransform(sourceBSpline->GetBulkTransform() );
-    return true;
-    }
-  else
-    {
-    result->SetIdentity();
-    }
-  typedef BSplineTransformType::BulkTransformType BulkXfrmType;
-
-  const BulkXfrmType *bulkXfrm =
-    dynamic_cast<const BulkXfrmType *>(source);
-  if( bulkXfrm == 0 )
-    {
-    return false;
-    }
-  result->SetBulkTransform(bulkXfrm);
-  return true;
-}
-
-void
-TransformConvertError(GenericTransformType *inputXfrm,
-                      const std::string & targetClassName)
-{
-  std::cerr << "Can't convert transform of type "
-            << inputXfrm->GetTransformTypeAsString()
-            << " to "
-            << targetClassName
-            << std::endl;
 }
 
 #define CHECK_PARAMETER_IS_SET(parameter, message) \
@@ -220,27 +199,38 @@ TransformConvertError(GenericTransformType *inputXfrm,
     return EXIT_FAILURE;                          \
     }
 
-int main(int argc, char *argv[])
+template<class TScalarType>
+int
+DoConversion( int argc, char *argv[] )
 {
   PARSE_ARGS;
 
-  CHECK_PARAMETER_IS_SET(inputTransform,
-                         "Missing inputTransform parameter");
-  CHECK_PARAMETER_IS_SET(outputTransformType,
-                         "Missing outpuTransformType");
+  typedef itk::Transform< TScalarType, 3, 3 >                                 GenericTransformType;
+  typedef itk::BSplineDeformableTransform< TScalarType,
+                                           GenericTransformImageNS::SpaceDimension,
+                                           GenericTransformImageNS::SplineOrder>    BSplineTransformType;
+
+  typedef itk::AffineTransform< TScalarType, 3 >            AffineTransformType;
+  typedef itk::VersorRigid3DTransform< TScalarType >        VersorRigid3DTransformType;
+  typedef itk::ScaleVersor3DTransform< TScalarType >        ScaleVersor3DTransformType;
+  typedef itk::ScaleSkewVersor3DTransform< TScalarType >    ScaleSkewVersor3DTransformType;
 
   // read the input transform
-  itk::TransformFileReader::Pointer reader =
-    itk::TransformFileReader::New();
+  typedef itk::TransformFileReaderTemplate<TScalarType>  TransformFileReaderType;
+  typename TransformFileReaderType::Pointer reader = TransformFileReaderType::New();
   reader->SetFileName(inputTransform.c_str() );
   reader->Update();
-  itk::TransformFileReader::TransformListType *transformList =
-    reader->GetTransformList();
-  GenericTransformType::Pointer inputXfrm = dynamic_cast<GenericTransformType *>(transformList->front().GetPointer() );
+  typename TransformFileReaderType::TransformListType *transformList = reader->GetTransformList();
+  typename GenericTransformType::Pointer inputXfrm = dynamic_cast<GenericTransformType *>( transformList->front().GetPointer() );
+
+  std::cout << "------------------------ " << std::endl;
+  std::cout << "Input Transform Type Saved on Memory ==> " << inputXfrm->GetTransformTypeAsString() << std::endl;
+  std::cout << "* Input transform parameters: " << inputXfrm->GetParameters() << std::endl;
+  std::cout << "* Input transform fixed parameters: " << inputXfrm->GetFixedParameters() << std::endl;
+  std::cout << "------------------------ " << std::endl;
 
   // Handle BSpline type
-  BSplineTransformType::Pointer bsplineInputXfrm =
-    dynamic_cast<BSplineTransformType *>(inputXfrm.GetPointer() );
+  typename BSplineTransformType::Pointer bsplineInputXfrm = dynamic_cast<BSplineTransformType *>( inputXfrm.GetPointer() );
   if( bsplineInputXfrm.IsNotNull() )
     {
     transformList->pop_front();
@@ -249,8 +239,8 @@ int main(int argc, char *argv[])
       std::cerr << "Error, the second transform needed for BSplineDeformableTransform is missing." << std::endl;
       return EXIT_FAILURE;
       }
-    BSplineTransformType::BulkTransformType::Pointer bulkXfrm =
-      dynamic_cast<BSplineTransformType::BulkTransformType *>(transformList->front().GetPointer() );
+    typename BSplineTransformType::BulkTransformType::Pointer bulkXfrm =
+      dynamic_cast<typename BSplineTransformType::BulkTransformType *>(transformList->front().GetPointer() );
     if( bulkXfrm.IsNull() )
       {
       std::cerr << "Error, the second transform is not a bulk transform" << std::endl;
@@ -303,65 +293,66 @@ int main(int argc, char *argv[])
     return EXIT_SUCCESS;
     }
 
-  CHECK_PARAMETER_IS_SET(outputTransform,
-                         "Missing outputTransform parameter");
-
-  GenericTransformType::Pointer outputXfrm;
+  //output transform processing
+  typename GenericTransformType::Pointer outputXfrm;
 
   if( outputTransformType == "Affine" )
     {
-    AffineTransformType::Pointer affineXfrm = AffineTransformType::New();
-    if( ExtractTransform(affineXfrm, inputXfrm.GetPointer() ) == false )
+    typename AffineTransformType::Pointer affineXfrm = AffineTransformType::New();
+    if( ExtractTransform<TScalarType>(affineXfrm, inputXfrm.GetPointer() ) == false )
       {
-      TransformConvertError(inputXfrm, "Affine Transform");
+      TransformConvertError<TScalarType>(inputXfrm, "Affine Transform");
       return EXIT_FAILURE;
       }
     outputXfrm = affineXfrm.GetPointer();
     }
   else if( outputTransformType == "VersorRigid" )
     {
-    VersorRigid3DTransformType::Pointer versorRigidXfrm =
-      VersorRigid3DTransformType::New();
-    if( ExtractTransform(versorRigidXfrm, inputXfrm.GetPointer() ) == false )
+    typename VersorRigid3DTransformType::Pointer versorRigidXfrm = VersorRigid3DTransformType::New();
+    if( ExtractTransform<TScalarType>(versorRigidXfrm, inputXfrm.GetPointer() ) == false )
       {
-      TransformConvertError(inputXfrm, "VersorRigid3D Transform");
+      TransformConvertError<TScalarType>(inputXfrm, "VersorRigid3D Transform");
       return EXIT_FAILURE;
       }
     outputXfrm = versorRigidXfrm.GetPointer();
     }
   else if( outputTransformType == "ScaleVersor" )
     {
-    ScaleVersor3DTransformType::Pointer scaleVersorXfrm =
-      ScaleVersor3DTransformType::New();
-    if( ExtractTransform(scaleVersorXfrm, inputXfrm.GetPointer() ) == false )
+    typename ScaleVersor3DTransformType::Pointer scaleVersorXfrm = ScaleVersor3DTransformType::New();
+    if( ExtractTransform<TScalarType>( scaleVersorXfrm, inputXfrm.GetPointer() ) == false )
       {
-      TransformConvertError(inputXfrm, "ScaleVersor Transform");
+      TransformConvertError<TScalarType>(inputXfrm, "ScaleVersor Transform");
       return EXIT_FAILURE;
       }
     outputXfrm = scaleVersorXfrm.GetPointer();
     }
   else if( outputTransformType == "ScaleSkewVersor" )
     {
-    ScaleSkewVersor3DTransformType::Pointer scaleSkewVersorXfrm =
-      ScaleSkewVersor3DTransformType::New();
-    if( ExtractTransform(scaleSkewVersorXfrm, inputXfrm.GetPointer() ) == false )
+    typename ScaleSkewVersor3DTransformType::Pointer scaleSkewVersorXfrm = ScaleSkewVersor3DTransformType::New();
+    if( ExtractTransform<TScalarType>( scaleSkewVersorXfrm, inputXfrm.GetPointer() ) == false )
       {
-      TransformConvertError(inputXfrm, "ScaleSkewVersor Transform");
+      TransformConvertError<TScalarType>(inputXfrm, "ScaleSkewVersor Transform");
       return EXIT_FAILURE;
       }
     outputXfrm = scaleSkewVersorXfrm.GetPointer();
     }
+
   if( outputTransformType == "Same" )
     {
-    typedef itk::TransformFileWriter TransformWriterType;
-    TransformWriterType::Pointer transformWriter = TransformWriterType::New();
+    typedef typename itk::TransformFileWriterTemplate<TScalarType> TransformWriterType;
+    typename TransformWriterType::Pointer transformWriter = TransformWriterType::New();
     transformWriter->SetFileName(outputTransform);
-    for( itk::TransformFileReader::TransformListType::iterator it = transformList->begin();
+    for( typename itk::TransformFileReaderTemplate<TScalarType>::TransformListType::iterator it = transformList->begin();
          it != transformList->end(); ++it )
       {
-      transformWriter->AddTransform( (*it).GetPointer() );
+      typename GenericTransformType::Pointer outXfrm = dynamic_cast<GenericTransformType *>( (*it).GetPointer() );
+      transformWriter->AddTransform( outXfrm );
+      //
+      std::cout << "Output Transform Type Written to the Disk ==> " << outXfrm->GetTransformTypeAsString() << std::endl;
+      std::cout << "* Output transform parameters: " << outXfrm->GetParameters() << std::endl;
+      std::cout << "* Output transform fixed parameters: " << outXfrm->GetFixedParameters() << std::endl;
+      std::cout << "------------------------ " << std::endl;
       }
-
     try
       {
       transformWriter->Update();
@@ -375,7 +366,43 @@ int main(int argc, char *argv[])
   else
     {
     // write the resulting transform.
-    itk::WriteTransformToDisk(outputXfrm.GetPointer(), outputTransform);
+    std::cout << "Output Transform Type Written to the Disk ==> " << outputXfrm->GetTransformTypeAsString() << std::endl;
+    std::cout << "* Output transform parameters: " << outputXfrm->GetParameters() << std::endl;
+    std::cout << "* Output transform fixed parameters: " << outputXfrm->GetFixedParameters() << std::endl;
+    std::cout << "------------------------ " << std::endl;
+    //
+    itk::WriteTransformToDisk<TScalarType>(outputXfrm.GetPointer(), outputTransform);
     }
+  return EXIT_SUCCESS;
+}
+
+
+int main(int argc, char *argv[])
+{
+  PARSE_ARGS;
+
+  CHECK_PARAMETER_IS_SET(inputTransform,
+                         "Missing inputTransform parameter");
+  CHECK_PARAMETER_IS_SET(outputTransform,
+                         "Missing outputTransform parameter");
+  CHECK_PARAMETER_IS_SET(outputTransformType,
+                         "Missing outpuTransformType");
+  CHECK_PARAMETER_IS_SET(outputPrecisionType,
+                         "Missing outputPrecisionType");
+
+  if( outputPrecisionType == "double" )
+    {
+    return DoConversion<double>( argc, argv );
+    }
+  else if( outputPrecisionType == "float" )
+    {
+    return DoConversion<float>( argc, argv );
+    }
+  else
+    {
+    std::cerr << "Error: Invalid parameter for output precision type." << std::endl;
+    return EXIT_FAILURE;
+    }
+
   return EXIT_SUCCESS;
 }

--- a/BRAINSTransformConvert/BRAINSTransformConvert.xml
+++ b/BRAINSTransformConvert/BRAINSTransformConvert.xml
@@ -6,7 +6,7 @@
   <version>1.0</version>
   <documentation-url>A utility to convert between transform file formats.</documentation-url>
   <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt</license>
-  <contributor>Hans J. Johnson,Kent Williams</contributor>
+  <contributor>Hans J. Johnson,Kent Williams, Ali Ghayoor</contributor>
   <acknowledgements>
   </acknowledgements>
 
@@ -38,6 +38,15 @@
       <element>ScaleSkewVersor</element>
       <element>DisplacementField</element>
       <element>Same</element>
+    </string-enumeration>
+
+    <string-enumeration>
+      <name>outputPrecisionType</name>
+      <longflag>--outputPrecisionType</longflag>
+      <description>Precision type of the output transform. It can be either single precision or double precision</description>
+      <default>double</default>
+      <element>double</element>
+      <element>float</element>
     </string-enumeration>
 
     <image>

--- a/BRAINSTransformConvert/TestSuite/BRAINSTransformConvertMakeTestFiles.cxx
+++ b/BRAINSTransformConvert/TestSuite/BRAINSTransformConvertMakeTestFiles.cxx
@@ -51,7 +51,7 @@ int main(int argc, char * *argv)
 
   std::string versorRigidName(argv[1]);
   versorRigidName += "/VersorRigidTransform.txt";
-  itk::WriteTransformToDisk(versorRigidTransform.GetPointer(), versorRigidName);
+  itk::WriteTransformToDisk<double>(versorRigidTransform.GetPointer(), versorRigidName);
 
   ScaleVersor3DTransformType::Pointer scaleVersorTransform =
     CreateTransform<ScaleVersor3DTransformType>();
@@ -72,7 +72,7 @@ int main(int argc, char * *argv)
 
   std::string scaleVersorName(argv[1]);
   scaleVersorName += "/ScaleVersorTransform.txt";
-  itk::WriteTransformToDisk(scaleVersorTransform, scaleVersorName);
+  itk::WriteTransformToDisk<double>(scaleVersorTransform, scaleVersorName);
 
   ScaleSkewVersor3DTransformType::Pointer scaleSkewVersorTransform =
     CreateTransform<ScaleSkewVersor3DTransformType>();
@@ -90,7 +90,7 @@ int main(int argc, char * *argv)
 
   std::string scaleSkewVersorName(argv[1]);
   scaleSkewVersorName += "/ScaleSkewVersorTransform.txt";
-  itk::WriteTransformToDisk(scaleSkewVersorTransform, scaleSkewVersorName);
+  itk::WriteTransformToDisk<double>(scaleSkewVersorTransform, scaleSkewVersorName);
 
   AffineTransformType::Pointer affineTransform =
     CreateTransform<AffineTransformType>();
@@ -113,7 +113,7 @@ int main(int argc, char * *argv)
 
   std::string affineName(argv[1]);
   affineName += "/AffineTransform.txt";
-  itk::WriteTransformToDisk(affineTransform, affineName);
+  itk::WriteTransformToDisk<double>(affineTransform, affineName);
 
   typedef itk::Image<signed short, 3> ImageType;
   ImageType::RegionType            region;
@@ -184,7 +184,7 @@ int main(int argc, char * *argv)
 
   std::string bsplineName(argv[1]);
   bsplineName += "/BSplineDeformableTransform.txt";
-  itk::WriteTransformToDisk(bsplineTransform, bsplineName);
+  itk::WriteTransformToDisk<double>(bsplineTransform, bsplineName);
 
   return EXIT_SUCCESS;
 }

--- a/BRAINSTransformConvert/TestSuite/CMakeLists.txt
+++ b/BRAINSTransformConvert/TestSuite/CMakeLists.txt
@@ -51,96 +51,100 @@ set(BSplineDeformableTargets DisplacementField)
 set(TransformTestImage "${CMAKE_CURRENT_BINARY_DIR}/TransformConvertTestImage.nii.gz")
 
 foreach(SourceTransform VersorRigid ScaleVersor ScaleSkewVersor Affine BSplineDeformable)
-  foreach(TargetTransform IN LISTS ${SourceTransform}Targets)
+  foreach(TargetPrecisionType float double)
+    foreach(TargetTransform IN LISTS ${SourceTransform}Targets)
 
-    set(TransformConvertTestName Convert${SourceTransform}To${TargetTransform})
-    set(SourceTransformName "${CMAKE_CURRENT_BINARY_DIR}/${SourceTransform}Transform.txt")
-    set(TargetTransformName "${CMAKE_CURRENT_BINARY_DIR}/${SourceTransform}To${TargetTransform}.txt")
-    set(DisplacementVolumeImage "${CMAKE_CURRENT_BINARY_DIR}/${SourceTransform}Displacement.nii.gz")
-    #
-    # do the conversion
-    add_test(NAME ${TransformConvertTestName} COMMAND
+      set(TransformConvertTestName Convert${SourceTransform}To${TargetTransform}In${TargetPrecisionType})
+      set(SourceTransformName "${CMAKE_CURRENT_BINARY_DIR}/${SourceTransform}Transform.txt")
+      set(TargetTransformName "${CMAKE_CURRENT_BINARY_DIR}/${SourceTransform}To${TargetTransform}.txt")
+      set(DisplacementVolumeImage "${CMAKE_CURRENT_BINARY_DIR}/${SourceTransform}Displacement.nii.gz")
+      #
+      # do the conversion
+      add_test(NAME ${TransformConvertTestName} COMMAND
       ${LAUNCH_EXE} $<TARGET_FILE:BRAINSTransformConvert>
       --inputTransform ${SourceTransformName}
       --outputTransform ${TargetTransformName}
       --outputTransformType ${TargetTransform}
+      --outputPrecisionType ${TargetPrecisionType}
       --referenceVolume ${TransformTestImage}         # Only needed for DisplacementField transforms
       --displacementVolume ${DisplacementVolumeImage} # Only needed for DisplacementField transforms
       )
-    set_property(TEST ${TestName} APPEND PROPERTY DEPENDS BRAINSTransformConvertMakeTestFilesTest)
-    set_property(TEST ${TestName} APPEND PROPERTY DEPENDS BRAINSTransformConvert)
+      set_property(TEST ${TestName} APPEND PROPERTY DEPENDS BRAINSTransformConvertMakeTestFilesTest)
+      set_property(TEST ${TestName} APPEND PROPERTY DEPENDS BRAINSTransformConvert)
 
 
-    if(NOT "${SourceTransform}" STREQUAL "${TargetTransform}")
-      if(NOT "${TargetTransform}" STREQUAL "DisplacementField")
-        #
-        # Do the backwards conversion which will fail
-        set(BadTransformConvertTestName "Bad${TransformConvertTestName}")
-        set(BadTransformConvertTargetName ${BadTransformConvertTestName}.txt)
-        add_test(NAME ${BadTransformConvertTestName} COMMAND
+      if(NOT "${SourceTransform}" STREQUAL "${TargetTransform}")
+        if(NOT "${TargetTransform}" STREQUAL "DisplacementField")
+          #
+          # Do the backwards conversion which will fail
+          set(BadTransformConvertTestName "Bad${TransformConvertTestName}")
+          set(BadTransformConvertTargetName ${BadTransformConvertTestName}.txt)
+          add_test(NAME ${BadTransformConvertTestName} COMMAND
           ${LAUNCH_EXE} $<TARGET_FILE:BRAINSTransformConvert>
           --inputTransform ${TargetTransformName}
           --outputTransform ${BadTransformConvertTargetName}
           --outputTransformType ${SourceTransform}
+          --outputPrecisionType ${TargetPrecisionType}
           --referenceVolume ${TransformTestImage}
           --displacementVolume ${DisplacementVolumeImage}
           )
-        set_property(TEST ${BadTransformConvertTestName}
-          APPEND PROPERTY DEPENDS BRAINSTransformConvertMakeTestFilesTest)
-        set_property(TEST ${BadTransformConvertTestName}
-          APPEND PROPERTY DEPENDS ${TransformConvertTestName})
-        set_tests_properties(${BadTransformConvertTestName} PROPERTIES WILL_FAIL ON)
+          set_property(TEST ${BadTransformConvertTestName}
+            APPEND PROPERTY DEPENDS BRAINSTransformConvertMakeTestFilesTest)
+          set_property(TEST ${BadTransformConvertTestName}
+            APPEND PROPERTY DEPENDS ${TransformConvertTestName})
+          set_tests_properties(${BadTransformConvertTestName} PROPERTIES WILL_FAIL ON)
+        endif()
       endif()
-    endif()
 
-    # resample the test image using BRAINSResample
-    # and original transform
-    set(ResampleWSourceTestName ResampleWSource${SourceTransform}${TargetTransform})
-    set(ResampleWSourceOutputImage ${ResampleWSourceTestName}.nii.gz)
+      # resample the test image using BRAINSResample
+      # and original transform
+      set(ResampleWSourceTestName ResampleWSource${SourceTransform}${TargetTransform}${TargetPrecisionType})
+      set(ResampleWSourceOutputImage ${ResampleWSourceTestName}.nii.gz)
 
-    add_test(NAME ${ResampleWSourceTestName}
-      COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSResample>
-      --inputVolume ${TransformTestImage}
-      --outputVolume ${ResampleWSourceOutputImage}
-      --pixelType short
-      --warpTransform ${SourceTransformName})
-    set_property(TEST ${ResampleWSourceTestName} APPEND PROPERTY DEPENDS BRAINSResample)
-    set_property(TEST ${TestName} APPEND PROPERTY DEPENDS BRAINSTransformConvertMakeTestFilesTest)
-
-    # resample the test image using BRAINSResample
-    # and converted transform
-    set(ResampleWTargetTestName ResampleWTarget${SourceTransform}${TargetTransform})
-    set(ResampleWTargetOutputImage ${ResampleWTargetTestName}.nii.gz)
-
-    # Displacement field takes different command line
-    if(NOT "${TargetTransform}" STREQUAL "DisplacementField")
-      add_test(NAME ${ResampleWTargetTestName}
+      add_test(NAME ${ResampleWSourceTestName}
         COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSResample>
         --inputVolume ${TransformTestImage}
-        --outputVolume ${ResampleWTargetOutputImage}
+        --outputVolume ${ResampleWSourceOutputImage}
         --pixelType short
-        --warpTransform ${TargetTransformName})
-    else()
-      add_test(NAME ${ResampleWTargetTestName}
-        COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSResample>
-        --inputVolume ${TransformTestImage}
-        --outputVolume ${ResampleWTargetOutputImage}
-        --pixelType short
-        --deformationVolume ${DisplacementVolumeImage})
-    endif()
+        --warpTransform ${SourceTransformName})
+      set_property(TEST ${ResampleWSourceTestName} APPEND PROPERTY DEPENDS BRAINSResample)
+      set_property(TEST ${TestName} APPEND PROPERTY DEPENDS BRAINSTransformConvertMakeTestFilesTest)
 
-    #
-    # depend on previous test, and BRAINSResample
-    set_property(TEST ${ResampleWTargetTestName} APPEND PROPERTY DEPENDS ${TransformConvertTestName})
-    set_property(TEST ${ResampleWTargetTestName} APPEND PROPERTY DEPENDS BRAINSResample)
+      # resample the test image using BRAINSResample
+      # and converted transform
+      set(ResampleWTargetTestName ResampleWTarget${SourceTransform}${TargetTransform}${TargetPrecisionType})
+      set(ResampleWTargetOutputImage ${ResampleWTargetTestName}.nii.gz)
 
-    set(ImageCompareTestName ImageCompare${SourceTransform}${TargetTransform})
-    add_test(NAME ${ImageCompareTestName} COMMAND ${LAUNCH_EXE} ${ImageCompare}
-      ${ResampleWSourceOutputImage} ${ResampleWTargetOutputImage})
+      # Displacement field takes different command line
+      if(NOT "${TargetTransform}" STREQUAL "DisplacementField")
+        add_test(NAME ${ResampleWTargetTestName}
+          COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSResample>
+          --inputVolume ${TransformTestImage}
+          --outputVolume ${ResampleWTargetOutputImage}
+          --pixelType short
+          --warpTransform ${TargetTransformName})
+      else()
+        add_test(NAME ${ResampleWTargetTestName}
+          COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSResample>
+          --inputVolume ${TransformTestImage}
+          --outputVolume ${ResampleWTargetOutputImage}
+          --pixelType short
+          --deformationVolume ${DisplacementVolumeImage})
+      endif()
 
-    set_property(TEST ${ImageCompareTestName} APPEND PROPERTY DEPENDS ImageCompare)
-    set_property(TEST ${ImageCompareTestName} APPEND PROPERTY DEPENDS ${ResampleWSourceTestName})
-    set_property(TEST ${ImageCompareTestName} APPEND PROPERTY DEPENDS ${ResampleWTargetTestName})
+      #
+      # depend on previous test, and BRAINSResample
+      set_property(TEST ${ResampleWTargetTestName} APPEND PROPERTY DEPENDS ${TransformConvertTestName})
+      set_property(TEST ${ResampleWTargetTestName} APPEND PROPERTY DEPENDS BRAINSResample)
 
+      set(ImageCompareTestName ImageCompare${SourceTransform}${TargetTransform}${TargetPrecisionType})
+      add_test(NAME ${ImageCompareTestName} COMMAND ${LAUNCH_EXE} ${ImageCompare}
+        ${ResampleWSourceOutputImage} ${ResampleWTargetOutputImage})
+
+      set_property(TEST ${ImageCompareTestName} APPEND PROPERTY DEPENDS ImageCompare)
+      set_property(TEST ${ImageCompareTestName} APPEND PROPERTY DEPENDS ${ResampleWSourceTestName})
+      set_property(TEST ${ImageCompareTestName} APPEND PROPERTY DEPENDS ${ResampleWTargetTestName})
+
+    endforeach()
   endforeach()
 endforeach()

--- a/GTRACT/Cmdline/future_work/gtractCoRegAnatomyRigid.cxx
+++ b/GTRACT/Cmdline/future_work/gtractCoRegAnatomyRigid.cxx
@@ -175,5 +175,5 @@ int main(int argc, char * *argv)
     }
   GenericTransformType::Pointer versor3DTransform = registerImageFilter->GetCurrentGenericTransform();
 
-  WriteTransformToDisk(versor3DTransform, outputRigidTransform);
+  itk::WriteTransformToDisk<double>(versor3DTransform, outputRigidTransform);
 }

--- a/GTRACT/Cmdline/gtractCoRegAnatomy.cxx
+++ b/GTRACT/Cmdline/gtractCoRegAnatomy.cxx
@@ -266,7 +266,6 @@ int main(int argc, char *argv[])
     }
 
   GenericTransformType::Pointer outputTransform = registerImageFilter->GetCurrentGenericTransform();
-  // WriteTransformToDisk(outputTransform.GetPointer(), outputTransformName);
-  WriteTransformToDisk(outputTransform, outputTransformName);
+  itk::WriteTransformToDisk<double>(outputTransform, outputTransformName);
   return EXIT_SUCCESS;
 }

--- a/GTRACT/Cmdline/gtractCoRegAnatomyBspline.cxx
+++ b/GTRACT/Cmdline/gtractCoRegAnatomyBspline.cxx
@@ -209,6 +209,6 @@ int main(int argc, char *argv[])
     }
 
   GenericTransformType::Pointer bsplineTransform = registerImageFilter->GetCurrentGenericTransform();
-  WriteTransformToDisk(bsplineTransform.GetPointer(), outputBsplineTransform);
+  itk::WriteTransformToDisk<double>(bsplineTransform.GetPointer(), outputBsplineTransform);
   return EXIT_SUCCESS;
 }

--- a/GTRACT/Cmdline/gtractInvertBSplineTransform.cxx
+++ b/GTRACT/Cmdline/gtractInvertBSplineTransform.cxx
@@ -99,6 +99,6 @@ int main(int argc, char *argv[])
   invertTransformFilter->Update();
   std::cout << "TPS Inversion Complete" << std::endl;
 
-  itk::WriteTransformToDisk(invertTransformFilter->GetOutput(), outputTransform);
+  itk::WriteTransformToDisk<double>(invertTransformFilter->GetOutput(), outputTransform);
   return EXIT_SUCCESS;
 }

--- a/GTRACT/Cmdline/gtractInvertRigidTransform.cxx
+++ b/GTRACT/Cmdline/gtractInvertRigidTransform.cxx
@@ -50,6 +50,6 @@ int main(int argc, char *argv[])
   GenericTransformType::Pointer forwardTransform = itk::ReadTransformFromDisk(inputTransform);
   RigidTransformType::Pointer   reverseTransform = RigidTransformType::New();
   forwardTransform->GetInverse(reverseTransform);
-  itk::WriteTransformToDisk(reverseTransform, outputTransform);
+  itk::WriteTransformToDisk<double>(reverseTransform, outputTransform);
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
A new flags are added to BRAINSTransformConvert tool:
--outputPrecisionType

This flag can be set as "float" or "double", and it can work well with
other options like outputTransformType.

This patch is tested and works properly based on the last version of ITK
that includes updated transform file reader/writer filters.
The updated filters can convert their input transforms to the requested
output precision type automatically.

Testsuite is changed to add float precision tests. Number of tests are
increased from 63 to 125 and all of them are passed successfully.
"100% tests passed, 0 tests failed out of 125".

This patch can be merged safely.
