### PR TITLE
ENH: Add ROI BSpline

### DIFF
--- a/BRAINSFit/BRAINSFit.cxx
+++ b/BRAINSFit/BRAINSFit.cxx
@@ -255,10 +255,6 @@ int main(int argc, char *argv[])
         }
       }
     }
-  if( minimumStepLength.size() != 0 )
-    {
-    std::cout << "WARNING: The minimumStepLength array is not needed by ITKv4 registration framework. It can be removed from command line." << std::endl;
-    }
 
   // Need to ensure that the order of transforms is from smallest to largest.
   try


### PR DESCRIPTION
If "useROIBSpline" flag is used, the BSpline transform grid will be initialized based on the input masked image. If this flag is not set, the BSpline grid will be set based on the original fixed image. 
