### PR TITLE
BUG: make BRAINSTools build independent of ANTS

### DIFF
--- a/BRAINSABC/brainseg/EMSegmentationFilter.hxx
+++ b/BRAINSABC/brainseg/EMSegmentationFilter.hxx
@@ -36,7 +36,9 @@
 #include "itkBRAINSROIAutoImageFilter.h"
 #include "BRAINSFitBSpline.h"
 #include "BRAINSFitUtils.h"
+#ifdef USE_ANTS
 #include "BRAINSFitSyN.h"
+#endif
 #include "BRAINSABCUtilities.h"
 #include "LLSBiasCorrector.h"
 


### PR DESCRIPTION
The BRAINSFitSyN.h header file uses some ANTs libraries; therefore,
it should not be included when ANTs build option is off.
