### PR TITLE
BUG: New method for MSP estimation in BCD

### DIFF
--- a/BRAINSConstellationDetector/src/landmarksConstellationDetector.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationDetector.h
@@ -239,6 +239,10 @@ public:
 protected:
 
 private:
+  void EulerToVersorRigid( VersorTransformType::Pointer &, const RigidTransformType::ConstPointer );
+
+  void DoResampleInPlace( const SImageType::ConstPointer, const RigidTransformType::ConstPointer, SImageType::Pointer & );
+
   VersorTransformType::Pointer ComputeACPCAlignedZeroCenteredTransform(void);
 
   // Linear model estimation using EPCA

--- a/BRAINSTransformConvert/TestSuite/BRAINSTransformConvertMakeTestFiles.cxx
+++ b/BRAINSTransformConvert/TestSuite/BRAINSTransformConvertMakeTestFiles.cxx
@@ -22,7 +22,7 @@
 #include "itkScaleVersor3DTransform.h"
 #include "itkScaleSkewVersor3DTransform.h"
 #include "itkAffineTransform.h"
-#include "itkBSplineTransform.h"
+#include "itkBSplineDeformableTransform.h"
 #include "itkTransformFileWriter.h"
 #include "itkTransformFileReader.h"
 #include "itkImageRegionIterator.h"
@@ -57,7 +57,7 @@ int main(int argc, char * *argv)
     return EXIT_FAILURE;
     }
 
-  typedef itk::BSplineTransform<double, 3, 3> BSplineTransformType;
+  typedef itk::BSplineDeformableTransform<double, 3, 3> BSplineDeformableTransformType;
 
   VersorRigid3DTransformType::Pointer versorRigidTransform
     = CreateTransform<VersorRigid3DTransformType>();
@@ -166,8 +166,8 @@ int main(int argc, char * *argv)
   testImageName += "/TransformConvertTestImage.nii.gz";
   itkUtil::WriteImage<ImageType>(testImage, testImageName);
 
-  BSplineTransformType::Pointer bsplineTransform =
-    CreateTransform<BSplineTransformType>();
+  BSplineDeformableTransformType::Pointer bsplineTransform =
+    CreateTransform<BSplineDeformableTransformType>();
 
   translation[0] = -1.0; translation[1] = 0.6; translation[2] = -0.5;
   affineTransform->Translate(translation);
@@ -187,19 +187,19 @@ int main(int argc, char * *argv)
 
   bsplineTransform->SetBulkTransform(affineTransform.GetPointer() );
 
-  BSplineTransformType::PhysicalDimensionsType fixedPhysicalDimensions;
-  BSplineTransformType::MeshSizeType           meshSize;
+  BSplineDeformableTransformType::PhysicalDimensionsType fixedPhysicalDimensions;
+  BSplineDeformableTransformType::MeshSizeType           meshSize;
   for( unsigned int i = 0; i < 3; i++ )
     {
     fixedPhysicalDimensions[i] = spacing[i]
       * static_cast<double>(region.GetSize()[i] - 1);
     }
-  meshSize.Fill( 5 - BSplineTransformType::SplineOrder );
+  meshSize.Fill( 5 - BSplineDeformableTransformType::SplineOrder );
   bsplineTransform->SetGridOrigin(origin);
   bsplineTransform->SetGridRegion(region);
   bsplineTransform->SetGridSpacing(spacing);
 
-  BSplineTransformType::ParametersType parameters(bsplineTransform->GetNumberOfParameters() );
+  BSplineDeformableTransformType::ParametersType parameters(bsplineTransform->GetNumberOfParameters() );
   parameters.Fill(0.0);
   bsplineTransform->SetParameters(parameters);
 


### PR DESCRIPTION
An important bug is catched in BCD. Previously BCD input was manipulated in
many cases that would make the final ResampleInPlace meaningless!

Now, MSP estimation is done in a new way to preserve the original input
image.
