### PR TITLE
BUG: remove itkVersorTransformOptimizerv4 from BRAINSTools

### DIFF
--- a/BRAINSCommonLib/BRAINSFitHelperTemplate.h
+++ b/BRAINSCommonLib/BRAINSFitHelperTemplate.h
@@ -42,8 +42,7 @@
 
 #include "itkCenteredVersorTransformInitializer.h"
 #include "itkCenteredTransformInitializer.h"
-#include "itkVersorRigid3DTransformOptimizer.h"
-#include "itkVersorTransformOptimizer.h"
+#include "itkRegularStepGradientDescentOptimizerv4.h"
 #include "itkMultiThreader.h"
 #include "itkResampleImageFilter.h"
 #include "itkAffineTransform.h"

--- a/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
+++ b/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
@@ -31,7 +31,6 @@
 #include "BRAINSFitHelperTemplate.h"
 #include "itkConjugateGradientLineSearchOptimizerv4.h"
 #include "itkLBFGSBOptimizerv4.h"
-#include "itkVersorTransformOptimizerv4.h"
 
 #include "itkLabelObject.h"
 #include "itkStatisticsLabelObject.h"
@@ -744,8 +743,8 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
     if( currentTransformType == "Rigid" )
       {
       //  Choose TransformType for the itk registration class template:
-      typedef VersorRigid3DTransformType           TransformType;
-      typedef itk::VersorTransformOptimizerv4      OptimizerType;
+      typedef VersorRigid3DTransformType                          TransformType;
+      typedef itk::RegularStepGradientDescentOptimizerv4<double>  OptimizerType;
       //
       // Process the initialITKTransform as VersorRigid3DTransform:
       //
@@ -833,8 +832,8 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
     else if( currentTransformType == "ScaleVersor3D" )
       {
       //  Choose TransformType for the itk registration class template:
-      typedef ScaleVersor3DTransformType      TransformType; // NumberOfEstimatedParameter = 9;
-      typedef itk::VersorTransformOptimizerv4 OptimizerType;
+      typedef ScaleVersor3DTransformType                          TransformType; // NumberOfEstimatedParameter = 9;
+      typedef itk::RegularStepGradientDescentOptimizerv4<double>  OptimizerType;
       //
       // Process the initialITKTransform as ScaleVersor3DTransform:
       //
@@ -934,8 +933,8 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
     else if( currentTransformType == "ScaleSkewVersor3D" )
       {
       //  Choose TransformType for the itk registration class template:
-      typedef ScaleSkewVersor3DTransformType    TransformType;  // NumberOfEstimatedParameter = 15;
-      typedef itk::VersorTransformOptimizerv4   OptimizerType;
+      typedef ScaleSkewVersor3DTransformType                       TransformType;  // NumberOfEstimatedParameter = 15;
+      typedef itk::RegularStepGradientDescentOptimizerv4<double>   OptimizerType;
       //
       // Process the initialITKTransform as ScaleSkewVersor3D:
       //
@@ -1192,7 +1191,6 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
       const int m_MaximumNumberOfEvaluations = 900;
       const int m_MaximumNumberOfCorrections = 12;
 
-      //typedef itk::LBFGSBOptimizerv4       OptimizerType;
       typedef typename itk::LBFGSBOptimizerv4                  LBFGSBOptimizerType;
       typedef typename LBFGSBOptimizerType::Pointer            LBFGSBOptimizerTypePointer;
       typedef typename LBFGSBOptimizerType::ParametersType     OptimizerParameterType;

--- a/BRAINSCommonLib/genericRegistrationHelper.h
+++ b/BRAINSCommonLib/genericRegistrationHelper.h
@@ -39,7 +39,7 @@
 #include "itkMattesMutualInformationImageToImageMetricv4.h"
 #include "itkConjugateGradientLineSearchOptimizerv4.h"
 #include "itkGradientDescentOptimizerv4.h"
-#include "itkVersorTransformOptimizerv4.h"
+#include "itkRegularStepGradientDescentOptimizerv4.h"
 
 #define COMMON_MMI_METRIC_TYPE itk::MattesMutualInformationImageToImageMetricv4
 
@@ -404,7 +404,7 @@ public:
   typedef typename OptimizerType::ScalesType     OptimizerScalesType;
   typedef typename OptimizerType::ParametersType OptimizerParametersType;
 
-  typedef itk::GradientDescentOptimizerv4Template< double > GenericOptimizerType;
+  typedef itk::GradientDescentOptimizerBasev4Template< double > GenericOptimizerType;
 
   typedef typename MetricType::FixedImageMaskType  FixedBinaryVolumeType;
   typedef typename FixedBinaryVolumeType::Pointer  FixedBinaryVolumePointer;

--- a/BRAINSCommonLib/genericRegistrationHelper.hxx
+++ b/BRAINSCommonLib/genericRegistrationHelper.hxx
@@ -262,15 +262,15 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
       // end of versor scaling
     std::cout << "Initializer, optimizerScales: " << optimizerScales << "." << std::endl;
 
-    typedef itk::VersorTransformOptimizerv4Template<double> VersorOptimizerType;
+    typedef itk::RegularStepGradientDescentOptimizerv4<double> VersorOptimizerType;
     typename VersorOptimizerType::Pointer versorOptimizer = VersorOptimizerType::New();
 
     versorOptimizer->SetScales( optimizerScales );
-    versorOptimizer->SetMaximumStepSizeInPhysicalUnits( m_MaximumStepLength  );
     versorOptimizer->SetNumberOfIterations( m_NumberOfIterations );
     versorOptimizer->SetLearningRate( m_MaximumStepLength );
-    versorOptimizer->SetConvergenceWindowSize( 10 );
-    versorOptimizer->SetMinimumConvergenceValue( 1e-6 );
+    versorOptimizer->SetRelaxationFactor( m_RelaxationFactor );
+    versorOptimizer->SetMinimumStepLength( 1e-6 );
+    versorOptimizer->SetGradientMagnitudeTolerance( 1e-4 );
     versorOptimizer->SetReturnBestParametersAndValue(true);
 
     optimizer = versorOptimizer;

--- a/BRAINSConstellationDetector/src/landmarksConstellationAligner.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationAligner.cxx
@@ -44,15 +44,9 @@
 #include "landmarksConstellationAlignerCLP.h"
 
 // D E F I N E S //////////////////////////////////////////////////////////////
-
-const unsigned int LocalImageDimension = 3;
-
 typedef SImageType::PointType                      ImagePointType;
 
 // F U N C T I O N S //////////////////////////////////////////////////////////
-//////////////////
-
-//////////////////
 RigidTransformType::Pointer GetACPCAlignedZeroCenteredTransform(const LandmarksMapType & landmarks)
 {
   SImageType::PointType ZeroCenter;
@@ -67,7 +61,6 @@ RigidTransformType::Pointer GetACPCAlignedZeroCenteredTransform(const LandmarksM
 }
 
 // M A I N ////////////////////////////////////////////////////////////////////
-
 int main( int argc, char *argv[] )
 {
   PARSE_ARGS;


### PR DESCRIPTION
The VersorTransformOptimizerv4 is removed from ITKv4, and its usage 
should be replaced by newly added RegularStepGradientDescentOptimizerv4.

This patch addresses the above changes, so now we can build BRIASTools
based on the last version of ITK without any compiler error.
