### PR TITLE
ENH: adding user-level option to set the metric seed

### DIFF
--- a/BRAINSCommonLib/BRAINSFitHelper.h
+++ b/BRAINSCommonLib/BRAINSFitHelper.h
@@ -159,6 +159,8 @@ public:
   itkGetConstMacro(ObserveIterations,        bool);
   itkSetMacro(UseROIBSpline, bool);
   itkGetConstMacro(UseROIBSpline, bool);
+  itkSetMacro(MetricSeed, int);
+  itkGetConstMacro(MetricSeed, int);
 
   const std::vector<GenericTransformType::Pointer> * GetGenericTransformListPtr()
   {
@@ -263,6 +265,7 @@ private:
   bool                                       m_ObserveIterations;
   std::string                                m_CostMetric;
   bool                                       m_UseROIBSpline;
+  int                                        m_MetricSeed;
   itk::Object::Pointer                       m_Helper;
   // DEBUG OPTION:
   int m_ForceMINumberOfThreads;
@@ -281,7 +284,18 @@ BRAINSFitHelper::SetupRegistration()
   //
   // set up cost metric
   typename TLocalCostMetric::Pointer localCostMetric = TLocalCostMetric::New();
-  localCostMetric->ReinitializeSeed(76926294);
+  // From ITK documentation: calling the method ReinitializeSeed() without
+  // arguments will use the clock from your machine in order to have a very
+  // random initialization of the seed. This will indeed increase the
+  // non-deterministic behavior of the metric.
+  if(this->m_MetricSeed != 0)
+    {
+    localCostMetric->ReinitializeSeed(this->m_MetricSeed);
+    }
+  else
+    {
+    localCostMetric->ReinitializeSeed();
+    }
   localCostMetric->SetInterpolator(localLinearInterpolator);
   localCostMetric->SetFixedImage(this->m_FixedVolume);
   localCostMetric->SetFixedImageRegion( this->m_FixedVolume->GetBufferedRegion() );

--- a/BRAINSFit/BRAINSFit.cxx
+++ b/BRAINSFit/BRAINSFit.cxx
@@ -473,6 +473,7 @@ int main(int argc, char *argv[])
     myHelper->SetDebugLevel(debugLevel);
     myHelper->SetCostMetric(costMetric);
     myHelper->SetUseROIBSpline(useROIBSpline);
+    myHelper->SetMetricSeed(metricSeed);
     if( debugLevel > 7 )
       {
       myHelper->PrintCommandLine(true, "BF");

--- a/BRAINSFit/BRAINSFit.xml
+++ b/BRAINSFit/BRAINSFit.xml
@@ -565,6 +565,15 @@
       <description>A file to write out final information report in CSV file: MetricName,MetricValue,FixedImageName,FixedMaskName,MovingImageName,MovingMaskName</description>
       <channel>output</channel>
     </file>
+
+    <integer>
+      <name>metricSeed</name>
+      <longflag>metricSeed</longflag>
+      <label>Image similarity metric seed</label>
+      <description>Seed value will be used to reinitialize the metric. To ensure consistent results, the same seed value should be used across runs. If the seed value is set to 0, the sampler will use the clock of your machine to initialize the metric, which will lead to a random initialization of the seed.</description>
+      <default>76926294</default>
+    </integer>
+
   </parameters>
 
 </executable>


### PR DESCRIPTION
This feature is valuable in evaluating the consistency of registration and its
sensitivity to the sample selection.
