### PR TITLE
COMP: Fix compilation problem: relocation R_X86_64_32 against `a local s...

### DIFF
--- a/BRAINSABC/brainseg/CMakeLists.txt
+++ b/BRAINSABC/brainseg/CMakeLists.txt
@@ -32,6 +32,18 @@ DebugImageViewerLibAdditions(BRAINSABCCOMMONLIBLibraries)
 
 target_link_libraries(BRAINSABCCOMMONLIB ${BRAINSABCCOMMONLIBLibraries} )
 
+#
+# To fix compilation problem: relocation R_X86_64_32 against `a local symbol' can not be
+# used when making a shared object; recompile with -fPIC
+# See http://www.cmake.org/pipermail/cmake/2007-May/014350.html
+#
+# XXX When minimum CMake version will be changed to version >=2.8.9, the following code
+# could be used instead:
+# set_target_properties(BRAINSABCCOMMONLIB PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set_target_properties(BRAINSABCCOMMONLIB PROPERTIES COMPILE_FLAGS "-fPIC")
+endif()
+
 ## Build all the programs
 ##
 set(ALL_PROGS_LIST

--- a/BRAINSCommonLib/CMakeLists.txt
+++ b/BRAINSCommonLib/CMakeLists.txt
@@ -43,6 +43,18 @@ set(BRAINSCommonLib_SRCS
 add_library(BRAINSCommonLib STATIC ${BRAINSCommonLib_SRCS})
 target_link_libraries(BRAINSCommonLib ${ITK_LIBRARIES} ${ANTS_LIBS} ${double-conversion_LIBRARIES})
 
+#
+# To fix compilation problem: relocation R_X86_64_32 against `a local symbol' can not be
+# used when making a shared object; recompile with -fPIC
+# See http://www.cmake.org/pipermail/cmake/2007-May/014350.html
+#
+# XXX When minimum CMake version will be changed to version >=2.8.9, the following code
+# could be used instead:
+# set_target_properties(BRAINSCommonLib PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set_target_properties(BRAINSCommonLib PROPERTIES COMPILE_FLAGS "-fPIC")
+endif()
+
 install(TARGETS BRAINSCommonLib
   RUNTIME DESTINATION ${BRAINSTools_CLI_INSTALL_RUNTIME_DESTINATION} COMPONENT RuntimeLibraries
   LIBRARY DESTINATION ${BRAINSTools_CLI_INSTALL_LIBRARY_DESTINATION} COMPONENT RuntimeLibraries

--- a/BRAINSConstellationDetector/gui/CMakeLists.txt
+++ b/BRAINSConstellationDetector/gui/CMakeLists.txt
@@ -50,6 +50,18 @@ add_library( BRAINSConstellationDetectorGUICOMMONLIB STATIC
   ${HEADERS_MOC}
   )
 
+#
+# To fix compilation problem: relocation R_X86_64_32 against `a local symbol' can not be
+# used when making a shared object; recompile with -fPIC
+# See http://www.cmake.org/pipermail/cmake/2007-May/014350.html
+#
+# XXX When minimum CMake version will be changed to version >=2.8.9, the following code
+# could be used instead:
+# set_target_properties(BRAINSConstellationDetectorGUICOMMONLIB PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set_target_properties(BRAINSConstellationDetectorGUICOMMONLIB PROPERTIES COMPILE_FLAGS "-fPIC")
+endif()
+
 if(VTK_USE_QVTK)
   set(LOCAL_VTK_QVTK_LIB QVTK)
 endif()

--- a/BRAINSConstellationDetector/src/CMakeLists.txt
+++ b/BRAINSConstellationDetector/src/CMakeLists.txt
@@ -9,6 +9,18 @@ add_library(landmarksConstellationCOMMONLIB STATIC
   BRAINSConstellationDetectorPrimary.cxx)
 target_link_libraries(landmarksConstellationCOMMONLIB BRAINSCommonLib ${ITK_LIBRARIES})
 
+#
+# To fix compilation problem: relocation R_X86_64_32 against `a local symbol' can not be
+# used when making a shared object; recompile with -fPIC
+# See http://www.cmake.org/pipermail/cmake/2007-May/014350.html
+#
+# XXX When minimum CMake version will be changed to version >=2.8.9, the following code
+# could be used instead:
+# set_target_properties(landmarksConstellationCOMMONLIB PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set_target_properties(landmarksConstellationCOMMONLIB PROPERTIES COMPILE_FLAGS "-fPIC")
+endif()
+
 ## Build all the programs
 ##
 set(ALL_PROGS_LIST

--- a/BRAINSCut/BRAINSCutConfiguration/CMakeLists.txt
+++ b/BRAINSCut/BRAINSCutConfiguration/CMakeLists.txt
@@ -8,3 +8,15 @@ link_libraries( itksys )
 ##
 add_library(NetConfigurationCOMMONLIB STATIC ${NetConfiguration_SRCS})
 target_link_libraries(NetConfigurationCOMMONLIB BRAINSCommonLib ${ITK_LIBRARIES})
+
+#
+# To fix compilation problem: relocation R_X86_64_32 against `a local symbol' can not be
+# used when making a shared object; recompile with -fPIC
+# See http://www.cmake.org/pipermail/cmake/2007-May/014350.html
+#
+# XXX When minimum CMake version will be changed to version >=2.8.9, the following code
+# could be used instead:
+# set_target_properties(NetConfigurationCOMMONLIB PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set_target_properties(NetConfigurationCOMMONLIB PROPERTIES COMPILE_FLAGS "-fPIC")
+endif()

--- a/BRAINSCut/CMakeLists.txt
+++ b/BRAINSCut/CMakeLists.txt
@@ -43,6 +43,17 @@ target_link_libraries(BRAINSCutCOMMONLIB
   ${OpenCV_LIBRARIES}
   )
 
+#
+# To fix compilation problem: relocation R_X86_64_32 against `a local symbol' can not be
+# used when making a shared object; recompile with -fPIC
+# See http://www.cmake.org/pipermail/cmake/2007-May/014350.html
+#
+# XXX When minimum CMake version will be changed to version >=2.8.9, the following code
+# could be used instead:
+# set_target_properties(BRAINSCutCOMMONLIB PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set_target_properties(BRAINSCutCOMMONLIB PROPERTIES COMPILE_FLAGS "-fPIC")
+endif()
 
 ## Build all the programs
 ##

--- a/BRAINSDemonWarp/CMakeLists.txt
+++ b/BRAINSDemonWarp/CMakeLists.txt
@@ -34,6 +34,18 @@ DebugImageViewerLibAdditions(BRAINSDemonWarpTemplatesLIBLibraries)
 
 target_link_libraries(BRAINSDemonWarpTemplatesLIB ${BRAINSDemonWarpTemplatesLIBLibraries})
 
+#
+# To fix compilation problem: relocation R_X86_64_32 against `a local symbol' can not be
+# used when making a shared object; recompile with -fPIC
+# See http://www.cmake.org/pipermail/cmake/2007-May/014350.html
+#
+# XXX When minimum CMake version will be changed to version >=2.8.9, the following code
+# could be used instead:
+# set_target_properties(BRAINSDemonWarpTemplatesLIB PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set_target_properties(BRAINSDemonWarpTemplatesLIB PROPERTIES COMPILE_FLAGS "-fPIC")
+endif()
+
 set(ALL_PROGS_LIST
   BRAINSDemonWarp
   VBRAINSDemonWarp

--- a/BRAINSTalairach/CMakeLists.txt
+++ b/BRAINSTalairach/CMakeLists.txt
@@ -17,6 +17,17 @@ set(BRAINSTalairachSupportLib_SRCS
 add_library(BRAINSTalairachSupportLib STATIC ${BRAINSTalairachSupportLib_SRCS})
 target_link_libraries(BRAINSTalairachSupportLib BRAINSCommonLib ${VTK_LIBRARIES})
 
+#
+# To fix compilation problem: relocation R_X86_64_32 against `a local symbol' can not be
+# used when making a shared object; recompile with -fPIC
+# See http://www.cmake.org/pipermail/cmake/2007-May/014350.html
+#
+# XXX When minimum CMake version will be changed to version >=2.8.9, the following code
+# could be used instead:
+# set_target_properties(BRAINSTalairachSupportLib PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set_target_properties(BRAINSTalairachSupportLib PROPERTIES COMPILE_FLAGS "-fPIC")
+endif()
 
 set(BRAINSTalairachLibraries BRAINSTalairachSupportLib )
 

--- a/GTRACT/Common/CMakeLists.txt
+++ b/GTRACT/Common/CMakeLists.txt
@@ -19,3 +19,14 @@ set(GTRACTCommon_SRC
 add_library(GTRACTCommon STATIC ${GTRACTCommon_SRC})
 target_link_libraries(GTRACTCommon BRAINSCommonLib ${VTK_LIBRARIES} ${double-conversion_LIBRARIES})
 
+#
+# To fix compilation problem: relocation R_X86_64_32 against `a local symbol' can not be
+# used when making a shared object; recompile with -fPIC
+# See http://www.cmake.org/pipermail/cmake/2007-May/014350.html
+#
+# XXX When minimum CMake version will be changed to version >=2.8.9, the following code
+# could be used instead:
+# set_target_properties(GTRACTCommon PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set_target_properties(GTRACTCommon PROPERTIES COMPILE_FLAGS "-fPIC")
+endif()


### PR DESCRIPTION
...ymbol'

This commits fixes build error occurring when building _without_ relying
on BRAINStools Superbuild. In the superbuild case, the -fPIC flag
is SuperBuild.cmake.
