### PR TITLE
BUG: Add multiple baselines for linux

### DIFF
--- a/BRAINSFit/TestSuite/CMakeLists.txt
+++ b/BRAINSFit/TestSuite/CMakeLists.txt
@@ -1590,7 +1590,7 @@ endif()
 set(BRAINSFitTestName BRAINSFitTest_ROIBSpline)
 ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSFitTestDriver>
-  --compare DATA{${TestData_DIR}/${BRAINSFitTestName}.result.nrrd}
+  --compare DATA{${TestData_DIR}/${BRAINSFitTestName}.result.nrrd,:}
             ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nrrd
   --compareIntensityTolerance 7
   --compareRadiusTolerance 0

--- a/TestData/BRAINSFitTest_ROIBSpline.result.linux.nrrd.md5
+++ b/TestData/BRAINSFitTest_ROIBSpline.result.linux.nrrd.md5
@@ -1,0 +1,1 @@
+e598d40ff9d2bc9b1b349f6c1a6533ff


### PR DESCRIPTION
BRAINSFitTest_ROIBSpline is passed on Mac but not on Linux.
Therefore, multiple baselines are used for this test.
