### PR TITLE
ENH: Print selective parameters in BSpline observer

### DIFF
--- a/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
+++ b/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
@@ -1276,9 +1276,13 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
 
       bsplineTx->SetIdentity();
 
+      const int psize = bsplineTx->GetNumberOfParameters();
       std::cout << "Initialized BSpline transform is set to be an identity transform." << std::endl;
-      std::cout << "  - Number of parameters = "
-                << bsplineTx->GetNumberOfParameters() << std::endl << std::endl;
+      std::cout << "  - Number of parameters = " << psize << std::endl;
+      if( psize/15 > 1 )
+        {
+        std::cout << "-- WARNING: Only one in every " << (psize/15) << " parameters is printed on screen.\n" << std::endl;
+        }
       //std::cout << "Intial Parameters = " << std::endl
       //          << bsplineTx->GetParameters() << std::endl;
 
@@ -1334,6 +1338,7 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
 
       typedef itk::Image<float, 3> RegisterImageType;
 
+      // TODO: pass this option by commandline
       const bool ObserveIterations = true;
       if( ObserveIterations == true )
         {

--- a/BRAINSCommonLib/genericRegistrationHelper.h
+++ b/BRAINSCommonLib/genericRegistrationHelper.h
@@ -251,11 +251,17 @@ public:
       {
       std::cout << std::setw(  4 ) << std::setfill( ' ' ) << optimizer->GetCurrentIteration() << "   ";
       std::cout << std::setw( 10 ) << std::setfill( ' ' ) << optimizer->GetValue() << "   ";
-      if( parmsNonEmpty && psize < 15 ) // Exclude BSpline transform from parameters printing.
+      if( parmsNonEmpty ) // For BSpline tranform with large parameters space (>15), every (psize/15)th parameter is printed.
         {
-        std::cout << parms;
+        std::cout << "[ ";
+        int i = 0;
+        while( i<psize )
+          {
+          std::cout << parms[i] << " ";
+          i += std::max(1,(psize/15));
+          }
+        std::cout << "]" << std::endl;
         }
-      std::cout << std::endl;
       }
     //
     // GenerateHistogram


### PR DESCRIPTION
For BSpline tranform with large parameters space (>15), every
(ParametersSize / 15)th variable is printed.
