### PR TITLE
ENH: Generalize the legacy PerformTestMMI

### DIFF
--- a/BRAINSFit/CMakeLists.txt
+++ b/BRAINSFit/CMakeLists.txt
@@ -36,6 +36,7 @@ configure_file(
 
 set(ALL_PROGS_LIST
   BRAINSFit
+  PerformMetricTest
   )
 
 set(BRAINSFitLibraries BRAINSCommonLib ${ANTS_LIBS})

--- a/BRAINSFit/PerformMetricTest.xml
+++ b/BRAINSFit/PerformMetricTest.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<executable>
+  <category>Registration</category>
+  <title>Metric Test</title>
+  <description>
+    Compare Mattes/MSQ metric value for two input images and a possible input BSpline transform.
+  </description>
+  <version>1.0</version>
+  <documentation-url>A utility to compare metric value between two input images.</documentation-url>
+  <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt</license>
+  <contributor>Ali Ghayoor</contributor>
+  <acknowledgements>
+  </acknowledgements>
+
+  <parameters>
+    <label>IO</label>
+    <description>Input parameters</description>
+
+    <transform>
+      <channel>input</channel>
+      <name>inputBSplineTransform</name>
+      <label>Transform File Name</label>
+      <description>
+        Input transform that is use to warp moving image before metric comparison.
+      </description>
+      <longflag>inputBSplineTransform</longflag>
+    </transform>
+
+    <image>
+      <channel>input</channel>
+      <name>inputFixedImage</name>
+      <label>Fixed image</label>
+      <longflag>inputFixedImage</longflag>
+    </image>
+
+    <image>
+      <channel>input</channel>
+      <name>inputMovingImage</name>
+      <label>Moving image</label>
+      <longflag>inputMovingImage</longflag>
+    </image>
+  </parameters>
+
+  <parameters>
+    <label>Input variables</label>
+    <description>Metric type and input parameters.</description>
+
+    <string-enumeration>
+      <name>metricType</name>
+      <longflag>metricType</longflag>
+      <label>Metric type</label>
+      <description>Comparison metric type</description>
+      <default>MMI</default>
+      <element>MMI</element>
+      <element>MSE</element>
+    </string-enumeration>
+
+    <integer>
+      <name>numberOfSamples</name>
+      <longflag>numberOfSamples</longflag>
+      <label>Number Of Samples</label>
+      <description>The number of voxels sampled for metric evaluation.</description>
+      <default>0</default>
+    </integer>
+
+    <integer>
+      <name>numberOfHistogramBins</name>
+      <longflag>numberOfHistogramBins</longflag>
+      <label>Number Of Historgram Bins</label>
+      <description>The number of historgram bins when MMI (Mattes) is metric type.</description>
+      <default>50</default>
+    </integer>
+
+  </parameters>
+</executable>

--- a/BRAINSFit/TestSuite/CMakeLists.txt
+++ b/BRAINSFit/TestSuite/CMakeLists.txt
@@ -23,11 +23,6 @@ set_target_properties(CenterOfROIInitTest PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${
 ExternalData_add_test(${PROJECT_NAME}FetchData NAME CenterOfROIInitTest
   COMMAND ${LAUNCH_EXE}  $<TARGET_FILE:CenterOfROIInitTest>)
 
-add_executable(PerformTestMMI PerformTestMMI.cxx )
-set(PerformTestMMILibraries BRAINSCommonLib ${ITK_LIBRARIES} ${OPTIONAL_DEBUG_LINK_LIBRARIES} )
-target_link_libraries(PerformTestMMI ${PerformTestMMILibraries} )
-set_target_properties(PerformTestMMI PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${BRAINSTools_BINARY_DIR})
-
 set(BRAINSFitTestName BRAINSFitTest_AffineRotationMasks)
 ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSFitTestDriver>


### PR DESCRIPTION
PerformTestMMI was a simple program to evaluation Mattes metric value
between two images after warping the second image if a BSpline transform
is defined.
The above program is expanded to work with different metric type that is
defined by a "--metricType" flag. Currently MMI (mattes mutual
information) and MSE (mean square error) metrics are supported.
