### PR TITLE
COMP: Update to use latest release OpenCV

### DIFF
--- a/BRAINSCut/CMakeLists.txt
+++ b/BRAINSCut/CMakeLists.txt
@@ -2,7 +2,10 @@
 
 message(STATUS "BRAINSCut OpenCV_DIR = ${OpenCV_DIR}")
 find_package( OpenCV REQUIRED)
+#message("OpenCV_INCLUDE_DIRS:${OpenCV_INCLUDE_DIRS}
+#OpenCV_LIBS:${OpenCV_LIBS}")
 
+include_directories(${OpenCV_INCLUDE_DIRS})
 ###
 add_subdirectory(BRAINSFeatureCreators)
 

--- a/SuperBuild/External_OpenCV.cmake
+++ b/SuperBuild/External_OpenCV.cmake
@@ -98,8 +98,10 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
     )
 
   ### --- End Project specific additions
+  # set(${proj}_REPOSITORY "${git_protocol}://github.com/BRAINSia/opencv.git") # USE THIS FOR UPDATED VERSION
+  # set(${proj}_GIT_TAG "20131101_Upstream") # USE THIS FOR UPDATED VERSION
   set(${proj}_REPOSITORY "${git_protocol}://github.com/BRAINSia/opencv.git") # USE THIS FOR UPDATED VERSION
-  set(${proj}_GIT_TAG "20131101_Upstream") # USE THIS FOR UPDATED VERSION
+  set(${proj}_GIT_TAG "OpenCV-2.4.9")
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}
     GIT_TAG ${${proj}_GIT_TAG}


### PR DESCRIPTION
Hans: We were using our own patch on OpenCV to build, and I decided to try to use the current release version.  Both the old branch and the current OpenCV 2.4.9 throw a bunch of warnings.

I tried using your branch with some of the fixes for warnings, but rebasing that patch on the current OpenCV  seemed to be tricky.  I can try to re-apply your changes where appropriate.  As it is, this branch is no more 'warning-y' than the previous one used in BRAINSTools.
