### PR TITLE
WIP: BRAINSFit with Euler3D as the rigid transform

### DIFF
--- a/BRAINSCommonLib/BRAINSFitBSpline.h
+++ b/BRAINSCommonLib/BRAINSFitBSpline.h
@@ -12,7 +12,7 @@
 #if (ITK_VERSION_MAJOR < 4)
 #include "itkOptImageToImageMetric.h"
 #else
-#include "itkImageToImageMetric.h"
+#include "itkImageToImageMetricv4.h"
 #endif
 #include "genericRegistrationHelper.h"
 
@@ -28,7 +28,7 @@ typename BSplineTransformType::Pointer
 DoBSpline(typename BSplineTransformType::Pointer InitializerBsplineTransform,
           typename RegisterImageType::Pointer m_FixedVolume,
           typename RegisterImageType::Pointer m_MovingVolume,
-          typename itk::ImageToImageMetric<
+          typename itk::ImageToImageMetricv4<
             RegisterImageType, RegisterImageType>::Pointer CostMetricObject,
           const double m_MaxBSplineDisplacement,
           const float m_CostFunctionConvergenceFactor,

--- a/BRAINSCommonLib/BRAINSFitHelper.cxx
+++ b/BRAINSCommonLib/BRAINSFitHelper.cxx
@@ -4,13 +4,13 @@
 #include "BRAINSFitHelperTemplate.h"
 
 #include "genericRegistrationHelper.h"
-#include "itkNormalizedCorrelationImageToImageMetric.h"
-#include "itkMeanSquaresImageToImageMetric.h"
+#include "itkCorrelationImageToImageMetricv4.h"
+#include "itkMeanSquaresImageToImageMetricv4.h"
 #include "itkKullbackLeiblerCompareHistogramImageToImageMetric.h"
 #include "itkHistogramImageToImageMetric.h"
 #include "itkKappaStatisticImageToImageMetric.h"
 #include "itkMeanReciprocalSquareDifferenceImageToImageMetric.h"
-#include "itkMutualInformationHistogramImageToImageMetric.h"
+#include "itkJointHistogramMutualInformationImageToImageMetricv4.h"
 #include "itkGradientDifferenceImageToImageMetric.h"
 #include "itkCompareHistogramImageToImageMetric.h"
 #include "itkCorrelationCoefficientHistogramImageToImageMetric.h"
@@ -53,14 +53,14 @@ BRAINSFitHelper::BRAINSFitHelper() :
   m_OutputFixedVolumeROI(""),
   m_OutputMovingVolumeROI(""),
   m_PermitParameterVariation(0),
-  m_NumberOfSamples(500000),
+  m_NumberOfSamples(0), // normally this variable should NOT be used; however, it is kept for backward compatiblity.
+  m_SamplingPercentage(1), // instead or number of samples, sampling% should be used that is a number between 0 and 1.
   m_NumberOfHistogramBins(50),
   m_HistogramMatch(false),
   m_RemoveIntensityOutliers(0.00),
   m_NumberOfMatchPoints(10),
   m_NumberOfIterations(1, 1500),
   m_MaximumStepLength(0.2),
-  m_MinimumStepLength(1, 0.005),
   m_RelaxationFactor(0.5),
   m_TranslationScale(1000.0),
   m_ReproportionScale(1.0),
@@ -80,7 +80,7 @@ BRAINSFitHelper::BRAINSFitHelper() :
   // m_AccumulatedNumberOfIterationsForAllLevels(0),
   m_DebugLevel(0),
   m_CurrentGenericTransform(NULL),
-  m_GenericTransformList(0),
+  //m_GenericTransformList(0),
   m_DisplayDeformedImage(false),
   m_PromptUserAfterDisplay(false),
   m_FinalMetricValue(0.0),
@@ -88,11 +88,59 @@ BRAINSFitHelper::BRAINSFitHelper() :
   m_CostMetric("MMI"), // Default to Mattes Mutual Information Metric
   m_UseROIBSpline(false),
   m_Helper(NULL),
+  m_SamplingStrategy(AffineRegistrationType::NONE),
+  m_NormalizeInputImages(false),
   m_ForceMINumberOfThreads(-1)
 {
   m_SplineGridSize[0] = 14;
   m_SplineGridSize[1] = 10;
   m_SplineGridSize[2] = 12;
+}
+
+/*
+This function returns a normalized image with values between 0 and 1.
+HACK: parameters are hard coded but some of them should be passed by flags.
+*/
+template <typename ImageType>
+typename ImageType::Pointer
+NormalizeImage(typename ImageType::Pointer inputImage)
+{
+  typedef itk::Statistics::ImageToHistogramFilter<ImageType>   HistogramFilterType;
+  typedef typename HistogramFilterType::InputBooleanObjectType InputBooleanObjectType;
+  typedef typename HistogramFilterType::HistogramSizeType      HistogramSizeType;
+  typedef typename HistogramFilterType::HistogramType          HistogramType;
+
+  HistogramSizeType histogramSize( 1 );
+  histogramSize[0] = 256;
+
+  typename InputBooleanObjectType::Pointer autoMinMaxInputObject = InputBooleanObjectType::New();
+  autoMinMaxInputObject->Set( true );
+
+  typename HistogramFilterType::Pointer histogramFilter = HistogramFilterType::New();
+  histogramFilter->SetInput( inputImage );
+  histogramFilter->SetAutoMinimumMaximumInput( autoMinMaxInputObject );
+  histogramFilter->SetHistogramSize( histogramSize );
+  histogramFilter->SetMarginalScale( 10.0 );
+  histogramFilter->Update();
+
+  float lowerValue = histogramFilter->GetOutput()->Quantile( 0, 0 );
+  float upperValue = histogramFilter->GetOutput()->Quantile( 0, 1 );
+
+  typedef itk::IntensityWindowingImageFilter<ImageType, ImageType> IntensityWindowingImageFilterType;
+  typename IntensityWindowingImageFilterType::Pointer windowingFilter = IntensityWindowingImageFilterType::New();
+  windowingFilter->SetInput( inputImage );
+  windowingFilter->SetWindowMinimum( lowerValue );
+  windowingFilter->SetWindowMaximum( upperValue );
+  windowingFilter->SetOutputMinimum( 0 );
+  windowingFilter->SetOutputMaximum( 1 );
+  windowingFilter->Update();
+
+  typename ImageType::Pointer outputImage = NULL;
+  outputImage = windowingFilter->GetOutput();
+  outputImage->Update();
+  outputImage->DisconnectPipeline();
+
+  return outputImage;
 }
 
 void
@@ -101,15 +149,15 @@ BRAINSFitHelper::Update(void)
   // Do remove intensity outliers if requested
   if(  m_RemoveIntensityOutliers > vcl_numeric_limits<float>::epsilon() )
     {
-    this->m_FixedVolume = ClampNoisyTailsOfImage<FixedVolumeType, FixedBinaryVolumeType>(
+    this->m_FixedVolume = ClampNoisyTailsOfImage<FixedImageType, FixedBinaryVolumeType>(
         m_RemoveIntensityOutliers, this->m_FixedVolume.GetPointer(), this->m_FixedBinaryVolume.GetPointer() );
-    this->m_PreprocessedMovingVolume = ClampNoisyTailsOfImage<MovingVolumeType, MovingBinaryVolumeType>(
+    this->m_PreprocessedMovingVolume = ClampNoisyTailsOfImage<MovingImageType, MovingBinaryVolumeType>(
         m_RemoveIntensityOutliers, this->m_MovingVolume.GetPointer(), this->m_MovingBinaryVolume.GetPointer() );
       {
       if( this->m_DebugLevel > 9 )
         {
           {
-          typedef itk::ImageFileWriter<FixedVolumeType> WriterType;
+          typedef itk::ImageFileWriter<FixedImageType> WriterType;
           WriterType::Pointer writer = WriterType::New();
           writer->UseCompressionOn();
           writer->SetFileName("DEBUGNormalizedFixedVolume.nii.gz");
@@ -126,7 +174,7 @@ BRAINSFitHelper::Update(void)
             }
           }
           {
-          typedef itk::ImageFileWriter<MovingVolumeType> WriterType;
+          typedef itk::ImageFileWriter<MovingImageType> WriterType;
           WriterType::Pointer writer = WriterType::New();
           writer->UseCompressionOn();
           writer->SetFileName("DEBUGNormalizedMovingVolume.nii.gz");
@@ -153,7 +201,7 @@ BRAINSFitHelper::Update(void)
   // Do Histogram equalization on moving image if requested.
   if( m_HistogramMatch )
     {
-    typedef itk::OtsuHistogramMatchingImageFilter<FixedVolumeType, MovingVolumeType> HistogramMatchingFilterType;
+    typedef itk::OtsuHistogramMatchingImageFilter<FixedImageType, MovingImageType> HistogramMatchingFilterType;
     HistogramMatchingFilterType::Pointer histogramfilter = HistogramMatchingFilterType::New();
 
     // TODO:  Regina:  Write various histogram matching specializations and
@@ -186,7 +234,7 @@ BRAINSFitHelper::Update(void)
     this->m_PreprocessedMovingVolume = histogramfilter->GetOutput();
     if( this->m_DebugLevel > 5 )
       {
-      typedef itk::ImageFileWriter<MovingVolumeType> WriterType;
+      typedef itk::ImageFileWriter<MovingImageType> WriterType;
       WriterType::Pointer writer = WriterType::New();
       writer->UseCompressionOn();
       writer->SetFileName("DEBUGHISTOGRAMMATCHEDMOVING.nii.gz");
@@ -208,110 +256,62 @@ BRAINSFitHelper::Update(void)
     this->m_PreprocessedMovingVolume = this->m_MovingVolume;
     }
 
+  if( m_NormalizeInputImages )
+    {
+    this->m_FixedVolume = NormalizeImage< FixedImageType >( this->m_FixedVolume );
+    this->m_PreprocessedMovingVolume = NormalizeImage< MovingImageType >( this->m_PreprocessedMovingVolume );
+    }
+
+  const bool     gradientfilter = false;
+
+  GenericMetricType::Pointer metric;
   if( this->m_CostMetric == "MMI" )
     {
-    typedef COMMON_MMI_METRIC_TYPE<FixedVolumeType, MovingVolumeType> MetricType;
-    this->SetupRegistration<MetricType>();
+    typedef COMMON_MMI_METRIC_TYPE<FixedImageType, MovingImageType, FixedImageType, double> MIMetricType;
+    MIMetricType::Pointer mutualInformationMetric = MIMetricType::New();
+    mutualInformationMetric = mutualInformationMetric;
+    mutualInformationMetric->SetNumberOfHistogramBins( this->m_NumberOfHistogramBins );
+    mutualInformationMetric->SetUseMovingImageGradientFilter( gradientfilter );
+    mutualInformationMetric->SetUseFixedImageGradientFilter( gradientfilter );
+    mutualInformationMetric->SetUseFixedSampledPointSet( false );
+    metric = mutualInformationMetric;
 
-    MetricType::Pointer localCostMetric = this->GetCostMetric<MetricType>();
-    localCostMetric->SetNumberOfHistogramBins(this->m_NumberOfHistogramBins);
-    const bool UseCachingOfBSplineWeights = ( m_UseCachingOfBSplineWeightsMode == "ON" ) ? true : false;
-    localCostMetric->SetUseCachingOfBSplineWeights(UseCachingOfBSplineWeights);
-
-    this->RunRegistration<MetricType>();
+    this->SetupRegistration< MIMetricType >(metric);
+    this->RunRegistration< MIMetricType >();
     }
   else if( this->m_CostMetric == "MSE" )
     {
-    typedef itk::MeanSquaresImageToImageMetric<FixedVolumeType, MovingVolumeType> MetricType;
-    this->SetupRegistration<MetricType>();
-    this->RunRegistration<MetricType>();
+    typedef itk::MeanSquaresImageToImageMetricv4<FixedImageType, MovingImageType, FixedImageType, double> MSEMetricType;
+    MSEMetricType::Pointer meanSquareMetric = MSEMetricType::New();
+    meanSquareMetric = meanSquareMetric;
+    metric = meanSquareMetric;
+
+    this->SetupRegistration< MSEMetricType >(metric);
+    this->RunRegistration< MSEMetricType >();
     }
   else if( this->m_CostMetric == "NC" )
     {
-    typedef itk::NormalizedCorrelationImageToImageMetric<FixedVolumeType, MovingVolumeType> MetricType;
-    this->SetupRegistration<MetricType>();
-    this->RunRegistration<MetricType>();
-    }
-  // This requires additional machinery (training transform, etc) and hence
-  // isn't as easy to incorporate
-  // into the BRAINSFit framework.
-  /*else if(this->m_CostMetric == "KL")
-    {
-    typedef itk::KullbackLeiblerCompareHistogramImageToImageMetric<FixedVolumeType,MovingVolumeType> MetricType;
-    this->SetupRegistration<MetricType>();
-this->RunRegistration<MetricType>();
-    }*/
-  else if( this->m_CostMetric == "KS" )
-    {
-    if( this->m_HistogramMatch )
-      {
-      itkExceptionMacro(<< "The KS cost metric is not compatible with histogram matching.");
-      }
-    // This metric only works with binary images that it knows the value of.
-    // It defaults to 255, so we threshold the inputs to 255.
-    typedef itk::BinaryThresholdImageFilter<FixedVolumeType, FixedVolumeType> BinaryThresholdFixedVolumeType;
-    BinaryThresholdFixedVolumeType::Pointer binaryThresholdFixedVolume = BinaryThresholdFixedVolumeType::New();
-    binaryThresholdFixedVolume->SetInput(this->m_FixedVolume);
-    binaryThresholdFixedVolume->SetOutsideValue(0);
-    binaryThresholdFixedVolume->SetInsideValue(255);
-    binaryThresholdFixedVolume->SetLowerThreshold(1);
-    binaryThresholdFixedVolume->Update();
-    this->m_FixedVolume = binaryThresholdFixedVolume->GetOutput();
+    typedef itk::CorrelationImageToImageMetricv4<FixedImageType, MovingImageType, FixedImageType, double> corrMetricType;
+    corrMetricType::Pointer corrMetric = corrMetricType::New();
+    metric = corrMetric;
 
-    typedef itk::BinaryThresholdImageFilter<MovingVolumeType, MovingVolumeType> BinaryThresholdMovingVolumeType;
-    BinaryThresholdMovingVolumeType::Pointer binaryThresholdMovingVolume = BinaryThresholdMovingVolumeType::New();
-    binaryThresholdMovingVolume->SetInput(this->m_MovingVolume);
-    binaryThresholdMovingVolume->SetOutsideValue(0);
-    binaryThresholdMovingVolume->SetInsideValue(255);
-    binaryThresholdMovingVolume->SetLowerThreshold(1);
-    binaryThresholdMovingVolume->Update();
-    this->m_PreprocessedMovingVolume = binaryThresholdMovingVolume->GetOutput();
-
-    typedef itk::KappaStatisticImageToImageMetric<FixedVolumeType, MovingVolumeType> MetricType;
-    this->SetupRegistration<MetricType>();
-    this->RunRegistration<MetricType>();
-    }
-  else if( this->m_CostMetric == "MRSD" )
-    {
-    typedef itk::MeanReciprocalSquareDifferenceImageToImageMetric<FixedVolumeType, MovingVolumeType> MetricType;
-    this->SetupRegistration<MetricType>();
-    this->RunRegistration<MetricType>();
-    }
-  else if( this->m_CostMetric == "MIH" )
-    {
-    typedef itk::MutualInformationHistogramImageToImageMetric<FixedVolumeType, MovingVolumeType> MetricType;
-    this->SetupRegistration<MetricType>();
-    this->RunRegistration<MetricType>();
-    }
-  else if( this->m_CostMetric == "GD" )
-    {
-    typedef itk::GradientDifferenceImageToImageMetric<FixedVolumeType, MovingVolumeType> MetricType;
-    this->SetupRegistration<MetricType>();
-    this->RunRegistration<MetricType>();
-    }
-  else if( this->m_CostMetric == "CCH" )
-    {
-    typedef itk::CorrelationCoefficientHistogramImageToImageMetric<FixedVolumeType, MovingVolumeType> MetricType;
-    this->SetupRegistration<MetricType>();
-    this->RunRegistration<MetricType>();
+    this->SetupRegistration< corrMetricType >(metric);
+    this->RunRegistration< corrMetricType >();
     }
   else if( this->m_CostMetric == "MC" )
     {
-    typedef itk::MatchCardinalityImageToImageMetric<FixedVolumeType, MovingVolumeType> MetricType;
-    this->SetupRegistration<MetricType>();
-    this->RunRegistration<MetricType>();
-    }
-  else if( this->m_CostMetric == "MSEH" )
-    {
-    typedef itk::MeanSquaresHistogramImageToImageMetric<FixedVolumeType, MovingVolumeType> MetricType;
-    this->SetupRegistration<MetricType>();
-    this->RunRegistration<MetricType>();
-    }
-  else if( this->m_CostMetric == "NMIH" )
-    {
-    typedef itk::NormalizedMutualInformationHistogramImageToImageMetric<FixedVolumeType, MovingVolumeType> MetricType;
-    this->SetupRegistration<MetricType>();
-    this->RunRegistration<MetricType>();
+    typedef itk::JointHistogramMutualInformationImageToImageMetricv4<FixedImageType, MovingImageType, FixedImageType, double> MutualInformationMetricType;
+    MutualInformationMetricType::Pointer mutualInformationMetric = MutualInformationMetricType::New();
+    mutualInformationMetric = mutualInformationMetric;
+    mutualInformationMetric->SetNumberOfHistogramBins( this->m_NumberOfHistogramBins );
+    mutualInformationMetric->SetUseMovingImageGradientFilter( gradientfilter );
+    mutualInformationMetric->SetUseFixedImageGradientFilter( gradientfilter );
+    mutualInformationMetric->SetUseFixedSampledPointSet( false );
+    mutualInformationMetric->SetVarianceForJointPDFSmoothing( 1.0 );
+    metric = mutualInformationMetric;
+
+    this->SetupRegistration< MutualInformationMetricType >(metric);
+    this->RunRegistration< MutualInformationMetricType >();
     }
   else
     {
@@ -342,7 +342,7 @@ BRAINSFitHelper::PrintSelf(std::ostream & os, Indent indent) const
     {
     os << indent << "MovingBinaryVolume: IS NULL" << std::endl;
     }
-  os << indent << "NumberOfSamples:      " << this->m_NumberOfSamples << std::endl;
+  os << indent << "SamplingPercentage:      " << this->m_SamplingPercentage << std::endl;
 
   os << indent << "NumberOfIterations:    [";
   for( unsigned int q = 0; q < this->m_NumberOfIterations.size(); ++q )
@@ -352,12 +352,6 @@ BRAINSFitHelper::PrintSelf(std::ostream & os, Indent indent) const
   os << "]" << std::endl;
   os << indent << "NumberOfHistogramBins:" << this->m_NumberOfHistogramBins << std::endl;
   os << indent << "MaximumStepLength:    " << this->m_MaximumStepLength << std::endl;
-  os << indent << "MinimumStepLength:     [";
-  for( unsigned int q = 0; q < this->m_MinimumStepLength.size(); ++q )
-    {
-    os << this->m_MinimumStepLength[q] << " ";
-    }
-  os << "]" << std::endl;
   os << indent << "TransformType:     [";
   for( unsigned int q = 0; q < this->m_TransformType.size(); ++q )
     {
@@ -376,8 +370,6 @@ BRAINSFitHelper::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "MaskInferiorCutOffFromCenter:   " << this->m_MaskInferiorCutOffFromCenter << std::endl;
   os << indent << "ActualNumberOfIterations:       " << this->m_ActualNumberOfIterations << std::endl;
   os << indent << "PermittedNumberOfIterations:       " << this->m_PermittedNumberOfIterations << std::endl;
-  // os << indent << "AccumulatedNumberOfIterationsForAllLevels: " <<
-  // this->m_AccumulatedNumberOfIterationsForAllLevels << std::endl;
 
   os << indent << "SplineGridSize:     [";
   for( unsigned int q = 0; q < this->m_SplineGridSize.size(); ++q )
@@ -420,7 +412,7 @@ BRAINSFitHelper::PrintCommandLine(const bool dumpTempVolumes, const std::string 
   if( dumpTempVolumes == true )
     {
       {
-      typedef itk::ImageFileWriter<FixedVolumeType> WriterType;
+      typedef itk::ImageFileWriter<FixedImageType> WriterType;
       WriterType::Pointer writer = WriterType::New();
       writer->UseCompressionOn();
       writer->SetFileName(fixedVolumeString);
@@ -437,7 +429,7 @@ BRAINSFitHelper::PrintCommandLine(const bool dumpTempVolumes, const std::string 
         }
       }
       {
-      typedef itk::ImageFileWriter<MovingVolumeType> WriterType;
+      typedef itk::ImageFileWriter<MovingImageType> WriterType;
       WriterType::Pointer writer = WriterType::New();
       writer->UseCompressionOn();
       writer->SetFileName(movingVolumeString);
@@ -490,7 +482,7 @@ BRAINSFitHelper::PrintCommandLine(const bool dumpTempVolumes, const std::string 
       oss << "--maskProcessingMode ROI "   << "  \\" << std::endl;
       }
     }
-  oss << "--numberOfSamples " << this->m_NumberOfSamples  << "  \\" << std::endl;
+  oss << "--samplingPercentage " << this->m_SamplingPercentage  << "  \\" << std::endl;
 
   oss << "--numberOfIterations ";
   for( unsigned int q = 0; q < this->m_NumberOfIterations.size(); ++q )
@@ -504,15 +496,6 @@ BRAINSFitHelper::PrintCommandLine(const bool dumpTempVolumes, const std::string 
   oss << " \\" << std::endl;
   oss << "--numberOfHistogramBins " << this->m_NumberOfHistogramBins  << "  \\" << std::endl;
   oss << "--maximumStepLength " << this->m_MaximumStepLength  << "  \\" << std::endl;
-  oss << "--minimumStepLength ";
-  for( unsigned int q = 0; q < this->m_MinimumStepLength.size(); ++q )
-    {
-    oss << this->m_MinimumStepLength[q];
-    if( q < this->m_MinimumStepLength.size() - 1 )
-      {
-      oss << ",";
-      }
-    }
   oss << " \\" << std::endl;
   oss << "--transformType ";
   for( unsigned int q = 0; q < this->m_TransformType.size(); ++q )

--- a/BRAINSCommonLib/BRAINSFitHelperTemplate.h
+++ b/BRAINSCommonLib/BRAINSFitHelperTemplate.h
@@ -33,6 +33,9 @@
 
 #include "itkFindCenterOfBrainFilter.h"
 
+#include "itkBSplineTransform.h"
+#include "itkBSplineTransformParametersAdaptor.h"
+
 // TODO:  This needs to be moved to the top, and header files moved to this
 // header where needed.
 #include "BRAINSFitBSpline.h"
@@ -76,16 +79,33 @@ public:
   typedef typename MovingImageType::ConstPointer MovingImageConstPointer;
   typedef typename MovingImageType::Pointer      MovingImagePointer;
 
-  typedef typename itk::ImageToImageMetric<FixedImageType, MovingImageType> MetricType;
+  typedef typename itk::ImageToImageMetricv4
+                      <FixedImageType,
+                      MovingImageType,
+                      FixedImageType,
+                      double> MetricType;
 
   /** Constants for the image dimensions */
   itkStaticConstMacro(FixedImageDimension, unsigned int, FixedImageType::ImageDimension);
   itkStaticConstMacro(MovingImageDimension, unsigned int, MovingImageType::ImageDimension);
 
+  //typedef itk::CompositeTransform<double, MovingImageDimension>     CompositeTransformType;
+  typedef typename CompositeTransformType::Pointer                  CompositeTransformPointer;
+  typedef IdentityTransform<double, MovingImageDimension>           IdentityTransformType;
+
   typedef SpatialObject<itkGetStaticConstMacro(FixedImageDimension)>  FixedBinaryVolumeType;
   typedef SpatialObject<itkGetStaticConstMacro(MovingImageDimension)> MovingBinaryVolumeType;
   typedef typename FixedBinaryVolumeType::Pointer                     FixedBinaryVolumePointer;
   typedef typename MovingBinaryVolumeType::Pointer                    MovingBinaryVolumePointer;
+
+  typedef itk::TranslationTransform<double, MovingImageDimension>                               TranslationTransformType;
+  typedef itk::AffineTransform<double, MovingImageDimension>                                    AffineTransformType;
+  typedef itk::ScalableAffineTransform<double, MovingImageDimension>                            ScalableAffineTransformType;
+  typedef itk::ImageRegistrationMethodv4<FixedImageType, MovingImageType, AffineTransformType>  AffineRegistrationType;
+  typedef typename AffineRegistrationType::MetricSamplingStrategyType                           SamplingStrategyType;
+
+  typedef typename AffineTransformType::Superclass                                   MatrixOffsetTransformBaseType;
+  typedef typename MatrixOffsetTransformBaseType::Pointer                            MatrixOffsetTransformBasePointer;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -122,14 +142,13 @@ public:
     WINDOWSINC_INTERP = 1
     } InterpolationType;
 
-  itkSetMacro(NumberOfSamples,        unsigned int);
-  itkGetConstMacro(NumberOfSamples,        unsigned int);
+  itkSetMacro(SamplingPercentage,            double);
+  itkGetConstMacro(SamplingPercentage,       double);
   itkSetMacro(NumberOfHistogramBins,         unsigned int);
-  itkGetConstMacro(NumberOfHistogramBins,         unsigned int);
+  itkGetConstMacro(NumberOfHistogramBins,    unsigned int);
   itkSetMacro(NumberOfMatchPoints,           unsigned int);
   itkGetConstMacro(NumberOfMatchPoints,           unsigned int);
   VECTORitkSetMacro(NumberOfIterations,   std::vector<int> /**/);
-  VECTORitkSetMacro(MinimumStepLength, std::vector<double> );
   itkSetMacro(MaximumStepLength,             double);
   itkGetConstMacro(MaximumStepLength,             double);
   itkSetMacro(RelaxationFactor,              double);
@@ -154,8 +173,8 @@ public:
   itkGetConstMacro(UseExplicitPDFDerivativesMode, std::string);
   itkSetMacro(MaskInferiorCutOffFromCenter, double);
   itkGetConstMacro(MaskInferiorCutOffFromCenter, double);
-  itkSetMacro(CurrentGenericTransform,  GenericTransformType::Pointer);
-  itkGetConstMacro(CurrentGenericTransform,  GenericTransformType::Pointer);
+  itkSetMacro(CurrentGenericTransform,  CompositeTransformPointer);
+  itkGetConstMacro(CurrentGenericTransform,  CompositeTransformPointer);
 
   // cppcheck-suppress unusedFunction
   VECTORitkSetMacro(TransformType, std::vector<std::string> );
@@ -178,10 +197,10 @@ public:
   itkSetMacro(UseROIBSpline, bool);
   itkGetConstMacro(UseROIBSpline, bool);
 
-  const std::vector<GenericTransformType::Pointer> * GetGenericTransformListPtr()
-  {
-    return &m_GenericTransformList;
-  }
+//  const std::vector<GenericTransformType::Pointer> * GetGenericTransformListPtr()
+//  {
+//    return &m_GenericTransformList;
+//  }
 
   /** Method to set the Permission to vary by level  */
   void SetPermitParameterVariation(std::vector<int> perms)
@@ -203,6 +222,9 @@ public:
 
   itkSetMacro(ForceMINumberOfThreads, int);
   itkGetConstMacro(ForceMINumberOfThreads, int);
+
+  itkSetMacro(SamplingStrategy,SamplingStrategyType);
+  itkGetConstMacro(SamplingStrategy,SamplingStrategyType);
 protected:
   BRAINSFitHelperTemplate();
   virtual ~BRAINSFitHelperTemplate()
@@ -215,13 +237,17 @@ protected:
     * the registration. */
   void  GenerateData();
 
+  //typename AffineTransformType::Pointer CollapseLinearTransforms(const CompositeTransformType * compositeTransform);
+  template<class TransformType>
+  typename TransformType::Pointer
+  CollapseLinearTransforms(const CompositeTransformType * compositeTransform);
+
   /** instantiate and call the Registration Helper */
   template <class TransformType,
             class OptimizerType,
             class MetricType>
   void FitCommonCode(int numberOfIterations,
-                     double minimumStepLength,
-                     typename TransformType::Pointer & initialITKTransform);
+                     typename CompositeTransformType::Pointer & initialITKTransform);
 private:
 
   BRAINSFitHelperTemplate(const Self &); // purposely not implemented
@@ -235,7 +261,7 @@ private:
   std::string               m_OutputFixedVolumeROI;
   std::string               m_OutputMovingVolumeROI;
 
-  unsigned int m_NumberOfSamples;
+  double       m_SamplingPercentage;
   unsigned int m_NumberOfHistogramBins;
   bool         m_HistogramMatch;
   float        m_RemoveIntensityOutliers;
@@ -244,7 +270,6 @@ private:
   // TODO:  Would be better to have unsigned int
   std::vector<int>         m_NumberOfIterations;
   double                   m_MaximumStepLength;
-  std::vector<double>      m_MinimumStepLength;
   double                   m_RelaxationFactor;
   double                   m_TranslationScale;
   double                   m_ReproportionScale;
@@ -260,17 +285,17 @@ private:
   double                   m_MaxBSplineDisplacement;
   unsigned int             m_ActualNumberOfIterations;
   unsigned int             m_PermittedNumberOfIterations;
-  // unsigned int             m_AccumulatedNumberOfIterationsForAllLevels;
   unsigned int                               m_DebugLevel;
-  GenericTransformType::Pointer              m_CurrentGenericTransform;
-  std::vector<GenericTransformType::Pointer> m_GenericTransformList;
+  CompositeTransformPointer                  m_CurrentGenericTransform;
+  //std::vector<GenericTransformType::Pointer> m_GenericTransformList;
   bool                                       m_DisplayDeformedImage;
   bool                                       m_PromptUserAfterDisplay;
   double                                     m_FinalMetricValue;
   bool                                       m_ObserveIterations;
   typename MetricType::Pointer               m_CostMetricObject;
-  bool             m_UseROIBSpline;
-  std::vector<int> m_PermitParameterVariation;
+  bool                                       m_UseROIBSpline;
+  std::vector<int>                           m_PermitParameterVariation;
+  SamplingStrategyType                       m_SamplingStrategy;
   // DEBUG OPTION:
   int m_ForceMINumberOfThreads;
 };  // end BRAINSFitHelperTemplate class

--- a/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
+++ b/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
@@ -11,6 +11,7 @@
 #include "itkOtsuHistogramMatchingImageFilter.h"
 #include <fstream>
 #include "BRAINSFitHelperTemplate.h"
+#include "itkConjugateGradientLineSearchOptimizerv4.h"
 
 #include "itkLabelObject.h"
 #include "itkStatisticsLabelObject.h"
@@ -139,11 +140,10 @@ DoCenteredInitialization( typename FixedImageType::Pointer & orientedFixedVolume
   if( initializeTransformMode == "useGeometryAlign" )
     {
     // useGeometryAlign assumes objects are center in field of view, with
-    // different
+    // different geometrical center
     typedef itk::CenteredTransformInitializer<TransformType, FixedImageType,
                                               MovingImageType> OrdinaryInitializerType;
-    typename OrdinaryInitializerType::Pointer CenteredInitializer =
-      OrdinaryInitializerType::New();
+    typename OrdinaryInitializerType::Pointer CenteredInitializer = OrdinaryInitializerType::New();
 
     CenteredInitializer->SetFixedImage(orientedFixedVolume);
     CenteredInitializer->SetMovingImage(orientedMovingVolume);
@@ -185,8 +185,7 @@ DoCenteredInitialization( typename FixedImageType::Pointer & orientedFixedVolume
     mask2movingCast->SetInput(tempOutputMovingVolumeROI);
     mask2movingCast->Update();
 
-    typename SpecificInitializerType::Pointer CenteredInitializer =
-      SpecificInitializerType::New();
+    typename SpecificInitializerType::Pointer CenteredInitializer = SpecificInitializerType::New();
 
     CenteredInitializer->SetFixedImage(mask2fixedCast->GetOutput() );
     CenteredInitializer->SetMovingImage(mask2movingCast->GetOutput() );
@@ -206,10 +205,8 @@ DoCenteredInitialization( typename FixedImageType::Pointer & orientedFixedVolume
     // GetCenterOfBrain<MovingImageType>(orientedMovingVolume);
     //     typename FixedImageType::PointType fixedCenter
     // GetCenterOfBrain<FixedImageType>(orientedFixedVolume);
-    typedef typename itk::FindCenterOfBrainFilter<MovingImageType>
-      MovingFindCenterFilter;
-    typename MovingFindCenterFilter::Pointer movingFindCenter =
-      MovingFindCenterFilter::New();
+    typedef typename itk::FindCenterOfBrainFilter<MovingImageType> MovingFindCenterFilter;
+    typename MovingFindCenterFilter::Pointer movingFindCenter = MovingFindCenterFilter::New();
     movingFindCenter->SetInput(orientedMovingVolume);
     if( movingMask.IsNotNull() )
       {
@@ -238,10 +235,8 @@ DoCenteredInitialization( typename FixedImageType::Pointer & orientedFixedVolume
       movingMask = p;
       }
 
-    typedef typename itk::FindCenterOfBrainFilter<FixedImageType>
-      FixedFindCenterFilter;
-    typename FixedFindCenterFilter::Pointer fixedFindCenter =
-      FixedFindCenterFilter::New();
+    typedef typename itk::FindCenterOfBrainFilter<FixedImageType> FixedFindCenterFilter;
+    typename FixedFindCenterFilter::Pointer fixedFindCenter = FixedFindCenterFilter::New();
     fixedFindCenter->SetInput(orientedFixedVolume);
     if( fixedMask.IsNotNull() )
       {
@@ -290,18 +285,19 @@ DoCenteredInitialization( typename FixedImageType::Pointer & orientedFixedVolume
     bestEulerAngles3D->SetCenter(rotationCenter);
     bestEulerAngles3D->SetTranslation(translationVector);
 
-    typedef itk::Euler3DTransform<double> EulerAngle3DTransformType;
     typename EulerAngle3DTransformType::Pointer currentEulerAngles3D = EulerAngle3DTransformType::New();
     currentEulerAngles3D->SetCenter(rotationCenter);
     currentEulerAngles3D->SetTranslation(translationVector);
 
-    CostMetricObject->SetTransform(currentEulerAngles3D);
+    CostMetricObject->SetMovingTransform(currentEulerAngles3D);
     CostMetricObject->Initialize();
     // void QuickSampleParameterSpace(void)
       {
       currentEulerAngles3D->SetRotation(0, 0, 0);
       // Initialize with current guess;
-      double max_cc = CostMetricObject->GetValue( currentEulerAngles3D->GetParameters() );
+      //double max_cc = CostMetricObject->GetValue( currentEulerAngles3D->GetParameters() );
+      double max_cc = CostMetricObject->GetValue();
+
       // rough search in neighborhood.
       const double one_degree = 1.0F * vnl_math::pi / 180.0F;
       const double HAStepSize = 3.0 * one_degree;
@@ -315,7 +311,8 @@ DoCenteredInitialization( typename FixedImageType::Pointer & orientedFixedVolume
           for( double PA = -PARange * one_degree; PA <= PARange * one_degree; PA += PAStepSize )
             {
             currentEulerAngles3D->SetRotation(PA, 0, HA);
-            const double current_cc = CostMetricObject->GetValue( currentEulerAngles3D->GetParameters() );
+            //const double current_cc = CostMetricObject->GetValue( currentEulerAngles3D->GetParameters() );
+            const double current_cc = CostMetricObject->GetValue();
             if( current_cc < max_cc )
               {
               max_cc = current_cc;
@@ -399,6 +396,8 @@ DoCenteredInitialization( typename FixedImageType::Pointer & orientedFixedVolume
         }
 #endif
       }
+    // --------- There is no more need to convert Euler3D to versorRigid3D ------------------
+    /*
     typename VersorRigid3DTransformType::Pointer quickSetVersor = VersorRigid3DTransformType::New();
     quickSetVersor->SetCenter( bestEulerAngles3D->GetCenter() );
     quickSetVersor->SetTranslation( bestEulerAngles3D->GetTranslation() );
@@ -407,6 +406,7 @@ DoCenteredInitialization( typename FixedImageType::Pointer & orientedFixedVolume
       localRotation.Set( bestEulerAngles3D->GetMatrix() );
       quickSetVersor->SetRotation(localRotation);
       }
+    */
 #ifdef DEBUGGING_PRINT_IMAGES
       {
       typedef itk::ResampleImageFilter<FixedImageType, MovingImageType, double> ResampleFilterType;
@@ -461,28 +461,22 @@ DoCenteredInitialization( typename FixedImageType::Pointer & orientedFixedVolume
         }
       }
 #endif
-    AssignRigid::AssignConvertedTransform( initialITKTransform, quickSetVersor.GetPointer() );
+    // AssignRigid::AssignConvertedTransform( initialITKTransform, quickSetVersor.GetPointer() );
+    AssignRigid::AssignConvertedTransform( initialITKTransform, bestEulerAngles3D.GetPointer() );
     }
   else if( initializeTransformMode == "useMomentsAlign" )
     {
     // useMomentsAlign assumes that the structures being registered have same
-    // amount
-    // of mass approximately uniformly distributed.
-    typename SpecificInitializerType::Pointer CenteredInitializer =
-      SpecificInitializerType::New();
+    // amount of mass approximately uniformly distributed.
+    typename SpecificInitializerType::Pointer CenteredInitializer = SpecificInitializerType::New();
 
     CenteredInitializer->SetFixedImage(orientedFixedVolume);
     CenteredInitializer->SetMovingImage(orientedMovingVolume);
     CenteredInitializer->SetTransform(initialITKTransform);
-    CenteredInitializer->MomentsOn();                    // Use intensity center
-                                                         // of
-    // mass
-
+    CenteredInitializer->MomentsOn();   // Use intensity center of mass
     CenteredInitializer->InitializeTransform();
     }
-  else                     // can't happen unless an unimplemented CLP option
-                           // was
-  // added:
+  else                     // can't happen unless an unimplemented CLP option was added:
     {
     itkGenericExceptionMacro(<< "FAILURE:  Improper mode for initializeTransformMode: "
                              << initializeTransformMode);
@@ -502,14 +496,13 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::BRAINSFitHelperTemplat
   m_MovingBinaryVolume(NULL),
   m_OutputFixedVolumeROI(""),
   m_OutputMovingVolumeROI(""),
-  m_NumberOfSamples(500000),
+  m_SamplingPercentage(1),
   m_NumberOfHistogramBins(50),
   m_HistogramMatch(false),
   m_RemoveIntensityOutliers(0.00),
   m_NumberOfMatchPoints(10),
   m_NumberOfIterations(1, 1500),
   m_MaximumStepLength(0.2),
-  m_MinimumStepLength(1, 0.005),
   m_RelaxationFactor(0.5),
   m_TranslationScale(1000.0),
   m_ReproportionScale(1.0),
@@ -525,10 +518,8 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::BRAINSFitHelperTemplat
   m_MaxBSplineDisplacement(0.0),
   m_ActualNumberOfIterations(0),
   m_PermittedNumberOfIterations(0),
-  // m_AccumulatedNumberOfIterationsForAllLevels(0),
   m_DebugLevel(0),
   m_CurrentGenericTransform(NULL),
-  m_GenericTransformList(0),
   m_DisplayDeformedImage(false),
   m_PromptUserAfterDisplay(false),
   m_FinalMetricValue(0.0),
@@ -536,6 +527,7 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::BRAINSFitHelperTemplat
   m_CostMetricObject(NULL),
   m_UseROIBSpline(0),
   m_PermitParameterVariation(0),
+  m_SamplingStrategy(AffineRegistrationType::NONE),
   m_ForceMINumberOfThreads(-1)
 {
   m_SplineGridSize[0] = 14;
@@ -544,13 +536,82 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::BRAINSFitHelperTemplat
 }
 
 template <class FixedImageType, class MovingImageType>
+template<class TransformType>
+typename TransformType::Pointer
+BRAINSFitHelperTemplate<FixedImageType, MovingImageType>
+::CollapseLinearTransforms(const CompositeTransformType * compositeTransform)
+{
+typename TransformType::Pointer totalTransform = TransformType::New();
+typename ScalableAffineTransformType::Pointer affineComposer = ScalableAffineTransformType::New();
+for( unsigned int n = 0; n < compositeTransform->GetNumberOfTransforms(); n++ )
+  {
+  typename GenericTransformType::Pointer transform = compositeTransform->GetNthTransform( n );
+  typename MatrixOffsetTransformBaseType::ConstPointer matrixOffsetTransform =
+                                                        dynamic_cast<MatrixOffsetTransformBaseType * const>( transform.GetPointer() );
+  std::string nthTransformType = transform->GetNameOfClass();
+  // ScaleVersor transform cannot be updated, so we update that indirectly using a scalable affine helper transform.
+  if( nthTransformType == "ScaleVersor3DTransform" /*|| nthTransformType == "ScaleSkewVersor3DTransform"*/ )
+    {
+    typename ScalableAffineTransformType::Pointer affineHelperTransform = ScalableAffineTransformType::New();
+    affineHelperTransform->SetMatrix( matrixOffsetTransform->GetMatrix() );
+    affineHelperTransform->SetOffset( matrixOffsetTransform->GetOffset() );
+    affineComposer->Compose( affineHelperTransform, true );
+
+    if( affineComposer.IsNotNull() )
+      {
+      typedef itk::Matrix<double, 3, 3>                Matrix3D;
+      typedef itk::Versor<double>                      VersorType;
+      typedef typename AffineTransformType::MatrixType MatrixType;
+
+      Matrix3D   NonOrthog = affineComposer->GetMatrix();
+      Matrix3D   Orthog( AssignRigid::orthogonalize(NonOrthog) );
+      MatrixType rotator;
+      rotator.operator=(Orthog);
+      VersorType versor;
+      versor.Set(rotator);
+
+      typename ScaleVersor3DTransformType::Pointer ScaleVersorTransform = ScaleVersor3DTransformType::New();
+      ScaleVersorTransform->SetIdentity();
+      ScaleVersorTransform->SetCenter( affineComposer->GetCenter() );
+      ScaleVersorTransform->SetRotation(versor);
+      ScaleVersorTransform->SetScale( affineComposer->GetScale() );
+      ScaleVersorTransform->SetTranslation( affineComposer->GetTranslation() );
+      if(ScaleVersorTransform.IsNotNull())
+        {
+        totalTransform->SetFixedParameters(ScaleVersorTransform->GetFixedParameters());
+        totalTransform->SetParameters(ScaleVersorTransform->GetParameters());
+        }
+      else
+        {
+        itkGenericExceptionMacro(<<"Failed to collapse linear transforms to ScaleVersoreD type.");
+        }
+      }
+    }
+  else
+    {
+    typename TransformType::Pointer nthTransform = TransformType::New();
+    nthTransform->SetMatrix( matrixOffsetTransform->GetMatrix() );
+    nthTransform->SetOffset( matrixOffsetTransform->GetOffset() );
+    totalTransform->Compose( nthTransform, true );
+    }
+  }
+typename TransformType::MatrixType matrix = totalTransform->GetMatrix();
+typename TransformType::OffsetType offset = totalTransform->GetOffset();
+std::cout << std::endl << "Matrix = " << std::endl << matrix << std::endl;
+std::cout << "Offset = " << offset << std::endl << std::endl;
+// DEBUG
+//  std::cout << "========total Composer" << std::endl;
+//  totalTransform->Print(std::cout);
+////////
+return totalTransform;
+}
+
+template <class FixedImageType, class MovingImageType>
 template <class TransformType, class OptimizerType, class MetricType>
 void
 BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::FitCommonCode(
   int numberOfIterations,
-  double minimumStepLength,
-  typename TransformType::Pointer &
-  initialITKTransform)
+  typename CompositeTransformType::Pointer & initialITKTransform)
 {
   // FitCommonCode
   typedef typename itk::MultiModal3DMutualRegistrationHelper
@@ -564,18 +625,11 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::FitCommonCode(
   appMutualRegistration = MultiModal3DMutualRegistrationHelperType::New();
 
   appMutualRegistration->SetNumberOfHistogramBins(m_NumberOfHistogramBins);
-
   appMutualRegistration->SetNumberOfIterations( numberOfIterations);
-
-  // TODO:  What do the following two lines really accomplish
-  // debug parameter, suppressed from command line
-  const bool initialTransformPassThru(false);
-  appMutualRegistration->SetInitialTransformPassThruFlag( initialTransformPassThru );
   appMutualRegistration->SetPermitParameterVariation( m_PermitParameterVariation );
-  appMutualRegistration->SetNumberOfSamples( m_NumberOfSamples );
+  appMutualRegistration->SetSamplingPercentage(m_SamplingPercentage);
   appMutualRegistration->SetRelaxationFactor( m_RelaxationFactor );
   appMutualRegistration->SetMaximumStepLength( m_MaximumStepLength );
-  appMutualRegistration->SetMinimumStepLength( minimumStepLength );
   appMutualRegistration->SetTranslationScale( m_TranslationScale );
   appMutualRegistration->SetReproportionScale( m_ReproportionScale );
   appMutualRegistration->SetSkewScale( m_SkewScale );
@@ -588,10 +642,11 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::FitCommonCode(
 
   appMutualRegistration->SetBackgroundFillValue(   m_BackgroundFillValue   );
 
-  appMutualRegistration->SetInitialTransform( initialITKTransform );
+  appMutualRegistration->SetInitialTransform( initialITKTransform.GetPointer() );
   appMutualRegistration->SetDisplayDeformedImage(m_DisplayDeformedImage);
   appMutualRegistration->SetPromptUserAfterDisplay(m_PromptUserAfterDisplay);
   appMutualRegistration->SetObserveIterations(m_ObserveIterations);
+  appMutualRegistration->SetSamplingStrategy(m_SamplingStrategy);
   /*
    *  At this point appMutualRegistration should be all set to make
    *  an itk pipeline class templated in TransformType etc.
@@ -600,19 +655,22 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::FitCommonCode(
   // initialize the interconnects between components
   appMutualRegistration->Initialize();
 
-  typename TransformType::Pointer finalTransform;
+  typename CompositeTransformType::Pointer finalTransform;
+  //typename TransformType::Pointer finalTransform;
   try
     {
     appMutualRegistration->Update();
-    finalTransform = appMutualRegistration->GetTransform();
+    finalTransform = appMutualRegistration->GetTransform(); // finalTransform is a composite transform
+    // DEBUG
+    //std::cout << "final transform: " << std::endl;
+    //finalTransform->Print(std::cout);
+    ////////
 
     // Find the metric value (It is needed when logFileReport flag is ON).
     //this->m_FinalMetricValue = appMutualRegistration->GetFinalMetricValue();
 
     this->m_ActualNumberOfIterations = appMutualRegistration->GetActualNumberOfIterations();
     this->m_PermittedNumberOfIterations = numberOfIterations;
-    // this->m_AccumulatedNumberOfIterationsForAllLevels +=
-    // appMutualRegistration->GetActualNumberOfIterations();
     }
   catch( itk::ExceptionObject& err )
     {
@@ -621,48 +679,53 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::FitCommonCode(
     }
 
   // Put the transform on the CurrentTransformList
-  // Initialize next level of transformations with previous transform
-  // result
-  this->m_CurrentGenericTransform = finalTransform;
+  // Initialize next level of transformations with previous transform result
+  this->m_CurrentGenericTransform->ClearTransformQueue(); // the finalTransform already has the ininitial transforms of
+                                                          // previous levels, so the generic tranform queue should be claeared.
+  if( finalTransform->IsLinear() )
+    {
+    std::cout << "Collapse linear transforms togheter to have just one linear transform ..." << std::endl;
+    std::string frontTransformType = finalTransform->GetFrontTransform()->GetNameOfClass();
+    // ScaleSkewVersor3DTransform transform cannot be updated, so it's not collapsable.
+    // Therefore, we have to write that to the disk as an Affine transform type.
+    // TODO: we should be able to write this transform as it is.
+    if( frontTransformType == "ScaleSkewVersor3DTransform" )
+      {
+      this->m_CurrentGenericTransform->AddTransform( CollapseLinearTransforms<AffineTransformType>( finalTransform ) );
+      }
+    else
+      {
+      this->m_CurrentGenericTransform->AddTransform( CollapseLinearTransforms<TransformType>( finalTransform ) );
+      }
+    }
+  else
+    {
+    typename CompositeTransformType::Pointer compToAdd;
+    typename CompositeTransformType::ConstPointer compXfrm =
+                              dynamic_cast<const CompositeTransformType *>( finalTransform.GetPointer() );
+    if( compXfrm.IsNotNull() )
+      {
+      compToAdd = compXfrm->Clone();
+      this->m_CurrentGenericTransform = compToAdd;
+      }
+    else
+      {
+      itkExceptionMacro(<< "The registration output composite transform is a NULL transform.");
+      }
+    }
 }
 
 template <class FixedImageType, class MovingImageType>
 void
 BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
 {
-  typedef COMMON_MMI_METRIC_TYPE<FixedImageType, MovingImageType> MattesMutualInformationMetricType;
-  unsigned currentTransformId = 0;
-
-  if( std::string(this->m_InitializeTransformMode) != "Off" )
-    {
-    m_GenericTransformList.resize(m_TransformType.size() + 1);
-    }
-  else
-    {
-    m_GenericTransformList.resize( m_TransformType.size() );
-    }
+  typedef itk::ConjugateGradientLineSearchOptimizerv4Template<double>  OptimizerType;
 
   if( this->m_DebugLevel > 3 )
     {
     this->PrintSelf(std::cout, 3);
     }
-  std::vector<double> localMinimumStepLength( m_TransformType.size() );
-  if( m_MinimumStepLength.size() != m_TransformType.size() )
-    {
-    if( m_MinimumStepLength.size() != 1 )
-      {
-      itkGenericExceptionMacro(<< "ERROR:  Wrong number of parameters for MinimumStepLength."
-                               << "It either needs to be 1 or the same size as TransformType.");
-      }
-    for( unsigned int q = 0; q < m_TransformType.size(); ++q )
-      {
-      localMinimumStepLength[q] = m_MinimumStepLength[0];
-      }
-    }
-  else
-    {
-    localMinimumStepLength = m_MinimumStepLength;
-    }
+
   std::vector<int> localNumberOfIterations( m_TransformType.size() );
   if( m_NumberOfIterations.size() != m_TransformType.size() )
     {
@@ -693,60 +756,62 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
     }
 
   // Initialize Transforms
-  if( localInitializeTransformMode != "Off" )
-  // Use CenteredVersorTranformInitializer
+  // Note that we don't want to estimate initialization if initial moving transform is provided already.
+  if( m_CurrentGenericTransform.IsNull() && localInitializeTransformMode != "Off" )
+    // Use CenteredTranformInitializer (Note that previously "CenteredVersorTranformInitializer" wase used for the versorRigid3D transform).
     {
-    typedef VersorRigid3DTransformType TransformType;
+    // typedef VersorRigid3DTransformType TransformType;
+    typedef itk::Euler3DTransform<double>         TransformType; // use Euler3D instead of VersorRigid3D as ITKv4
+                                                                 // still does not have suitable optimizers for versor transforms.
+
     std::cout << "Initializing transform with " << localInitializeTransformMode << std::endl;
-    typedef itk::CenteredVersorTransformInitializer<FixedImageType,
-                                                    MovingImageType> InitializerType;
+    // typedef itk::CenteredVersorTransformInitializer<FixedImageType, MovingImageType> InitializerType;
+    typedef itk::CenteredTransformInitializer<TransformType, FixedImageType, MovingImageType> InitializerType;
 
     TransformType::Pointer initialITKTransform =
       DoCenteredInitialization<FixedImageType, MovingImageType,
-                               TransformType, InitializerType, MetricType>(
-        m_FixedVolume,
-        m_MovingVolume,
-        m_FixedBinaryVolume,
-        m_MovingBinaryVolume,
-        localInitializeTransformMode, this->m_CostMetricObject);
-    m_CurrentGenericTransform = initialITKTransform.GetPointer();
-    localInitializeTransformMode = "Off";        // Now reset to Off once
-    // initialization is done.
+                               TransformType, InitializerType, MetricType>( m_FixedVolume,
+                                                                            m_MovingVolume,
+                                                                            m_FixedBinaryVolume,
+                                                                            m_MovingBinaryVolume,
+                                                                            localInitializeTransformMode, this->m_CostMetricObject );
+
+    // The currentGenericTransform will be initialized by estimated initial transform.
+    this->m_CurrentGenericTransform = CompositeTransformType::New();
+    this->m_CurrentGenericTransform->AddTransform( initialITKTransform.GetPointer() );
+
+    localInitializeTransformMode = "Off";  // Now reset to Off once initialization is done.
 
     // Now if necessary clip the images based on m_MaskInferiorCutOffFromCenter
-    DoCenteredTransformMaskClipping<TransformType,
-                                    FixedImageType::ImageDimension>(
-      m_FixedBinaryVolume,
-      m_MovingBinaryVolume,
-      initialITKTransform,
-      m_MaskInferiorCutOffFromCenter);
+    DoCenteredTransformMaskClipping<TransformType, FixedImageType::ImageDimension>(
+                                                                                   m_FixedBinaryVolume,
+                                                                                   m_MovingBinaryVolume,
+                                                                                   initialITKTransform,
+                                                                                   m_MaskInferiorCutOffFromCenter);
 
       {   // Write out some debugging information if requested
       if( ( !this->m_FixedBinaryVolume.IsNull() ) && ( m_OutputFixedVolumeROI != "" ) )
         {
         const MaskImageType::ConstPointer tempOutputFixedVolumeROI =
-          ExtractConstPointerToImageMaskFromImageSpatialObject(this->m_FixedBinaryVolume.GetPointer() );
+        ExtractConstPointerToImageMaskFromImageSpatialObject(this->m_FixedBinaryVolume.GetPointer() );
         itkUtil::WriteConstImage<MaskImageType>(tempOutputFixedVolumeROI, m_OutputFixedVolumeROI);
         }
       if( ( !this->m_MovingBinaryVolume.IsNull() ) && ( m_OutputMovingVolumeROI != "" ) )
         {
         const MaskImageType::ConstPointer tempOutputMovingVolumeROI =
-          ExtractConstPointerToImageMaskFromImageSpatialObject(this->m_MovingBinaryVolume.GetPointer() );
+        ExtractConstPointerToImageMaskFromImageSpatialObject(this->m_MovingBinaryVolume.GetPointer() );
         itkUtil::WriteConstImage<MaskImageType>(tempOutputMovingVolumeROI, m_OutputMovingVolumeROI);
         }
       }
-
-    m_GenericTransformList[currentTransformId++] = initialITKTransform;
     }
+
   for( unsigned int currentTransformIndex = 0;
        currentTransformIndex < m_TransformType.size();
        currentTransformIndex++ )
     {
-    // m_AccumulatedNumberOfIterationsForAllLevels +=
-    // localNumberOfIterations[currentTransformIndex];
     const std::string currentTransformType(m_TransformType[currentTransformIndex]);
     std::cout << "\n\n\n=============================== "
-              << "Starting Transform Estimations for "
+              << "ITKv4 Registration: Starting Transform Estimations for "
               << currentTransformType << "(" << currentTransformIndex + 1
               << " of " << m_TransformType.size() << ")."
               << "==============================="
@@ -758,24 +823,43 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
     if( currentTransformType == "Rigid" )
       {
       //  Choose TransformType for the itk registration class template:
-      typedef VersorRigid3DTransformType           TransformType;
-      typedef itk::VersorRigid3DTransformOptimizer OptimizerType;
-      // const int NumberOfEstimatedParameter = 6;
-
+      //typedef VersorRigid3DTransformType           TransformType;
+      typedef itk::Euler3DTransform<double>         TransformType;
       //
-      // Process the initialITKTransform as VersorRigid3DTransform:
+      // Process the initialITKTransform as Euler3DTransform:
       //
       TransformType::Pointer initialITKTransform = TransformType::New();
       initialITKTransform->SetIdentity();
-      if( m_CurrentGenericTransform.IsNotNull() )
+
+      //DEBUG
+      //m_CurrentGenericTransform->Print(std::cout);
+
+      if( m_CurrentGenericTransform.IsNotNull() ) //When null, m_CurrentGenericTransform will be initialized by identity.
         {
+        /* NOTE1: m_CurrentGenericTransform is a composite transform. When not null, it is initialized by:
+                 {Intial Moving Transform
+                        OR
+                  Estimated initial transform indicated by initialTransformMode
+                        OR
+                  Output of previous level}
+
+         * NOTE2: If the transform Type of the current level is linear,
+                  the m_CurrentGenericTransform should contain only one transform as we collapse all linear transforms together.
+         */
+        if( m_CurrentGenericTransform->GetNumberOfTransforms() != 1 )
+          {
+          itkGenericExceptionMacro("Linear initial composite transform should have only one component \
+                                   as all linaear transforms are collapsed together.");
+          }
+        const GenericTransformType::ConstPointer currInitTransformFormGenericComposite =
+                                                  m_CurrentGenericTransform->GetFrontTransform();
         try
           {
-          const std::string transformFileType = m_CurrentGenericTransform->GetNameOfClass();
-          if( transformFileType == "VersorRigid3DTransform" )
+          const std::string transformFileType = currInitTransformFormGenericComposite->GetNameOfClass();
+          if( transformFileType == "Euler3DTransform" )
             {
-            const VersorRigid3DTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<VersorRigid3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+            const Euler3DTransformType::ConstPointer tempInitializerITKTransform =
+            dynamic_cast<Euler3DTransformType const *>( currInitTransformFormGenericComposite.GetPointer() );
             if( tempInitializerITKTransform.IsNull() )
               {
               std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
@@ -784,23 +868,24 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
                                                   tempInitializerITKTransform);
             }
           else if( ( transformFileType == "ScaleVersor3DTransform" )
-                   || ( transformFileType == "ScaleSkewVersor3DTransform" )
-                   || ( transformFileType == "AffineTransform" ) )
+                  || ( transformFileType == "ScaleSkewVersor3DTransform" )
+                  || ( transformFileType == "AffineTransform" ) )
             {
             // CONVERTING TO RIGID TRANSFORM TYPE from other type:
             std::cout << "WARNING:  Extracting Rigid component type from transform." << std::endl;
-            VersorRigid3DTransformType::Pointer tempInitializerITKTransform = ComputeRigidTransformFromGeneric(
-                m_CurrentGenericTransform.GetPointer() );
+            Euler3DTransformType::Pointer tempInitializerITKTransform =
+                                                ComputeRigidTransformFromGeneric(currInitTransformFormGenericComposite.GetPointer() );
+
             AssignRigid::AssignConvertedTransform( initialITKTransform, tempInitializerITKTransform.GetPointer() );
             }
           else
             {
             std::cout
-              <<
-              "Unsupported initial transform file -- TransformBase first transform typestring, "
-              << transformFileType
-              << " not equal to required type VersorRigid3DTransform"
-              << std::endl;
+            <<
+            "Unsupported initial transform file -- TransformBase first transform typestring, "
+            << transformFileType
+            << " not equal to required type Euler3DTransform"
+            << std::endl;
             return;
             }
           }
@@ -808,39 +893,29 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
           {
           std::cout << "[FAILED]" << std::endl;
           std::cerr
-            << "Error while reading the m_CurrentGenericTransform" << std::endl;
+          << "Error while reading the m_CurrentGenericTransform" << std::endl;
           std::cerr << excp << std::endl;
           throw;
           }
         }
+      else
         {
-        // Special optimizations only for the MMI metric
-        // that need adjusting based on both the type of metric, and
-        // the "dimensionality" of the transform being adjusted.
-        typename MattesMutualInformationMetricType::Pointer test_MMICostMetric =
-          dynamic_cast<MattesMutualInformationMetricType *>(this->m_CostMetricObject.GetPointer() );
-        if( test_MMICostMetric.IsNotNull() )
-          {
-          const bool UseExplicitPDFDerivatives =
-            ( m_UseExplicitPDFDerivativesMode == "ON" || m_UseExplicitPDFDerivativesMode == "AUTO" ) ? true : false;
-          test_MMICostMetric->SetUseExplicitPDFDerivatives(UseExplicitPDFDerivatives);
-          }
+        m_CurrentGenericTransform = CompositeTransformType::New();
         }
+      // replace the original initial transform with the extracted version.
+      m_CurrentGenericTransform->ClearTransformQueue();
+      m_CurrentGenericTransform->AddTransform( initialITKTransform );
 
       this->FitCommonCode<TransformType, OptimizerType, MetricType>
         (localNumberOfIterations[currentTransformIndex],
-        localMinimumStepLength[currentTransformIndex],
-        initialITKTransform);
-      localInitializeTransformMode = "Off";   // Now turn of the initiallize
-                                              // code to off
+        this->m_CurrentGenericTransform);
+      // NOW, after running the above function, the m_CurrentGenericTransform contains the integration of initial transform and rigid registration results.
+      ///////////////////////
       }
     else if( currentTransformType == "ScaleVersor3D" )
       {
       //  Choose TransformType for the itk registration class template:
-      typedef ScaleVersor3DTransformType    TransformType;
-      typedef itk::VersorTransformOptimizer OptimizerType;
-      // const int NumberOfEstimatedParameter = 9;
-
+      typedef ScaleVersor3DTransformType    TransformType; // NumberOfEstimatedParameter = 9;
       //
       // Process the initialITKTransform as ScaleVersor3DTransform:
       //
@@ -848,13 +923,30 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
       initialITKTransform->SetIdentity();
       if( m_CurrentGenericTransform.IsNotNull() )
         {
+        /* NOTE1: m_CurrentGenericTransform is a composite transform. When not null, it is initialized by:
+         {Intial Moving Transform
+         OR
+         Estimated initial transform indicated by initialTransformMode
+         OR
+         Output of previous level}
+
+         * NOTE2: If the transform Type of the current level is linear,
+         the m_CurrentGenericTransform should contain only one transform as we collapse all linear transforms together.
+         */
+        if( m_CurrentGenericTransform->GetNumberOfTransforms() != 1 )
+          {
+          itkGenericExceptionMacro("Linear initial composite transform should have only one component \
+                                   as all linaear transforms are collapsed together.");
+          }
+        const GenericTransformType::ConstPointer currInitTransformFormGenericComposite =
+                                                  m_CurrentGenericTransform->GetFrontTransform();
         try
           {
-          const std::string transformFileType = m_CurrentGenericTransform->GetNameOfClass();
-          if( transformFileType == "VersorRigid3DTransform" )
+          const std::string transformFileType = currInitTransformFormGenericComposite->GetNameOfClass();
+          if( transformFileType == "Euler3DTransform" )
             {
-            const VersorRigid3DTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<VersorRigid3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+            const Euler3DTransformType::ConstPointer tempInitializerITKTransform =
+              dynamic_cast<Euler3DTransformType const *>( currInitTransformFormGenericComposite.GetPointer() );
             if( tempInitializerITKTransform.IsNull() )
               {
               std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
@@ -865,7 +957,7 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
           else if( transformFileType == "ScaleVersor3DTransform" )
             {
             const ScaleVersor3DTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<ScaleVersor3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+              dynamic_cast<ScaleVersor3DTransformType const *>( currInitTransformFormGenericComposite.GetPointer() );
             if( tempInitializerITKTransform.IsNull() )
               {
               std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
@@ -879,21 +971,18 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
             // CONVERTING TO RIGID TRANSFORM TYPE from other type:
             // TODO: we should preserve the Scale components
             std::cout << "WARNING:  Extracting Rigid component type from transform." << std::endl;
-            VersorRigid3DTransformType::Pointer tempInitializerITKTransform = ComputeRigidTransformFromGeneric(
-                m_CurrentGenericTransform.GetPointer() );
+            Euler3DTransformType::Pointer tempInitializerITKTransform = ComputeRigidTransformFromGeneric(
+                currInitTransformFormGenericComposite.GetPointer() );
             AssignRigid::AssignConvertedTransform( initialITKTransform, tempInitializerITKTransform.GetPointer() );
             }
-          else              // || transformFileType ==
-                            // "ScaleSkewVersor3DTransform"
-          // ||
-          // transformFileType == "AffineTransform"
+          else
             {
             std::cout
               <<
               "Unsupported initial transform file -- TransformBase first transform typestring, "
               << transformFileType
               <<
-              " not equal to required type VersorRigid3DTransform OR ScaleVersor3DTransform"
+              " not equal to required type Euler3DTransform OR ScaleVersor3DTransform"
               << std::endl;
             return;
             }
@@ -908,34 +997,25 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
           throw;
           }
         }
+      else
         {
-        // Special optimizations only for the MMI metric
-        // that need adjusting based on both the type of metric, and
-        // the "dimensionality" of the transform being adjusted.
-        typename MattesMutualInformationMetricType::Pointer test_MMICostMetric =
-          dynamic_cast<MattesMutualInformationMetricType *>(this->m_CostMetricObject.GetPointer() );
-        if( test_MMICostMetric.IsNotNull() )
-          {
-          const bool UseExplicitPDFDerivatives =
-            ( m_UseExplicitPDFDerivativesMode == "ON" || m_UseExplicitPDFDerivativesMode == "AUTO" ) ? true : false;
-          test_MMICostMetric->SetUseExplicitPDFDerivatives(UseExplicitPDFDerivatives);
-          }
+        m_CurrentGenericTransform = CompositeTransformType::New();
         }
-      // #include "FitCommonCode.tmpl"
+
+      // replace the original initial transform with the above converted version.
+      m_CurrentGenericTransform->ClearTransformQueue();
+      m_CurrentGenericTransform->AddTransform( initialITKTransform );
+
       this->FitCommonCode<TransformType, OptimizerType, MetricType>
-        (localNumberOfIterations[currentTransformIndex],
-        localMinimumStepLength[currentTransformIndex],
-        initialITKTransform);
-      localInitializeTransformMode = "Off";   // Now turn of the initiallize
-                                              // code to off
+      (localNumberOfIterations[currentTransformIndex],
+       this->m_CurrentGenericTransform);
+      // NOW, after running the above function, the m_CurrentGenericTransform contains the integration of initial transform and ScaleSkew registration results.
+      /////////////////////
       }
     else if( currentTransformType == "ScaleSkewVersor3D" )
       {
       //  Choose TransformType for the itk registration class template:
-      typedef ScaleSkewVersor3DTransformType TransformType;
-      typedef itk::VersorTransformOptimizer  OptimizerType;
-      // const int NumberOfEstimatedParameter = 15;
-
+      typedef ScaleSkewVersor3DTransformType TransformType;  // NumberOfEstimatedParameter = 15;
       //
       // Process the initialITKTransform as ScaleSkewVersor3D:
       //
@@ -943,13 +1023,30 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
       initialITKTransform->SetIdentity();
       if( m_CurrentGenericTransform.IsNotNull() )
         {
+        /* NOTE1: m_CurrentGenericTransform is a composite transform. When not null, it is initialized by:
+         {Intial Moving Transform
+         OR
+         Estimated initial transform indicated by initialTransformMode
+         OR
+         Output of previous level}
+
+         * NOTE2: If the transform Type of the current level is linear,
+         the m_CurrentGenericTransform should contain only one transform as we collapse all linear transforms together.
+         */
+        if( m_CurrentGenericTransform->GetNumberOfTransforms() != 1 )
+          {
+          itkGenericExceptionMacro("Linear initial composite transform should have only one component \
+                                   as all linaear transforms are collapsed together.");
+          }
+        const GenericTransformType::ConstPointer currInitTransformFormGenericComposite =
+                                                  m_CurrentGenericTransform->GetFrontTransform();
         try
           {
-          const std::string transformFileType = m_CurrentGenericTransform->GetNameOfClass();
-          if( transformFileType == "VersorRigid3DTransform" )
+          const std::string transformFileType = currInitTransformFormGenericComposite->GetNameOfClass();
+          if( transformFileType == "Euler3DTransform" )
             {
-            const VersorRigid3DTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<VersorRigid3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+            const Euler3DTransformType::ConstPointer tempInitializerITKTransform =
+              dynamic_cast<Euler3DTransformType const *>( currInitTransformFormGenericComposite.GetPointer() );
             if( tempInitializerITKTransform.IsNull() )
               {
               std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
@@ -960,7 +1057,7 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
           else if( transformFileType == "ScaleVersor3DTransform" )
             {
             const ScaleVersor3DTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<ScaleVersor3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+              dynamic_cast<ScaleVersor3DTransformType const *>( currInitTransformFormGenericComposite.GetPointer() );
             if( tempInitializerITKTransform.IsNull() )
               {
               std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
@@ -971,7 +1068,7 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
           else if( transformFileType == "ScaleSkewVersor3DTransform" )
             {
             const ScaleSkewVersor3DTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<ScaleSkewVersor3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+              dynamic_cast<ScaleSkewVersor3DTransformType const *>( currInitTransformFormGenericComposite.GetPointer() );
             if( tempInitializerITKTransform.IsNull() )
               {
               std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
@@ -984,17 +1081,15 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
             // CONVERTING TO RIGID TRANSFORM TYPE from other type:
             // TODO:  We should really preserve the Scale and Skew components
             std::cout << "WARNING:  Extracting Rigid component type from transform." << std::endl;
-            VersorRigid3DTransformType::Pointer tempInitializerITKTransform = ComputeRigidTransformFromGeneric(
-                m_CurrentGenericTransform.GetPointer() );
+            Euler3DTransformType::Pointer tempInitializerITKTransform = ComputeRigidTransformFromGeneric(
+                currInitTransformFormGenericComposite.GetPointer() );
             AssignRigid::AssignConvertedTransform( initialITKTransform, tempInitializerITKTransform.GetPointer() );
             }
-          else              // || transformFileType == "AffineTransform" ||
-          // transformFileType
-          // == "ScaleVersor3DTransform"
+          else
             {
             std::cout << "Unsupported initial transform file -- TransformBase first transform typestring, "
                       << transformFileType
-                      << " not equal to required type VersorRigid3DTransform "
+                      << " not equal to required type Euler3DTransform "
                       << "OR ScaleVersor3DTransform OR ScaleSkewVersor3DTransform"
                       << std::endl;
             return;
@@ -1009,34 +1104,24 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
           throw;
           }
         }
+      else
         {
-        // Special optimizations only for the MMI metric
-        // that need adjusting based on both the type of metric, and
-        // the "dimensionality" of the transform being adjusted.
-        typename MattesMutualInformationMetricType::Pointer test_MMICostMetric =
-          dynamic_cast<MattesMutualInformationMetricType *>(this->m_CostMetricObject.GetPointer() );
-        if( test_MMICostMetric.IsNotNull() )
-          {
-          const bool UseExplicitPDFDerivatives =
-            ( m_UseExplicitPDFDerivativesMode == "ON" || m_UseExplicitPDFDerivativesMode == "AUTO" ) ? true : false;
-          test_MMICostMetric->SetUseExplicitPDFDerivatives(UseExplicitPDFDerivatives);
-          }
+        m_CurrentGenericTransform = CompositeTransformType::New();
         }
-      // #include "FitCommonCode.tmpl"
+      // replace the original initial transform with the above converted version.
+      m_CurrentGenericTransform->ClearTransformQueue();
+      m_CurrentGenericTransform->AddTransform( initialITKTransform );
+
       this->FitCommonCode<TransformType, OptimizerType, MetricType>
-        (localNumberOfIterations[currentTransformIndex],
-        localMinimumStepLength[currentTransformIndex],
-        initialITKTransform);
-      localInitializeTransformMode = "Off";   // Now turn of the initiallize
-                                              // code to off
+      (localNumberOfIterations[currentTransformIndex],
+       this->m_CurrentGenericTransform);
+      // NOW, after running the above function, the m_CurrentGenericTransform contains the integration of initial transform and ScaleSkew registration results that is an "Affine" transform.
+      /////////////////////
       }
     else if( currentTransformType == "Affine" )
       {
       //  Choose TransformType for the itk registration class template:
       typedef itk::AffineTransform<double, Dimension>  TransformType;
-      typedef itk::RegularStepGradientDescentOptimizer OptimizerType;
-      // const int NumberOfEstimatedParameter = 12;
-
       //
       // Process the initialITKTransform
       //
@@ -1044,13 +1129,30 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
       initialITKTransform->SetIdentity();
       if( m_CurrentGenericTransform.IsNotNull() )
         {
+        /* NOTE1: m_CurrentGenericTransform is a composite transform. When not null, it is initialized by:
+         {Intial Moving Transform
+         OR
+         Estimated initial transform indicated by initialTransformMode
+         OR
+         Output of previous level}
+
+         * NOTE2: If the transform Type of the current level is linear,
+         the m_CurrentGenericTransform should contain only one transform as we collapse all linear transforms together.
+         */
+        if( m_CurrentGenericTransform->GetNumberOfTransforms() != 1 )
+          {
+          itkGenericExceptionMacro("Linear initial composite transform should have only one component \
+                                   as all linaear transforms are collapsed together.");
+          }
+        const GenericTransformType::ConstPointer currInitTransformFormGenericComposite =
+                                                  m_CurrentGenericTransform->GetFrontTransform();
         try
           {
-          const std::string transformFileType = m_CurrentGenericTransform->GetNameOfClass();
-          if( transformFileType == "VersorRigid3DTransform" )
+          const std::string transformFileType = currInitTransformFormGenericComposite->GetNameOfClass();
+          if( transformFileType == "Euler3DTransform" )
             {
-            const VersorRigid3DTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<VersorRigid3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+            const Euler3DTransformType::ConstPointer tempInitializerITKTransform =
+              dynamic_cast<Euler3DTransformType const *>( currInitTransformFormGenericComposite.GetPointer() );
             if( tempInitializerITKTransform.IsNull() )
               {
               std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
@@ -1061,7 +1163,7 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
           else if( transformFileType == "ScaleVersor3DTransform" )
             {
             const ScaleVersor3DTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<ScaleVersor3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+              dynamic_cast<ScaleVersor3DTransformType const *>( currInitTransformFormGenericComposite.GetPointer() );
             if( tempInitializerITKTransform.IsNull() )
               {
               std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
@@ -1072,7 +1174,7 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
           else if( transformFileType == "ScaleSkewVersor3DTransform" )
             {
             const ScaleSkewVersor3DTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<ScaleSkewVersor3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+              dynamic_cast<ScaleSkewVersor3DTransformType const *>( currInitTransformFormGenericComposite.GetPointer() );
             if( tempInitializerITKTransform.IsNull() )
               {
               std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
@@ -1082,8 +1184,8 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
             }
           else if( transformFileType == "AffineTransform" )
             {
-            const AffineTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<AffineTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+            const typename AffineTransformType::ConstPointer tempInitializerITKTransform =
+              dynamic_cast<AffineTransformType const *>( currInitTransformFormGenericComposite.GetPointer() );
             if( tempInitializerITKTransform.IsNull() )
               {
               std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
@@ -1096,7 +1198,7 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
             std::cout
               << "Unsupported initial transform file -- TransformBase first transform typestring, "
               << transformFileType
-              << " not equal to any recognized type VersorRigid3DTransform OR "
+              << " not equal to any recognized type Euler3DTransform OR "
               << "ScaleVersor3DTransform OR ScaleSkewVersor3DTransform OR AffineTransform"
               << std::endl;
             return;
@@ -1110,461 +1212,249 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
           throw;
           }
         }
-
+      else
         {
-        // Special optimizations only for the MMI metric
-        // that need adjusting based on both the type of metric, and
-        // the "dimensionality" of the transform being adjusted.
-        typename MattesMutualInformationMetricType::Pointer test_MMICostMetric =
-          dynamic_cast<MattesMutualInformationMetricType *>(this->m_CostMetricObject.GetPointer() );
-        if( test_MMICostMetric.IsNotNull() )
-          {
-          const bool UseExplicitPDFDerivatives =
-            ( m_UseExplicitPDFDerivativesMode == "ON" || m_UseExplicitPDFDerivativesMode == "AUTO" ) ? true : false;
-          test_MMICostMetric->SetUseExplicitPDFDerivatives(UseExplicitPDFDerivatives);
-          }
+        m_CurrentGenericTransform = CompositeTransformType::New();
         }
-      // #include "FitCommonCode.tmpl"
+
+      // replace the original initial transform with the above converted version.
+      m_CurrentGenericTransform->ClearTransformQueue();
+      m_CurrentGenericTransform->AddTransform( initialITKTransform );
+
       this->FitCommonCode<TransformType, OptimizerType, MetricType>
-        (localNumberOfIterations[currentTransformIndex],
-        localMinimumStepLength[currentTransformIndex],
-        initialITKTransform);
-      localInitializeTransformMode = "Off";   // Now turn of the initiallize
-                                              // code to off
+      (localNumberOfIterations[currentTransformIndex],
+       this->m_CurrentGenericTransform);
+      // NOW, after running the above function, the m_CurrentGenericTransform contains the integration of initial transform and Affine registration results.
+      /////////////////////
       }
     else if( currentTransformType == "BSpline" )
       {
-      //
-      // Process the bulkAffineTransform for BSpline's BULK
-      //
-      AffineTransformType::Pointer bulkAffineTransform =
-        AffineTransformType::New();
-      bulkAffineTransform->SetIdentity();
+      const unsigned int SplineOrder = 3;
+      typedef itk::BSplineTransform<double, 3, SplineOrder> BSplineTransformType;
 
-      typedef itk::Image<float, 3> RegisterImageType;
+      // we have a 3 level BSpline registration.
+      //const int numberOfLevels = 3;
+      const unsigned int numberOfLevels = 1;
 
-      BSplineTransformType::Pointer outputBSplineTransform =
-        BSplineTransformType::New();
-      outputBSplineTransform->SetIdentity();
+      typedef itk::ImageRegistrationMethodv4<FixedImageType, MovingImageType, BSplineTransformType> BSplineRegistrationType;
+      typename BSplineRegistrationType::Pointer bsplineRegistration = BSplineRegistrationType::New();
 
-      BSplineTransformType::Pointer initialBSplineTransform =
-        BSplineTransformType::New();
-      initialBSplineTransform->SetIdentity();
+      typename BSplineTransformType::Pointer outputBSplineTransform =
+        const_cast<BSplineTransformType *>( bsplineRegistration->GetOutput()->Get() );
 
+      //std::vector<unsigned int> size(3);
+      //size[0] = 3; size[1] = 3; size[2] = 3;
+
+      typename BSplineTransformType::PhysicalDimensionsType physicalDimensions;
+      typename BSplineTransformType::MeshSizeType meshSize;
+      for( unsigned int d = 0; d < 3; d++ )
         {
-        typedef BSplineTransformType::RegionType
-          TransformRegionType;
-        typedef TransformRegionType::SizeType
-          TransformSizeType;
-        typedef itk::BSplineDeformableTransformInitializer<BSplineTransformType,
-                                                                 RegisterImageType> InitializerType;
-        InitializerType::Pointer transformInitializer = InitializerType::New();
-        transformInitializer->SetTransform(initialBSplineTransform);
-
-        if( m_UseROIBSpline )
-          {
-          ImageMaskSpatialObjectType::Pointer roiMask = ImageMaskSpatialObjectType::New();
-          if( m_MovingBinaryVolume.GetPointer() != NULL )
-            {
-            ImageMaskSpatialObjectType::Pointer movingImageMask =
-              dynamic_cast<ImageMaskSpatialObjectType *>(m_MovingBinaryVolume.GetPointer() );
-
-            typedef itk::ResampleImageFilter<MaskImageType, MaskImageType, double> ResampleFilterType;
-            ResampleFilterType::Pointer resampler = ResampleFilterType::New();
-
-            if( m_CurrentGenericTransform.IsNotNull() )
-              {
-              // resample the moving mask, if available
-              resampler->SetTransform(m_CurrentGenericTransform);
-              resampler->SetInput( movingImageMask->GetImage() );
-              resampler->SetOutputParametersFromImage( m_FixedVolume );
-              resampler->Update();
-              }
-            if( m_FixedBinaryVolume.GetPointer() != NULL )
-              {
-              typedef itk::AddImageFilter<MaskImageType, MaskImageType> AddFilterType;
-              ImageMaskSpatialObjectType::Pointer fixedImageMask =
-                dynamic_cast<ImageMaskSpatialObjectType *>(m_FixedBinaryVolume.GetPointer() );
-              AddFilterType::Pointer adder = AddFilterType::New();
-              adder->SetInput1(fixedImageMask->GetImage() );
-              adder->SetInput2(resampler->GetOutput() );
-              adder->Update();
-              roiMask->SetImage(adder->GetOutput() );
-              }
-            else
-              {
-              roiMask->SetImage(resampler->GetOutput() );
-              }
-            }
-          else if( m_FixedBinaryVolume.GetPointer() != NULL )
-            {
-            ImageMaskSpatialObjectType::Pointer fixedImageMask =
-              dynamic_cast<ImageMaskSpatialObjectType *>(m_FixedBinaryVolume.GetPointer() );
-            roiMask->SetImage(fixedImageMask->GetImage() );
-            }
-
-          else
-            {
-            itkGenericExceptionMacro( << "ERROR: ROIBSpline mode can only be used with ROI(s) specified!");
-            return;
-            }
-
-          typename FixedImageType::PointType roiOriginPt;
-          typename FixedImageType::IndexType roiOriginIdx;
-          typename FixedImageType::Pointer    roiImage = FixedImageType::New();
-          typename FixedImageType::RegionType roiRegion =
-            roiMask->GetAxisAlignedBoundingBoxRegion();
-          typename FixedImageType::SpacingType roiSpacing =
-            m_FixedVolume->GetSpacing();
-
-          roiOriginIdx.Fill(0);
-          m_FixedVolume->TransformIndexToPhysicalPoint(roiRegion.GetIndex(), roiOriginPt);
-          roiRegion.SetIndex(roiOriginIdx);
-          roiImage->SetRegions(roiRegion);
-          roiImage->Allocate();
-          roiImage->FillBuffer(1.);
-          roiImage->SetSpacing(roiSpacing);
-          roiImage->SetOrigin(roiOriginPt);
-          roiImage->SetDirection( m_FixedVolume->GetDirection() );
-
-          transformInitializer->SetImage(roiImage);
-          }
-        else
-          {
-          transformInitializer->SetImage(m_FixedVolume);
-          }
-
-        TransformSizeType tempGridSize;
-        tempGridSize[0] = m_SplineGridSize[0];
-        tempGridSize[1] = m_SplineGridSize[1];
-        tempGridSize[2] = m_SplineGridSize[2];
-        transformInitializer->SetGridSizeInsideTheImage(tempGridSize);
-        transformInitializer->InitializeTransform();
-
-        std::cout << "BSpline initialized: " << initialBSplineTransform << std::endl;
+        physicalDimensions[d] = m_FixedVolume->GetSpacing()[d]
+        * static_cast<double>( m_FixedVolume->GetLargestPossibleRegion().GetSize()[d] - 1 );
+        meshSize[d] = m_SplineGridSize[d];
         }
 
-      if( m_CurrentGenericTransform.IsNotNull() )
+    //std::vector<std::vector<unsigned int> > shrinkFactorsList;
+    /*
+    std::vector<unsigned int>               factors(3);
+    factors[0] = 4;
+    factors[1] = 2;
+    factors[2] = 1;
+    */
+    //shrinkFactorsList.push_back(factors);
+
+    std::vector<unsigned int> factors(1);
+    factors[0] = 5;
+
+    // Create the transform adaptors
+    typedef itk::BSplineTransformParametersAdaptor<BSplineTransformType> BSplineTransformAdaptorType;
+    typename BSplineRegistrationType::TransformParametersAdaptorsContainerType adaptors;
+    // Create the transform adaptors specific to B-splines
+    for( unsigned int level = 0; level < numberOfLevels; ++level )
+      {
+      typedef itk::ShrinkImageFilter<FixedImageType, FixedImageType> ShrinkFilterType;
+      typename ShrinkFilterType::Pointer shrinkFilter = ShrinkFilterType::New();
+      shrinkFilter->SetShrinkFactors( factors[level] );
+      shrinkFilter->SetInput( m_FixedVolume );
+      shrinkFilter->Update();
+
+      // A good heuristic is to RealType the b-spline mesh resolution at each level
+      typename BSplineTransformType::MeshSizeType requiredMeshSize;
+      for( unsigned int d = 0; d < 3; d++ )
         {
-        try
-          {
-          const std::string transformFileType = m_CurrentGenericTransform->GetNameOfClass();
-          if( transformFileType == "VersorRigid3DTransform" )
-            {
-            const VersorRigid3DTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<VersorRigid3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
-            if( tempInitializerITKTransform.IsNull() )
-              {
-              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
-              }
-            AssignRigid::AssignConvertedTransform(bulkAffineTransform,
-                                                  tempInitializerITKTransform);
-            initialBSplineTransform->SetBulkTransform(bulkAffineTransform);
-            }
-          else if( transformFileType == "ScaleVersor3DTransform" )
-            {
-            const ScaleVersor3DTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<ScaleVersor3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
-            if( tempInitializerITKTransform.IsNull() )
-              {
-              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
-              }
-            AssignRigid::AssignConvertedTransform(bulkAffineTransform,
-                                                  tempInitializerITKTransform);
-            initialBSplineTransform->SetBulkTransform(bulkAffineTransform);
-            }
-          else if( transformFileType == "ScaleSkewVersor3DTransform" )
-            {
-            const ScaleSkewVersor3DTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<ScaleSkewVersor3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
-            if( tempInitializerITKTransform.IsNull() )
-              {
-              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
-              }
-            AssignRigid::AssignConvertedTransform(bulkAffineTransform,
-                                                  tempInitializerITKTransform);
-            initialBSplineTransform->SetBulkTransform(bulkAffineTransform);
-            }
-          else if( transformFileType == "AffineTransform" )
-            {
-            const AffineTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<AffineTransformType const *>( m_CurrentGenericTransform.GetPointer() );
-            if( tempInitializerITKTransform.IsNull() )
-              {
-              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
-              }
-            AssignRigid::AssignConvertedTransform(bulkAffineTransform,
-                                                  tempInitializerITKTransform);
-            initialBSplineTransform->SetBulkTransform(bulkAffineTransform);
-            }
-          else if( transformFileType == "BSplineDeformableTransform" )
-            {
-            const BSplineTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<BSplineTransformType const *>( m_CurrentGenericTransform.GetPointer() );
-            if( tempInitializerITKTransform.IsNull() )
-              {
-              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
-              }
-
-            initialBSplineTransform->SetBulkTransform(
-              tempInitializerITKTransform->GetBulkTransform() );
-            BSplineTransformType::ParametersType tempFixedInitialParameters =
-              tempInitializerITKTransform->GetFixedParameters();
-            BSplineTransformType::ParametersType initialFixedParameters =
-              initialBSplineTransform->GetFixedParameters();
-
-            bool checkMatch = true;         // Assume true;
-            if( initialFixedParameters.GetSize() != tempFixedInitialParameters.GetSize() )
-              {
-              checkMatch = false;
-              std::cerr << "ERROR INITILIZATION FIXED PARAMETERS DO NOT MATCH: " << initialFixedParameters.GetSize()
-                        << " != " << tempFixedInitialParameters.GetSize() << std::endl;
-              }
-            if( checkMatch ) //  This ramus covers the hypothesis that the FixedParameters
-                             //  represent the grid locations of the spline nodes.
-              {
-              for( unsigned int i = 0; i < initialFixedParameters.GetSize(); ++i )
-                {
-                if( initialFixedParameters.GetElement(i) != tempFixedInitialParameters.GetElement(i) )
-                  {
-                  checkMatch = false;
-                  std::cerr << "ERROR FIXED PARAMETERS DO NOT MATCH: " << initialFixedParameters.GetElement(i)
-                            << " != " << tempFixedInitialParameters.GetElement(i) << std::endl;
-                  }
-                }
-              BSplineTransformType::ParametersType tempInitialParameters =
-                tempInitializerITKTransform->GetParameters();
-              if( initialBSplineTransform->GetNumberOfParameters() ==
-                  tempInitialParameters.Size() )
-                {
-                initialBSplineTransform->SetFixedParameters(
-                  tempFixedInitialParameters);
-                initialBSplineTransform->SetParametersByValue(tempInitialParameters);
-                }
-              else
-                {
-                // Error, initializing from wrong size transform parameters;
-                //  Use its bulk transform only?
-                itkGenericExceptionMacro(
-                  << "Trouble using the m_CurrentGenericTransform"
-                  << "for initializing a BSPlineDeformableTransform:"
-                  << std::endl
-                  << "The initializing BSplineDeformableTransform has a different"
-                  << " number of Parameters, than what is required for the requested grid."
-                  << std::endl
-                  << "BRAINSFit was only able to use the bulk transform that was before it.");
-                }
-              }
-            else
-              {
-              itkGenericExceptionMacro(
-                << "ERROR:  initialization BSpline transform does not have the same "
-                << "parameter dimensions as the one currently specified.");
-              }
-            }
-          else if( transformFileType == "CompositeTransform" )
-            {
-            itkGenericExceptionMacro( << "Composite transform initializer type found:  "
-                                      << transformFileType )
-            }
-          else
-            {
-            itkGenericExceptionMacro( << "ERROR:  Invalid transform initializer type found:  "
-                                      << transformFileType )
-            }
-          }
-        catch( itk::ExceptionObject & excp )
-          {
-          std::cout << "[FAILED]" << std::endl;
-          std::cerr
-            << "Error while reading the m_CurrentGenericTransform"
-            << std::endl;
-          std::cerr << excp << std::endl;
-          throw;
-          }
+        requiredMeshSize[d] = meshSize[d] << level;
         }
 
-      // Special optimizations only for the MMI metric
-      // that need adjusting based on both the type of metric, and
-      // the "dimensionality" of the transform being adjusted.
-      typename MattesMutualInformationMetricType::Pointer test_MMICostMetric =
-        dynamic_cast<MattesMutualInformationMetricType *>(this->m_CostMetricObject.GetPointer() );
-      if( test_MMICostMetric.IsNotNull() )
+      typedef itk::BSplineTransformParametersAdaptor<BSplineTransformType> BSplineAdaptorType;
+      typename BSplineAdaptorType::Pointer bsplineAdaptor = BSplineAdaptorType::New();
+      bsplineAdaptor->SetTransform( outputBSplineTransform );
+      bsplineAdaptor->SetRequiredTransformDomainMeshSize( requiredMeshSize );
+      bsplineAdaptor->SetRequiredTransformDomainOrigin( shrinkFilter->GetOutput()->GetOrigin() );
+      bsplineAdaptor->SetRequiredTransformDomainDirection( shrinkFilter->GetOutput()->GetDirection() );
+      bsplineAdaptor->SetRequiredTransformDomainPhysicalDimensions( physicalDimensions );
+
+      adaptors.push_back( bsplineAdaptor.GetPointer() );
+      }
+
+      bsplineRegistration->SetFixedImage( 0, m_FixedVolume );
+      bsplineRegistration->SetMovingImage( 0, m_MovingVolume );
+
+      bsplineRegistration->SetNumberOfLevels( numberOfLevels );
+      for( unsigned int level = 0; level < numberOfLevels; ++level )
         {
-        // As recommended in documentation in
-        // itkMattesMutualInformationImageToImageMetric
-        // "UseExplicitPDFDerivatives = False ... This method is well suited
-        // for Transforms with a large number of parameters, such as,
-        // BSplineDeformableTransforms."
-        const bool UseExplicitPDFDerivatives =
-          ( m_UseExplicitPDFDerivativesMode != "ON" || m_UseExplicitPDFDerivativesMode == "AUTO" ) ? false : true;
-        test_MMICostMetric->SetUseExplicitPDFDerivatives(UseExplicitPDFDerivatives);
+        bsplineRegistration->SetShrinkFactorsPerDimension( level, factors[level] ); // check whether it accepts scalar or not
         }
 
-      outputBSplineTransform =
-        DoBSpline<RegisterImageType, SpatialObjectType,
-                  BSplineTransformType>(
-          initialBSplineTransform,
-          m_FixedVolume, m_MovingVolume,
-          this->m_CostMetricObject.GetPointer(),
-          this->m_MaxBSplineDisplacement,
-          this->m_CostFunctionConvergenceFactor,
-          this->m_ProjectedGradientTolerance,
-          this->m_DisplayDeformedImage,
-          this->m_PromptUserAfterDisplay);
-      if( outputBSplineTransform.IsNull() )
-        {
-        std::cout
-          << "Error -- the BSpline fit has failed." << std::endl;
-        std::cout
-          << "Error -- the BSpline fit has failed." << std::endl;
+      /*
+      typename BSplineRegistrationType::SmoothingSigmasArrayType sigmas(3);
+      sigmas[0] = 4;
+      sigmas[1] = 2;
+      sigmas[2] = 0;
+      */
+      typename BSplineRegistrationType::SmoothingSigmasArrayType sigmas(1);
+      sigmas[0] = 1;
 
-        m_ActualNumberOfIterations = 1;
-        m_PermittedNumberOfIterations = 1;
+      bsplineRegistration->SetSmoothingSigmasPerLevel( sigmas );
+      bsplineRegistration->SetSmoothingSigmasAreSpecifiedInPhysicalUnits( true );
+
+      bsplineRegistration->SetMetricSamplingStrategy(
+                                                     static_cast<typename BSplineRegistrationType::MetricSamplingStrategyType>( m_SamplingStrategy ) );
+      bsplineRegistration->SetMetricSamplingPercentage( m_SamplingPercentage );
+
+      typedef itk::RegistrationParameterScalesFromPhysicalShift<MetricType> ScalesEstimatorType;
+      typename ScalesEstimatorType::Pointer scalesEstimator = ScalesEstimatorType::New();
+      scalesEstimator->SetMetric( this->m_CostMetricObject );
+      scalesEstimator->SetTransformForward( true );
+
+      typedef itk::ConjugateGradientLineSearchOptimizerv4Template<double> ConjugateGradientDescentOptimizerType;
+      ConjugateGradientDescentOptimizerType::Pointer optimizer = ConjugateGradientDescentOptimizerType::New();
+      optimizer->SetLowerLimit( 0 );
+      optimizer->SetUpperLimit( 2 );
+      optimizer->SetEpsilon( 0.2 );
+      optimizer->SetLearningRate( m_MaximumStepLength );
+      optimizer->SetMaximumStepSizeInPhysicalUnits(m_MaximumStepLength);
+      optimizer->SetNumberOfIterations(localNumberOfIterations[currentTransformIndex]);
+      //optimizer->SetNumberOfIterations(10);
+      optimizer->SetScalesEstimator( scalesEstimator );
+      const double convergenceThreshold = 1e-6;
+      const int convergenceWindowSize = 10;
+      optimizer->SetMinimumConvergenceValue( convergenceThreshold );
+      optimizer->SetConvergenceWindowSize( convergenceWindowSize );
+      optimizer->SetDoEstimateLearningRateAtEachIteration( true );
+      optimizer->SetDoEstimateLearningRateOnce( false );
+
+      optimizer->DebugOn();
+
+      bsplineRegistration->SetOptimizer( optimizer );
+
+      this->m_CostMetricObject->DebugOn();
+
+      bsplineRegistration->SetMetric( this->m_CostMetricObject );
+
+      if( this->m_CurrentGenericTransform.IsNull() )
+        {
+        //BSplineTransformType::Pointer initialITKTransform = BSplineTransformType::New();
+        //initialITKTransform->SetIdentity();
+        m_CurrentGenericTransform = CompositeTransformType::New();
+        //m_CurrentGenericTransform->AddTransform( initialITKTransform );
         }
       else
         {
-        // Initialize next level of transformations with previous transform
-        // result
-        // TransformList.clear();
-        // TransformList.push_back(finalTransform);
-        m_CurrentGenericTransform = outputBSplineTransform;
-        // Now turn of the initiallize code to off
-        localInitializeTransformMode = "Off";
-          {
-          // HACK:  The BSpline optimizer does not return the correct iteration
-          // values.
-          m_ActualNumberOfIterations = 1;
-          m_PermittedNumberOfIterations = 3;
-          }
+        bsplineRegistration->SetMovingInitialTransform( this->m_CurrentGenericTransform );
         }
-      }
-    else if( currentTransformType == "Composite3D" )
-      {
-      itkGenericExceptionMacro(<< "Composite Transform is not yet Implemented");
+
+        ////////
+        //if(this->m_CurrentGenericTransform->GetNumberOfTransforms() == 1)
+          {
+          std::cout << "write the initial transform to the disk right before registration starts." << std::endl;
+          this->m_CurrentGenericTransform->Print(std::cout);
+          itk::TransformFileWriter::Pointer dwriter1 = itk::TransformFileWriter::New();
+          dwriter1->SetInput( this->m_CurrentGenericTransform );
+          dwriter1->SetFileName("initial_composite_bspline_DEBUG.h5");
+          dwriter1->Update();
+          }
+
+      bsplineRegistration->SetTransformParametersAdaptorsPerLevel( adaptors );
+      outputBSplineTransform->SetTransformDomainOrigin( m_FixedVolume->GetOrigin() );
+      outputBSplineTransform->SetTransformDomainPhysicalDimensions( physicalDimensions );
+      outputBSplineTransform->SetTransformDomainMeshSize( meshSize );
+      outputBSplineTransform->SetTransformDomainDirection( m_FixedVolume->GetDirection() );
+      outputBSplineTransform->SetIdentity();
+
+      bsplineRegistration->DebugOn();
+
+      try
+        {
+        std::cout << "*** Running bspline registration (meshSizeAtBaseLevel = " << meshSize << ") ***"
+        << std::endl << std::endl;
+        bsplineRegistration->Update();
+        }
+      catch( itk::ExceptionObject & e )
+        {
+        itkGenericExceptionMacro( << "Exception caught: " << e << std::endl );
+        }
+
+      if( outputBSplineTransform.IsNotNull() )
+        {
+        this->m_CurrentGenericTransform->AddTransform( outputBSplineTransform );
+        }
+      else
+        {
+        itkGenericExceptionMacro( << "******* Error: the BSpline output transform is null." << std::endl );
+        }
       }
     else if( currentTransformType == "SyN" )
       {
 #ifdef USE_ANTS
       //
-      // Process the bulkAffineTransform for SyN's transform initializer
+      // Process SyN transform initializer
       //
-      AffineTransformType::Pointer bulkAffineTransform = AffineTransformType::New();
-      bulkAffineTransform->SetIdentity();
-
-      CompositeTransformType::Pointer initialSyNTransform = CompositeTransformType::New();
-
+      // current m_CurrentGenericTransform will be used as an initializer for SyN registration.
       if( m_CurrentGenericTransform.IsNotNull() )
         {
-        try
+        // Note that the outputs of all the previous linear levels are composed in "one" transform.
+        if( m_CurrentGenericTransform->GetNumberOfTransforms() != 1 )
           {
-          const std::string transformFileType = m_CurrentGenericTransform->GetNameOfClass();
-          if( transformFileType == "VersorRigid3DTransform" )
-            {
-            const VersorRigid3DTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<VersorRigid3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
-            if( tempInitializerITKTransform.IsNull() )
-              {
-              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
-              }
-            AssignRigid::AssignConvertedTransform(bulkAffineTransform, tempInitializerITKTransform);
-            initialSyNTransform->AddTransform(bulkAffineTransform);
-            }
-          else if( transformFileType == "ScaleVersor3DTransform" )
-            {
-            const ScaleVersor3DTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<ScaleVersor3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
-            if( tempInitializerITKTransform.IsNull() )
-              {
-              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
-              }
-            AssignRigid::AssignConvertedTransform(bulkAffineTransform, tempInitializerITKTransform);
-            initialSyNTransform->AddTransform(bulkAffineTransform);
-            }
-          else if( transformFileType == "ScaleSkewVersor3DTransform" )
-            {
-            const ScaleSkewVersor3DTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<ScaleSkewVersor3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
-            if( tempInitializerITKTransform.IsNull() )
-              {
-              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
-              }
-            AssignRigid::AssignConvertedTransform(bulkAffineTransform, tempInitializerITKTransform);
-            initialSyNTransform->AddTransform(bulkAffineTransform);
-            }
-          else if( transformFileType == "AffineTransform" )
-            {
-            const AffineTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<AffineTransformType const *>( m_CurrentGenericTransform.GetPointer() );
-            if( tempInitializerITKTransform.IsNull() )
-              {
-              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
-              }
-            AssignRigid::AssignConvertedTransform(bulkAffineTransform, tempInitializerITKTransform);
-            initialSyNTransform->AddTransform(bulkAffineTransform);
-            }
-          else if( transformFileType == "BSplineDeformableTransform" )
-            {
-            itkGenericExceptionMacro( << "ERROR: Improper transform initializer for SyN registration: "
-                                      << "BSpline Transform cannot be used as a transform initializer for SyN registration"
-                                      << std::endl);
-            }
-          else if( transformFileType == "CompositeTransform" )
-            {
-            itkGenericExceptionMacro( << "ERROR:  Can not initialize SyN with CompositeTranform yet."
-                                      << transformFileType );
-            const CompositeTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<CompositeTransformType const *>( m_CurrentGenericTransform.GetPointer() );
-            if( tempInitializerITKTransform.IsNull() )
-              {
-              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
-              }
-            // AssignRigid::AssignConvertedTransform(bulkAffineTransform, tempInitializerITKTransform);
-            initialSyNTransform->AddTransform(bulkAffineTransform);
-            }
-          else
-            {
-            itkGenericExceptionMacro( << "ERROR:  Invalid transform initializer type found:  "
-                                      << transformFileType );
-            }
+          itkGenericExceptionMacro("Linear initial composite transform should have only one component \
+                                   as all linaear transforms are collapsed together.");
           }
-        catch( itk::ExceptionObject & excp )
-          {
-          std::cout << "[FAILED]" << std::endl;
-          std::cerr << "Error while reading the m_CurrentGenericTransform"
-                    << std::endl << excp << std::endl;
-          throw;
-          }
-        }
 
-      if( initialSyNTransform.IsNull() )
-        {
-        std::cout << "\n**********" << std::endl;
-        std::cout << "ERORR: Undefined intial transform for SyN registration:" << std::endl;
-        std::cout << "SyN registration process cannot be done!" << std::endl;
-        std::cout << "************" << std::endl;
-        itkGenericExceptionMacro( << "******* Error: Undefined intial transform for SyN registration." << std::endl );
+        const GenericTransformType::ConstPointer currInitTransformFormGenericComposite =
+                                                  m_CurrentGenericTransform->GetFrontTransform();
+        const std::string transformFileType = currInitTransformFormGenericComposite->GetNameOfClass();
+
+        // Bspline transform cannot be used as an initializer for SyN registration.
+        if( transformFileType == "BSplineDeformableTransform" )
+          {
+          itkGenericExceptionMacro( << "ERROR: Improper transform initializer for SyN registration: "
+                                    << "BSpline Transform cannot be used as a transform initializer for SyN registration"
+                                    << std::endl);
+          }
         }
       else
         {
-        CompositeTransformType::Pointer outputSyNTransform =
-          simpleSynReg<FixedImageType, MovingImageType>( m_FixedVolume,
-            m_MovingVolume,
-            initialSyNTransform );
+        // Initialize the registeration process with an Identity transform
+        typename AffineTransformType::Pointer initialITKTransform = AffineTransformType::New();
+        initialITKTransform->SetIdentity();
 
-        if( outputSyNTransform.IsNull() )
-          {
-          std::cout << "\n*******Error: the SyN registration has failed.********\n" << std::endl;
-          itkGenericExceptionMacro( << "******* Error: the SyN registration has failed." << std::endl );
-          }
-        else
-          {
-          // CompositeTransformType has derived from itk::Transform, so we can directly assigne that to the
-          // m_CurrentGenericTransform that is a GenericTransformType.
-          m_CurrentGenericTransform = outputSyNTransform.GetPointer();
-          // Now turn of the initiallize code to off
-          localInitializeTransformMode = "Off";
-          }
+        m_CurrentGenericTransform = CompositeTransformType::New();
+        m_CurrentGenericTransform->AddTransform( initialITKTransform );
+        }
+
+        typename CompositeTransformType::Pointer outputSyNTransform =
+          simpleSynReg<FixedImageType, MovingImageType>( m_FixedVolume,
+                                                        m_MovingVolume,
+                                                        m_CurrentGenericTransform );
+
+      if( outputSyNTransform.IsNull() )
+        {
+        std::cout << "\n*******Error: the SyN registration has failed.********\n" << std::endl;
+        itkGenericExceptionMacro( << "******* Error: the SyN registration has failed." << std::endl );
+        }
+      else
+        {
+        // Update m_CurrentGenericTransform after SyN registration.
+        m_CurrentGenericTransform = outputSyNTransform.GetPointer();
         }
 #else
       std::cout << "******* Error: BRAINSFit cannot do the SyN registration ***"
@@ -1578,15 +1468,6 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
         << "Error choosing what kind of transform to fit \""
         << currentTransformType << "(" << currentTransformIndex + 1 << " of " << m_TransformType.size() << "). ");
       }
-
-    if( currentTransformId > m_GenericTransformList.size() - 1 )
-      {
-      itkGenericExceptionMacro(
-        << "Out of bounds access for transform vector!" << std::endl);
-      }
-
-    m_GenericTransformList[currentTransformId] = m_CurrentGenericTransform;
-    currentTransformId++;
     }
   return;
 }
@@ -1614,7 +1495,7 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::PrintSelf(std::ostream
     {
     os << indent << "MovingBinaryVolume: IS NULL" << std::endl;
     }
-  os << indent << "NumberOfSamples:      " << this->m_NumberOfSamples << std::endl;
+  os << indent << "SamplingPercentage:      " << this->m_SamplingPercentage << std::endl;
 
   os << indent << "NumberOfIterations:    [";
   for( unsigned int q = 0; q < this->m_NumberOfIterations.size(); ++q )
@@ -1624,12 +1505,6 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::PrintSelf(std::ostream
   os << "]" << std::endl;
   os << indent << "NumberOfHistogramBins:" << this->m_NumberOfHistogramBins << std::endl;
   os << indent << "MaximumStepLength:    " << this->m_MaximumStepLength << std::endl;
-  os << indent << "MinimumStepLength:     [";
-  for( unsigned int q = 0; q < this->m_MinimumStepLength.size(); ++q )
-    {
-    os << this->m_MinimumStepLength[q] << " ";
-    }
-  os << "]" << std::endl;
   os << indent << "TransformType:     [";
   for( unsigned int q = 0; q < this->m_TransformType.size(); ++q )
     {

--- a/BRAINSCommonLib/GenericTransformImage.h
+++ b/BRAINSCommonLib/GenericTransformImage.h
@@ -18,6 +18,7 @@
 #include "itkScaleVersor3DTransform.h"
 #include "itkScaleSkewVersor3DTransform.h"
 #include "itkAffineTransform.h"
+#include "itkEuler3DTransform.h"
 #include <itkBSplineDeformableTransform.h>
 #include <itkThinPlateR2LogRSplineKernelTransform.h>
 #include "itkVersorRigid3DTransform.h"
@@ -55,6 +56,7 @@ typedef itk::BSplineDeformableTransform<
 
 typedef itk::AffineTransform<double, 3>                      AffineTransformType;
 typedef itk::VersorRigid3DTransform<double>                  VersorRigid3DTransformType;
+typedef itk::Euler3DTransform<double>                        Euler3DTransformType;
 typedef itk::ScaleVersor3DTransform<double>                  ScaleVersor3DTransformType;
 typedef itk::ScaleSkewVersor3DTransform<double>              ScaleSkewVersor3DTransformType;
 typedef itk::ThinPlateR2LogRSplineKernelTransform<double, 3> ThinPlateSpline3DTransformType;
@@ -138,7 +140,8 @@ extern GenericTransformType::Pointer ReadTransformFromDisk(const std::string & i
   * WriteTransformToDisk<TScalarType>(myAffine.GetPointer(), "myAffineFile.mat");
   * \endcode
   */
-extern VersorRigid3DTransformType::Pointer ComputeRigidTransformFromGeneric(
+//extern VersorRigid3DTransformType::Pointer ComputeRigidTransformFromGeneric(
+extern Euler3DTransformType::Pointer ComputeRigidTransformFromGeneric(
   const GenericTransformType::ConstPointer genericTransformToWrite);
 
 /**

--- a/BRAINSCommonLib/TestSuite/itkResampleInPlaceImageFilterTest.cxx
+++ b/BRAINSCommonLib/TestSuite/itkResampleInPlaceImageFilterTest.cxx
@@ -25,7 +25,8 @@
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
-#include "itkVersorRigid3DTransform.h"
+//#include "itkVersorRigid3DTransform.h"
+#include "itkEuler3DTransform.h"
 #include "itkImageRegionConstIterator.h"
 
 #include <iostream>
@@ -61,7 +62,8 @@ int main( int argc, char * argv[] )
 
   typedef itk::ImageRegionConstIterator<ImageType> ImageConstIterator;
   typedef itk::ImageFileReader<ImageType>          ReaderType;
-  typedef itk::VersorRigid3DTransform<double>      TransformType;
+  //typedef itk::VersorRigid3DTransform<double>      TransformType;
+  typedef itk::Euler3DTransform<double>      TransformType;
 
   typedef itk::ResampleInPlaceImageFilter<ImageType, ImageType> FilterType;
 
@@ -83,16 +85,19 @@ int main( int argc, char * argv[] )
     }
 
   // Set up transforms
+  /*
   itk::Vector<double, 3> rotationAxis;
   rotationAxis.Fill( 0. );
   rotationAxis[0] = 1.;
+  */
   double                 rotationAngle = .5; // in rad
   itk::Vector<double, 3> translation;
   translation.Fill( 0. );
   translation[1] = 300.; // in mm along P-axis
   TransformType::Pointer transform = TransformType::New();
   transform->SetIdentity();
-  transform->SetRotation( rotationAxis, rotationAngle );
+  // transform->SetRotation( rotationAxis, rotationAngle ); // Old set up for versorRigid3D
+  transform->SetRotation( rotationAngle, 0, 0 ); // New set up for Euler3D
   transform->Translate( translation, true );
 
   // Set up the resample filter

--- a/BRAINSCommonLib/genericRegistrationHelper.h
+++ b/BRAINSCommonLib/genericRegistrationHelper.h
@@ -17,16 +17,17 @@
 
 #include "BRAINSCommonLib.h"
 
-#if (ITK_VERSION_MAJOR < 4)
-#include "itkOptImageToImageMetric.h"
-#include "itkOptMattesMutualInformationImageToImageMetric.h"
-#else
-#include "itkImageToImageMetric.h"
-#include "itkMattesMutualInformationImageToImageMetric.h"
-#endif
-#define COMMON_MMI_METRIC_TYPE itk::MattesMutualInformationImageToImageMetric
+//#if (ITK_VERSION_MAJOR < 4)
+//#include "itkOptImageToImageMetric.h"
+//#include "itkOptMattesMutualInformationImageToImageMetric.h"
+//#else
+#include "itkImageToImageMetricv4.h"
+#include "itkMattesMutualInformationImageToImageMetricv4.h"
+#include "itkConjugateGradientLineSearchOptimizerv4.h"
+//#endif
+#define COMMON_MMI_METRIC_TYPE itk::MattesMutualInformationImageToImageMetricv4
 
-#include "itkImageRegistrationMethod.h"
+#include "itkImageRegistrationMethodv4.h"
 #include "itkLinearInterpolateImageFunction.h"
 #include "itkImage.h"
 #include "itkDataObjectDecorator.h"
@@ -42,6 +43,8 @@
 
 #include "itkMultiThreader.h"
 #include "itkResampleImageFilter.h"
+
+#include "itkIntensityWindowingImageFilter.h"
 
 #ifdef USE_DebugImageViewer
 #include "DebugImageViewerClient.h"
@@ -139,8 +142,11 @@ public:
   typedef  itk::Command           Superclass;
   typedef itk::SmartPointer<Self> Pointer;
   itkNewMacro(Self);
+
   typedef          TOptimizer  OptimizerType;
   typedef const OptimizerType *OptimizerPointer;
+
+  typedef const typename OptimizerType::ParametersType OptimizerParametersType;
 
   typedef typename COMMON_MMI_METRIC_TYPE<TImage, TImage> MattesMutualInformationMetricType;
   void SetDisplayDeformedImage(bool x)
@@ -217,7 +223,7 @@ public:
       return;
       }
 
-    typename OptimizerType::ParametersType parms =
+    OptimizerParametersType parms =
       optimizer->GetCurrentPosition();
     int  psize = parms.GetNumberOfElements();
     bool parmsNonEmpty = false;
@@ -378,6 +384,10 @@ public:
   typedef typename TransformOutputType::ConstPointer
     TransformOutputConstPointer;
 
+  itkStaticConstMacro(MovingImageDimension, unsigned int, MovingImageType::ImageDimension);
+
+  typedef itk::CompositeTransform<double, MovingImageDimension>     CompositeTransformType;
+
   typedef          TOptimizer                    OptimizerType;
   typedef const OptimizerType *                  OptimizerPointer;
   typedef typename OptimizerType::ScalesType     OptimizerScalesType;
@@ -388,12 +398,18 @@ public:
   typedef typename MetricType::MovingImageMaskType MovingBinaryVolumeType;
   typedef typename MovingBinaryVolumeType::Pointer MovingBinaryVolumePointer;
 
-  typedef LinearInterpolateImageFunction<
+  typedef ImageRegistrationMethodv4<
+      FixedImageType,
       MovingImageType,
-      double>    InterpolatorType;
+      TransformType>                                            RegistrationType;
+  typedef typename RegistrationType::Pointer                    RegistrationPointer;
 
-  typedef ImageRegistrationMethod<FixedImageType, MovingImageType> RegistrationType;
-  typedef typename RegistrationType::Pointer                       RegistrationPointer;
+  typedef itk::AffineTransform<double, 3>                             AffineTransformType;
+  typedef itk::ImageRegistrationMethodv4<
+      FixedImageType,
+      MovingImageType,
+      AffineTransformType>                                            AffineRegistrationType;
+  typedef typename AffineRegistrationType::MetricSamplingStrategyType SamplingStrategyType;
 
   typedef itk::CenteredTransformInitializer<
       TransformType,
@@ -421,28 +437,25 @@ public:
   itkGetConstObjectMacro(MovingImage, MovingImageType);
 
   /** Set/Get the InitialTransfrom. */
-  void SetInitialTransform(typename TransformType::Pointer initialTransform);
-  itkGetConstObjectMacro(InitialTransform, TransformType);
+  void SetInitialTransform(typename CompositeTransformType::Pointer initialTransform);
 
   /** Set/Get the Transfrom. */
   itkSetObjectMacro(Transform, TransformType);
-  typename TransformType::Pointer GetTransform(void);
+  typename CompositeTransformType::Pointer GetTransform(void);
 
   // itkSetMacro( PermitParameterVariation, std::vector<int>      );
 
   itkSetObjectMacro(CostMetricObject, MetricType);
   itkGetConstObjectMacro(CostMetricObject, MetricType);
 
-  itkSetMacro(NumberOfSamples,               unsigned int);
+  itkSetMacro(SamplingPercentage,            double);
   itkSetMacro(NumberOfHistogramBins,         unsigned int);
   itkSetMacro(NumberOfIterations,            unsigned int);
   itkSetMacro(RelaxationFactor,              double);
   itkSetMacro(MaximumStepLength,             double);
-  itkSetMacro(MinimumStepLength,             double);
   itkSetMacro(TranslationScale,              double);
   itkSetMacro(ReproportionScale,             double);
   itkSetMacro(SkewScale,                     double);
-  itkSetMacro(InitialTransformPassThruFlag,  bool);
   itkSetMacro(BackgroundFillValue,           double);
   itkSetMacro(DisplayDeformedImage,          bool);
   itkSetMacro(PromptUserAfterDisplay,        bool);
@@ -453,6 +466,9 @@ public:
   // Debug option for MI metric
   itkSetMacro(ForceMINumberOfThreads, int);
   itkGetConstMacro(ForceMINumberOfThreads, int);
+
+  itkSetMacro(SamplingStrategy,SamplingStrategyType);
+  itkGetConstMacro(SamplingStrategy,SamplingStrategyType);
 
   /** Returns the transform resulting from the registration process  */
   const TransformOutputType * GetOutput() const;
@@ -507,8 +523,9 @@ private:
 
   FixedImagePointer  m_FixedImage;
   MovingImagePointer m_MovingImage;
-  TransformPointer   m_InitialTransform;
-  TransformPointer   m_Transform;
+
+  typename CompositeTransformType::Pointer m_CompositeTransform;
+  TransformPointer                         m_Transform;
   //
   // make sure parameters persist until after they're used by the transform
 
@@ -517,22 +534,22 @@ private:
   std::vector<int> m_PermitParameterVariation;
   typename MetricType::Pointer  m_CostMetricObject;
 
-  unsigned int m_NumberOfSamples;
+  double       m_SamplingPercentage;
   unsigned int m_NumberOfHistogramBins;
   unsigned int m_NumberOfIterations;
   double       m_RelaxationFactor;
   double       m_MaximumStepLength;
-  double       m_MinimumStepLength;
   double       m_TranslationScale;
   double       m_ReproportionScale;
   double       m_SkewScale;
-  bool         m_InitialTransformPassThruFlag;
   double       m_BackgroundFillValue;
   unsigned int m_ActualNumberOfIterations;
   bool         m_DisplayDeformedImage;
   bool         m_PromptUserAfterDisplay;
   double       m_FinalMetricValue;
   bool         m_ObserveIterations;
+
+  SamplingStrategyType m_SamplingStrategy;
   // DEBUG OPTION:
   int m_ForceMINumberOfThreads;
 

--- a/BRAINSCommonLib/genericRegistrationHelper.hxx
+++ b/BRAINSCommonLib/genericRegistrationHelper.hxx
@@ -28,10 +28,13 @@
 #include "itkStatisticsImageFilter.h"
 #include "itkImageDuplicator.h"
 
+#include "itkTransformFileWriter.h"
+
 extern void debug_catch(void);
 
 namespace itk
 {
+
 /*
   * Constructor
   */
@@ -42,29 +45,29 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
 ::MultiModal3DMutualRegistrationHelper() :
   m_FixedImage(0),                         // has to be provided by the user.
   m_MovingImage(0),                        // has to be provided by the user.
-  m_InitialTransform(0),                   // has to be provided by the user.
+  m_CompositeTransform(NULL),              /* It is set by initial moving transform and
+                                              integrates that with registration output transform.*/
   m_Transform(0),                          // has to be provided by
                                            // this->Initialize().
   m_Registration(0),                       // has to be provided by
                                            // this->Initialize().
   m_PermitParameterVariation(0),
   m_CostMetricObject(NULL),
-  m_NumberOfSamples(100000),
+  m_SamplingPercentage(1),
   m_NumberOfHistogramBins(200),
   m_NumberOfIterations(0),
   m_RelaxationFactor(0.5),
   m_MaximumStepLength(0.2000),
-  m_MinimumStepLength(0.0001),
   m_TranslationScale(1000.0),
   m_ReproportionScale(25.0),
   m_SkewScale(25.0),
-  m_InitialTransformPassThruFlag(false),
   m_BackgroundFillValue(0.0),
   m_ActualNumberOfIterations(0),
   m_DisplayDeformedImage(false),
   m_PromptUserAfterDisplay(false),
   m_FinalMetricValue(0),
   m_ObserveIterations(true),
+  m_SamplingStrategy(AffineRegistrationType::NONE),
   m_ForceMINumberOfThreads(-1),
   m_InternalTransformTime(0)
 {
@@ -79,8 +82,8 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
 }
 
 /*
-  * Initialize by setting the interconnects between components.
-  */
+ * Initialize by setting the interconnects between components.
+ */
 template <typename TTransformType, typename TOptimizer, typename TFixedImage,
           typename TMovingImage, typename MetricType>
 void
@@ -101,220 +104,125 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
   //
   // Connect the transform to the Decorator.
   //
-  TransformOutputType *transformOutput =
-    static_cast<TransformOutputType *>( this->ProcessObject::GetOutput(0) );
+  //TransformOutputType *transformOutput = static_cast<TransformOutputType *>( this->ProcessObject::GetOutput(0) );
 
-  transformOutput->Set( m_Transform.GetPointer() );
+  //transformOutput->Set( m_Transform.GetPointer() );
 
-  typename OptimizerType::Pointer optimizer      = OptimizerType::New();
-  typename InterpolatorType::Pointer interpolator   = InterpolatorType::New();
+  if( this->m_CompositeTransform.IsNull() )
+    {
+    this->m_CompositeTransform = CompositeTransformType::New();
+    }
 
-  optimizer->SetMaximize(false);   // Mutual Information metrics are to be
-                                   // minimized.
+  typedef itk::RegistrationParameterScalesFromPhysicalShift<MetricType> ScalesEstimatorType;
+  typename ScalesEstimatorType::Pointer scalesEstimator = ScalesEstimatorType::New();
+  scalesEstimator->SetMetric( this->m_CostMetricObject );
+  scalesEstimator->SetTransformForward( true );
+  //scalesEstimator->DebugOn();
+
+  //HACK: optimizer is hardcoded.
+  //typename OptimizerType::Pointer optimizer = OptimizerType::New();
+  typedef itk::ConjugateGradientLineSearchOptimizerv4Template<double> ConjugateGradientDescentOptimizerType;
+  ConjugateGradientDescentOptimizerType::Pointer optimizer = ConjugateGradientDescentOptimizerType::New();//////?????
+
+  // Added for v4 optimizer
+  optimizer->SetLowerLimit( 0 );
+  optimizer->SetUpperLimit( 2 );
+  optimizer->SetEpsilon( 0.2 );
+  optimizer->SetLearningRate( m_MaximumStepLength );
+  optimizer->SetMaximumStepSizeInPhysicalUnits(m_MaximumStepLength);
+  optimizer->SetNumberOfIterations(m_NumberOfIterations);
+  optimizer->SetScalesEstimator( scalesEstimator );
+
+  const double convergenceThreshold = 1e-6;
+  const int convergenceWindowSize = 10;
+  optimizer->SetMinimumConvergenceValue( convergenceThreshold );
+  optimizer->SetConvergenceWindowSize( convergenceWindowSize );
+
+  optimizer->SetDoEstimateLearningRateAtEachIteration( true );
+  optimizer->SetDoEstimateLearningRateOnce( false );
+
+  //optimizer->DebugOn();
 
   m_Registration = RegistrationType::New();
 
-    {
-    // Special BUG work around for MMI metric
-    // that does not work in multi-threaded mode
-    typedef COMMON_MMI_METRIC_TYPE<FixedImageType, MovingImageType> MattesMutualInformationMetricType;
-    typename MattesMutualInformationMetricType::Pointer test_MMICostMetric =
-      dynamic_cast<MattesMutualInformationMetricType *>(this->m_CostMetricObject.GetPointer() );
-    if( test_MMICostMetric.IsNotNull() )
-      {
-      if( this->m_ForceMINumberOfThreads != 1 )
-        {
-        std::cout << "WARNING USING MAX MMI NUMBER OF THREADS:   " << this->m_ForceMINumberOfThreads << std::endl;
-        }
-      if( this->m_ForceMINumberOfThreads > 0 )
-        {
-        this->m_CostMetricObject->SetNumberOfThreads(this->m_ForceMINumberOfThreads);
-        this->m_Registration->SetNumberOfThreads(this->m_ForceMINumberOfThreads);
-        }
-      else
-        {
-        this->m_CostMetricObject->SetNumberOfThreads(itk::MultiThreader::GetGlobalDefaultNumberOfThreads() );
-        this->m_Registration->SetNumberOfThreads(itk::MultiThreader::GetGlobalDefaultNumberOfThreads() );
-        }
-      }
-    else
-      {
-      this->m_CostMetricObject->SetNumberOfThreads(itk::MultiThreader::GetGlobalDefaultNumberOfThreads() );
-      this->m_Registration->SetNumberOfThreads(itk::MultiThreader::GetGlobalDefaultNumberOfThreads() );
-      }
-    }
+  /*
+  // writing fixed and moving images right before passing to the registration filter
+  typedef typename  itk::ImageFileWriter< TFixedImage  > WriterType;
+  typename WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("fixedImageRightBeforeRegistrationStarts_DEBUG.nii.gz");
+  writer->SetInput(m_FixedImage);
+  writer->Update();
+
+  typename WriterType::Pointer writer2 = WriterType::New();
+  writer2->SetFileName("movingImageRightBeforeRegistrationStarts_DEBUG.nii.gz");
+  writer2->SetInput(m_MovingImage);
+  writer2->Update();
+  *//////////////////////////////////////////////////////////////
+
+  //m_CostMetricObject->DebugOn();
+
+  m_Registration->SetFixedImage(0, m_FixedImage);
+  m_Registration->SetMovingImage(0, m_MovingImage);
   m_Registration->SetMetric(this->m_CostMetricObject);
+
+////////////////////////HARD CODED PART//////////////////////
+  const unsigned int numberOfLevels = 2;
+
+  m_Registration->SetNumberOfLevels( numberOfLevels );
+
+  typename RegistrationType::ShrinkFactorsPerDimensionContainerType shrinkFactorsList;
+//  shrinkFactorsList[0]=1;
+//  shrinkFactorsList[1]=1;
+//  shrinkFactorsList[2]=1;
+//  m_Registration->SetShrinkFactorsPerDimension( 0, shrinkFactorsList );
+
+  shrinkFactorsList[0]=3;
+  shrinkFactorsList[1]=1;
+
+  for( unsigned int level = 0; level < numberOfLevels; ++level )
+    {
+    m_Registration->SetShrinkFactorsPerDimension( level, shrinkFactorsList[level] );
+    }
+
+  typename RegistrationType::SmoothingSigmasArrayType smoothingSigma;
+  smoothingSigma.SetSize(2);
+  smoothingSigma[0]=2;
+  smoothingSigma[1]=0;
+
+  m_Registration->SetSmoothingSigmasPerLevel(smoothingSigma);
+  m_Registration->SetSmoothingSigmasAreSpecifiedInPhysicalUnits(false);
+////////////////////////////////////////////////////////////
+
+  m_Registration->SetMetricSamplingStrategy(
+                static_cast<typename RegistrationType::MetricSamplingStrategyType>( m_SamplingStrategy ));
+  m_Registration->SetMetricSamplingPercentage(this->m_SamplingPercentage);
+
   m_Registration->SetOptimizer(optimizer);
-  m_Registration->SetInterpolator(interpolator);
 
-  m_Registration->SetTransform(m_Transform);
-  m_Registration->SetFixedImage(m_FixedImage);
-  m_Registration->SetMovingImage(m_MovingImage);
-
-  m_Registration->SetFixedImageRegion( m_FixedImage->GetLargestPossibleRegion() );
-
-  std::vector<int> localPermissionToVary( m_Transform->GetNumberOfParameters() );
-
+  if( this->m_CompositeTransform->GetNumberOfTransforms() > 0 )
     {
-    unsigned int i = 0;
-    while( i < m_Transform->GetNumberOfParameters() )
-      {
-      if( i < m_PermitParameterVariation.size() )
-        {
-        localPermissionToVary[i] = m_PermitParameterVariation[i];
-        }
-      else
-        {
-        localPermissionToVary[i] = 1;
-        }
-      ++i;
-      }
-    }
-  // Decode localPermissionToVary from its initial segment,
-  // PermitParameterVariation.
-  if( ( m_PermitParameterVariation.size() != m_Transform->GetNumberOfParameters() )
-      && ( m_PermitParameterVariation.size() != 0 ) )
-    {
-    std::cout << "WARNING:  The permit parameters SHOULD match the number of"
-              << " parameters used for this registration type."
-              << std::endl;
-    std::cout << "WARNING:  Padding with 1's for the unspecified parameters" << std::endl;
-    std::cout << "m_PermitParameterVariation " << m_PermitParameterVariation.size() << " != "
-              << m_Transform->GetNumberOfParameters() << std::endl;
-    std::cout << "\nUSING: [ ";
-    for( unsigned int i = 0; i < localPermissionToVary.size(); ++i )
-      {
-      std::cout << localPermissionToVary[i] << " ";
-      }
-    std::cout << " ]" << std::endl;
-    }
+    //this->m_CompositeTransform->SetOnlyMostRecentTransformToOptimizeOn();
 
-  if( m_InitialTransform )
-    {
-    // TODO: There should be no need to convert here, just assign m_Transform
-    // from m_InitialTransform.
-    //      They should be the same type!
+    /*
+    ////////
+    if(this->m_CompositeTransform->GetNumberOfTransforms() == 1)
       {
-      const typename TTransformType::ConstPointer tempInitializerITKTransform = m_InitialTransform.GetPointer();
-      // NOTE By calling AssignConvertedTransform, it also copies the values
-      AssignRigid::AssignConvertedTransform(m_Transform, tempInitializerITKTransform);
+      std::cout << "write the initial transform to the disk right before registration starts." << std::endl;
+      this->m_CompositeTransform->Print(std::cout);
+      itk::TransformFileWriter::Pointer dwriter1 = itk::TransformFileWriter::New();
+      dwriter1->SetInput( this->m_CompositeTransform->GetFrontTransform() );
+      dwriter1->SetFileName("initialTransformRightBeforeRegistrationStarts_DEBUG.mat");
+      dwriter1->Update();
       }
+    *//////
 
-    // No need to step on parameters that may not vary; they will remain
-    // identical with
-    // values from InitialTransform which defaults correctly to SetIdentity().
+    m_Registration->SetMovingInitialTransform( this->m_CompositeTransform );
     }
-  else      // Won't happen under BRAINSFitPrimary.
-    {
-    itkGenericExceptionMacro(<< "FAILURE:  InitialTransform must be set in"
-                             << " MultiModal3DMutualRegistrationHelper before Initialize is called.");
-    //  m_Transform would be SetIdentity() if this case continued.
-    }
-
-  //  We now pass the parameters of the current transform as the initial
-  //  parameters to be used when the registration process starts.
-  m_Registration->SetInitialTransformParameters( m_Transform->GetParameters() );
-
-  const double translationScale  = 1.0 / m_TranslationScale;
-  const double reproportionScale = 1.0 / m_ReproportionScale;
-  const double skewScale         = 1.0 / m_SkewScale;
-
-  OptimizerScalesType optimizerScales( m_Transform->GetNumberOfParameters() );
-
-  if( m_Transform->GetNumberOfParameters() == 15 )     //  ScaleSkew
-    {
-    for( unsigned int i = 0; i < m_Transform->GetNumberOfParameters(); ++i )
-      {
-      optimizerScales[i] = 1.0;
-      }
-    for( unsigned int i = 3; i < 6; ++i )
-      {
-      optimizerScales[i] = translationScale;
-      }
-    for( unsigned int i = 6; i < 9; ++i )
-      {
-      optimizerScales[i] = reproportionScale;
-      }
-    for( unsigned int i = 9; i < 15; ++i )
-      {
-      optimizerScales[i] = skewScale;
-      }
-    }
-  else if( m_Transform->GetNumberOfParameters() == 12 )     //  Affine
-    {
-    for( unsigned int i = 0; i < 9; ++i )
-      {
-      optimizerScales[i] = 1.0;
-      }
-    for( unsigned int i = 9; i < 12; ++i )
-      {
-      optimizerScales[i] = translationScale;
-      }
-    }
-  else if( m_Transform->GetNumberOfParameters() == 9 )    // ScaleVersorRigid3D
-    {
-    for( unsigned int i = 0; i < 3; ++i )
-      {
-      optimizerScales[i] = 1.0;
-      }
-    for( unsigned int i = 3; i < 6; ++i )
-      {
-      optimizerScales[i] = translationScale;
-      }
-    for( unsigned int i = 6; i < 9; ++i )
-      {
-      optimizerScales[i] = reproportionScale;
-      }
-    }
-  else if( m_Transform->GetNumberOfParameters() == 6 )     //  VersorRigid3D
-    {
-    for( unsigned int i = 0; i < 3; ++i )
-      {
-      optimizerScales[i] = 1.0;
-      }
-    for( unsigned int i = 3; i < 6; ++i )
-      {
-      optimizerScales[i] = translationScale;
-      }
-    }
-  else     // most likely (m_Transform->GetNumberOfParameters() == 3): uniform
-           // parameter scaling, whether
-           // just rotating OR just translating.
-    {
-    for( unsigned int i = 0; i < m_Transform->GetNumberOfParameters(); ++i )
-      {
-      optimizerScales[i] = 1.0;
-      }
-    }
-  // Step on parameters that may not vary; they also must be identical with
-  // SetIdentity().
-  for( unsigned int i = 0; i < m_Transform->GetNumberOfParameters(); ++i )
-    {
-    if( localPermissionToVary[i] == 0 )
-      {
-      // Make huge to greatly penilize any motion
-      optimizerScales[i] = 0.5 * vcl_numeric_limits<float>::max();
-      }
-    }
-
-  std::cout << "Initializer, optimizerScales: " << optimizerScales << "."
-            << std::endl;
-  optimizer->SetScales(optimizerScales);
-
-  optimizer->SetRelaxationFactor(m_RelaxationFactor);
-  optimizer->SetMaximumStepLength(m_MaximumStepLength);
-  optimizer->SetMinimumStepLength(m_MinimumStepLength);
-  optimizer->SetNumberOfIterations(m_NumberOfIterations);
-
-  // std::cout << "OPTIMIZER    THREADS USED: " << optimizer->GetNumberOfThreads()                << std::endl;
-  std::cout << "METRIC       THREADS USED: " << this->m_CostMetricObject->GetNumberOfThreads()
-            << " of " << itk::MultiThreader::GetGlobalDefaultNumberOfThreads() <<  std::endl;
-  std::cout << "REGISTRATION THREADS USED: " << this->m_Registration->GetNumberOfThreads()
-            << " of " << itk::MultiThreader::GetGlobalDefaultNumberOfThreads() <<  std::endl;
 
   // Create the Command observer and register it with the optimizer.
   // TODO:  make this output optional.
   //
+
   if( this->m_ObserveIterations == true )
     {
     typedef BRAINSFit::CommandIterationUpdate<TOptimizer, TTransformType, TMovingImage>
@@ -346,8 +254,8 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
 }
 
 /*
-  * Starts the Registration Process
-  */
+ * Starts the Registration Process
+ */
 template <typename TTransformType, typename TOptimizer, typename TFixedImage,
           typename TMovingImage, typename MetricType>
 void
@@ -368,47 +276,25 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
     this->m_InternalTransformTime = t;
     }
 
-  if( !m_InitialTransformPassThruFlag )
+  //m_Registration->DebugOn();
+
+  try
     {
-    bool               successful = false;
-    const unsigned int diff = this->m_NumberOfSamples / 10;
-    while( !successful )
-      {
-      try
-        {
-        m_Registration->Update();
-        successful = true;
-        }
-      catch( itk::ExceptionObject & /* err */ )
-        {
-        // Attempt to auto-recover if too many samples were requested.
-        // std::cerr << "ExceptionObject caught !" << std::endl;
-        // std::cerr << err << std::endl;
-        // Pass exception to caller
-        //        throw err;
-        //
-        // lower the number of samples you request
-        typename MetricType::Pointer autoResetNumberOfSamplesMetric =
-          dynamic_cast<MetricType *>( this->m_Registration->GetModifiableMetric() );
-        if( autoResetNumberOfSamplesMetric.IsNull() )
-          {
-          std::cout << "ERROR::" << __FILE__ << " " << __LINE__ << std::endl;
-          throw;
-          }
-        unsigned int localNumberOfSamples = autoResetNumberOfSamplesMetric->GetNumberOfSpatialSamples();
-        if( diff > localNumberOfSamples )
-          {
-          // we are done.  This can not be recovered from.
-          throw;
-          }
-        localNumberOfSamples -= diff;
-        autoResetNumberOfSamplesMetric->SetNumberOfSpatialSamples(localNumberOfSamples);
-        }
-      }
+    m_Registration->Update();
+    }
+  catch( itk::ExceptionObject & err )
+    {
+    // Attempt to auto-recover if too many samples were requested.
+    std::cerr << "ExceptionObject caught !" << std::endl;
+    std::cerr << err << std::endl;
+    // Pass exception to caller
+    throw err;
+    }
 
-    OptimizerParametersType finalParameters( m_Transform->GetNumberOfParameters() );
-
-    finalParameters = m_Registration->GetLastTransformParameters();
+  std::cout << "METRIC       THREADS USED: " << this->m_CostMetricObject->GetNumberOfThreadsUsed()
+  << " of " << itk::MultiThreader::GetGlobalDefaultNumberOfThreads() <<  std::endl;
+  std::cout << "REGISTRATION THREADS USED: " << this->m_Registration->GetNumberOfThreads()
+  << " of " << itk::MultiThreader::GetGlobalDefaultNumberOfThreads() <<  std::endl;
 
     OptimizerPointer optimizer =
       dynamic_cast<OptimizerPointer>( m_Registration->GetOptimizer() );
@@ -419,20 +305,36 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
     std::cout << "Stop condition from optimizer." << optimizer->GetStopConditionDescription() << std::endl;
     m_FinalMetricValue = optimizer->GetValue();
     m_ActualNumberOfIterations = optimizer->GetCurrentIteration();
-    m_Transform->SetParametersByValue(finalParameters);
+
+    m_Transform->SetFixedParameters( m_Registration->GetOutput()->Get()->GetFixedParameters() );
+    m_Transform->SetParameters( m_Registration->GetOutput()->Get()->GetParameters() );
+    /*
+    /////////
+    std::cout << "\n----------------\n";
+    std::cout << "Registration output transform:" << std::endl;
+    m_Transform->Print(std::cout);
+    /////////
+    */
       {
       this->m_InternalTransformTime = this->m_Transform->GetMTime();
       }
-    }
+
+  this->m_CompositeTransform->AddTransform( this->m_Transform ); // The registration output transform is added to the
+                                                                 // initial transform, and the result composite transform
+                                                                 // is returned as the final transform of this class.
+
+  std::cout << "\n---After registration:---";
   typename TransformType::MatrixType matrix = m_Transform->GetMatrix();
   typename TransformType::OffsetType offset = m_Transform->GetOffset();
   std::cout << std::endl << "Matrix = " << std::endl << matrix << std::endl;
-  std::cout << "Offset = " << offset << std::endl << std::endl;
+  std::cout << "Offset = " << offset << std::endl;
+  std::cout << "--------------" << std::endl << std::endl;
+
 }
 
-/**
-  *
-  */
+/*
+ *
+ */
 template <typename TTransformType, typename TOptimizer, typename TFixedImage,
           typename TMovingImage, typename MetricType>
 unsigned long
@@ -458,9 +360,9 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
     mtime = ( m > mtime ? m : mtime );
     }
 
-  if( m_InitialTransform )
+  if( m_CompositeTransform )
     {
-    m = m_InitialTransform->GetMTime();
+    m = m_CompositeTransform->GetMTime();
     mtime = ( m > mtime ? m : mtime );
     }
 
@@ -531,36 +433,57 @@ template <typename TTransformType, typename TOptimizer, typename TFixedImage,
 void
 MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
                                      TMovingImage, MetricType>
-::SetInitialTransform(typename TransformType::Pointer initialTransform)
+::SetInitialTransform(typename CompositeTransformType::Pointer initialTransform)
 {
   itkDebugMacro("setting Initial Transform to " << initialTransform);
-  if( this->m_InitialTransform.GetPointer() != initialTransform )
+  if( initialTransform.IsNull() )
     {
-    this->m_InitialTransform = initialTransform;
-    this->Modified();
+    itkGenericExceptionMacro("initial transform is null");
     }
+  typename CompositeTransformType::Pointer compToAdd;
+  compToAdd = initialTransform->Clone();
+  this->m_CompositeTransform = compToAdd;
+/*
+  typename CompositeTransformType::Pointer compToAdd;
+  typename CompositeTransformType::ConstPointer compXfrm =
+    dynamic_cast<const CompositeTransformType *>( initialTransform.GetPointer() );
+  if( compXfrm.IsNotNull() )
+    {
+    compToAdd = compXfrm->Clone();
+    this->m_CompositeTransform = compToAdd;
+    }
+  else
+    {
+    compToAdd = CompositeTransformType::New();
+    typename TransformType::Pointer xfrm = initialTransform->Clone();
+    compToAdd->AddTransform( xfrm );
+    this->m_CompositeTransform = compToAdd;
+    }
+*/
 }
 
 template <typename TTransformType, typename TOptimizer, typename TFixedImage,
           typename TMovingImage, typename MetricType>
 typename MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer,
-                                              TFixedImage, TMovingImage, MetricType>::TransformType::Pointer
+                                              TFixedImage, TMovingImage, MetricType>::CompositeTransformType::Pointer
 MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
                                      TMovingImage, MetricType>
 ::GetTransform(void)
 {
-  this->Update();
-  return m_Transform;
+  //this->Update();
+  return this->m_CompositeTransform;
+  //return this->m_Transform;
 }
 
 /*
-  *  Get Output
-  */
+ *  Get Output
+ */
+
 template <typename TTransformType, typename TOptimizer, typename TFixedImage,
           typename TMovingImage, typename MetricType>
 const typename MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer,
-                                                    TFixedImage, TMovingImage, MetricType>::TransformOutputType
-* MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
+                                                    TFixedImage, TMovingImage, MetricType>::TransformOutputType *
+MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
                                        TMovingImage, MetricType>
 ::GetOutput() const
   {
@@ -590,8 +513,8 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
 }
 
 /*
-  * PrintSelf
-  */
+ * PrintSelf
+ */
 template <typename TTransformType, typename TOptimizer, typename TFixedImage,
           typename TMovingImage, typename MetricType>
 void

--- a/BRAINSCommonLib/itkResampleInPlaceImageFilter.h
+++ b/BRAINSCommonLib/itkResampleInPlaceImageFilter.h
@@ -10,7 +10,8 @@
 #define __itkResampleInPlaceImageFilter_h
 
 #include "itkImageToImageFilter.h"
-#include "itkVersorRigid3DTransform.h"
+//#include "itkVersorRigid3DTransform.h"
+#include "itkEuler3DTransform.h"
 
 namespace itk
 {
@@ -33,7 +34,7 @@ namespace itk
  * of the image and there is no need to maintain the final transform any longer. ITK
  * image class has innate support for doing this.
  *
- * \param RigidTransform -- Currently must be a VersorRigid3D
+ * \param RigidTransform -- Currently must be a EulerRigid3D (x-- previously it was "versorRigid3D" --x)
  * \param InputImage -- The image to be duplicated and modified to incorporate the
  * rigid transform
  * \return -- An image with the same voxels values as the input, but with differnt
@@ -84,7 +85,8 @@ public:
 #endif
 
   /** Transform typedef */
-  typedef VersorRigid3DTransform<double>            RigidTransformType;
+  //typedef VersorRigid3DTransform<double>            RigidTransformType;
+  typedef Euler3DTransform<double>            RigidTransformType;
   typedef typename RigidTransformType::ConstPointer RigidTransformConstPointer;
 
   /** Set/Get rigid transform. The default is an identity transform */

--- a/BRAINSFit/BRAINSFit.xml
+++ b/BRAINSFit/BRAINSFit.xml
@@ -82,6 +82,17 @@
       <element>useGeometryAlign</element>
       <element>useCenterOfROIAlign</element>
     </string-enumeration>
+
+    <string-enumeration>
+      <name>metricSamplingStrategy</name>
+      <longflag>metricSamplingStrategy</longflag>
+      <label>Set Sampling Strategy</label>
+      <description>It defines the method that registration filter uses to sample the input fixed image={None,Regular,Random}</description>
+      <default>None</default>
+      <element>None</element>
+      <element>Random</element>
+      <element>Regular</element>
+    </string-enumeration>
   </parameters>
 
   <parameters>
@@ -146,9 +157,17 @@
       <name>numberOfSamples</name>
       <longflag>numberOfSamples</longflag>
       <label>Number Of Samples</label>
-      <description>The number of voxels sampled for mutual information computation.  Increase this for a slower, more careful fit.  You can also limit the sampling focus with ROI masks and ROIAUTO mask generation.</description>
-      <default>100000</default>
+      <description>The number of voxels sampled for mutual information computation.  Increase this for a slower, more careful fit. NOTE that it is suggested to use samplingPercentage instead of this option. However, if set, it overwrites the samplingPercentage option.  </description>
+      <default>0</default>
     </integer>
+
+    <double>
+      <name>samplingPercentage</name>
+      <longflag>samplingPercentage</longflag>
+      <label>Percentage Of Samples</label>
+      <description>This is a number in [0,1] interval that shows the percentage of the input fixed image voxels that are sampled for mutual information computation.  Increase this for a slower, more careful fit. You can also limit the sampling focus with ROI masks and ROIAUTO mask generation.</description>
+      <default>1</default>
+    </double>
 
     <integer-vector>
       <name>splineGridSize</name>
@@ -288,7 +307,7 @@
       <longflag deprecatedalias="minimumStepSize">minimumStepLength</longflag>
       <label>Minimum Step Length</label>
       <description>Each step in the optimization takes steps at least this big.  When none are possible, registration is complete.</description>
-      <default>0.005</default>
+      <default>0</default>
     </double-vector>
 
     <double>

--- a/BRAINSFit/TestSuite/CMakeLists.txt
+++ b/BRAINSFit/TestSuite/CMakeLists.txt
@@ -245,34 +245,6 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
 )
 ## NOTE: 7.3 above was computed explicitly through testing.
 
-set(BRAINSFitTestName BRAINSFitTest_BSplineBSplineRescaleHeadMasks)
-ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
-  COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSFitTestDriver>
-  --compare DATA{${TestData_DIR}/${BRAINSFitTestName}.result.nii.gz}
-            ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nii.gz
-  --compareIntensityTolerance 9
-  --compareRadiusTolerance 0
-  --compareNumberOfPixelsTolerance 1000
-  BRAINSFitTest
-  --costMetric MMI
-  --failureExitCode -1 --writeTransformOnFailure
-  --numberOfIterations 1500
-  --numberOfHistogramBins 200
-  --splineGridSize 7,5,6
-  --numberOfSamples 288000
-  --translationScale 250
-  --minimumStepLength 0.005
-  --outputVolumePixelType short
-  --maskProcessingMode ROIAUTO
-  --initialTransform DATA{${TestData_DIR}/Transforms_h5/Initializer_BRAINSFitTest_BSplineOnlyRescaleHeadMasks.${XFRM_EXT}}
-  --transformType BSpline
-  --fixedVolume DATA{${TestData_DIR}/test.nii.gz}
-  --movingVolume DATA{${TestData_DIR}/rotation.rescale.rigid.nii.gz}
-  --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nii.gz
-  --outputTransform ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.${XFRM_EXT}
-  --maxBSplineDisplacement 7.3
-)
-
 set(BRAINSFitTestName BRAINSFitTest_BSplineScaleRotationRescaleHeadMasks)
 ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSFitTestDriver>

--- a/SuperBuild/External_ANTs.cmake
+++ b/SuperBuild/External_ANTs.cmake
@@ -77,10 +77,10 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
    list(APPEND ${proj}_CMAKE_OPTIONS -DANTS_USE_QT:BOOL=ON)
  endif()
   ### --- End Project specific additions
-#  set(${proj}_REPOSITORY "https://github.com/stnava/ANTs.git")
-#  set(${proj}_GIT_TAG "9698e1460c50b5fb703e2dbcd382671cbd9902f1")
   set(${proj}_REPOSITORY "https://github.com/BRAINSia/ANTs.git")
   set(${proj}_GIT_TAG "ForceConsistentTypePresicion")
+  #set(${proj}_REPOSITORY "https://github.com/aghayoor/ANTs-1.git")
+  #set(${proj}_GIT_TAG "0c39e1adff5d6c8ffc0bb9ca222f96edbe32a8ca")
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}
     GIT_TAG ${${proj}_GIT_TAG}

--- a/SuperBuild/External_ITKv4.cmake
+++ b/SuperBuild/External_ITKv4.cmake
@@ -139,6 +139,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://itk.org/ITK.git)
   set(${proj}_GIT_TAG 9cfd006c13cfec907428bee7b27cbcf5a5005320)
+  #set(${proj}_REPOSITORY https://github.com/aghayoor/ITK.git) // remove this
   set(ITK_VERSION_ID ITK-4.5)
 
   ExternalProject_Add(${proj}


### PR DESCRIPTION
On this version, the "versorRigid3D" transform is replaced by
"Euler3D" transform that has more consistency with ITKv4 since
versor optimizers are not implemented in ITKv4 yet.

This version of BRAINSFit works pretty well on affine and rigid
transforms.
BRAINSFit without VersorRigid transform is useless, but I committed the current changes
as they may be used some time, or be a good guide for adding new options to BRIANFit later.
