### PR TITLE
ENH: Remove irrelevent parameters from BRAINSFit

### DIFF
--- a/AutoWorkup/DWIInACPCTest.py
+++ b/AutoWorkup/DWIInACPCTest.py
@@ -339,8 +339,6 @@ BSPLINE_T2_TO_RIPB0.inputs.useBSpline = True
 # BSPLINE_T2_TO_RIPB0.inputs.useROIBSpline = True
 
 ##  This needs to be debugged, it should work. BSPLINE_T2_TO_RIPB0.inputs.useROIBSpline = True
-BSPLINE_T2_TO_RIPB0.inputs.useExplicitPDFDerivativesMode = 'AUTO'
-BSPLINE_T2_TO_RIPB0.inputs.useCachingOfBSplineWeightsMode = 'ON'
 BSPLINE_T2_TO_RIPB0.inputs.maxBSplineDisplacement = 24
 BSPLINE_T2_TO_RIPB0.inputs.splineGridSize = [14, 10, 12]
 

--- a/AutoWorkup/SEMTools/registration/brainsfit.py
+++ b/AutoWorkup/SEMTools/registration/brainsfit.py
@@ -66,8 +66,6 @@ class BRAINSFitInputSpec(CommandLineInputSpec):
         desc="The half percentage to decide outliers of image intensities. The default value is zero, which means no outlier removal. If the value of 0.005 is given, the moduel will throw away 0.005 % of both tails, so 0.01% of intensities in total would be ignored in its statistic calculation. ", argstr="--removeIntensityOutliers %f")
     initializeRegistrationByCurrentGenericTransform = traits.Bool(
         desc="If this flag is ON, the current generic composite transform, resulted from the linear registration stages, is set to initialize the follow nonlinear registration process. However, by the default behaviour, the moving image is first warped based on the existant transform before it is passed to the BSpline registration filter. It is done to speed up the BSpline registration by reducing the computations of composite transform jacobian.", argstr="--initializeRegistrationByCurrentGenericTransform ")
-    useCachingOfBSplineWeightsMode = traits.Enum("ON", "OFF", desc="This is a 5x speed advantage at the expense of requiring much more memory.  Only relevant when transformType is BSpline.", argstr="--useCachingOfBSplineWeightsMode %s")
-    useExplicitPDFDerivativesMode = traits.Enum("AUTO", "ON", "OFF", desc="This option is not used in ITKv4 optimizers. There is no need to set that; however, this flag is not removed to keep backward compatibility.", argstr="--useExplicitPDFDerivativesMode %s")
     ROIAutoDilateSize = traits.Float(
         desc="This flag is only relavent when using ROIAUTO mode for initializing masks.  It defines the final dilation size to capture a bit of background outside the tissue region.  A setting of 10mm has been shown to help regularize a BSpline registration type so that there is some background constraints to match the edges of the head better.", argstr="--ROIAutoDilateSize %f")
     ROIAutoClosingSize = traits.Float(
@@ -77,7 +75,6 @@ class BRAINSFitInputSpec(CommandLineInputSpec):
     failureExitCode = traits.Int(desc="If the fit fails, exit with this status code.  (It can be used to force a successfult exit status of (0) if the registration fails due to reaching the maximum number of iterations.", argstr="--failureExitCode %d")
     writeTransformOnFailure = traits.Bool(desc="Flag to save the final transform even if the numberOfIterations are reached without convergence. (Intended for use when --failureExitCode 0 )", argstr="--writeTransformOnFailure ")
     numberOfThreads = traits.Int(desc="Explicitly specify the maximum number of threads to use. (default is auto-detected)", argstr="--numberOfThreads %d")
-    forceMINumberOfThreads = traits.Int(desc="Force the the maximum number of threads to use for non thread safe MI metric.", argstr="--forceMINumberOfThreads %d")
     debugLevel = traits.Int(desc="Display debug messages, and produce debug intermediate results.  0=OFF, 1=Minimal, 10=Maximum debugging.", argstr="--debugLevel %d")
     costFunctionConvergenceFactor = traits.Float(
         desc=" From itkLBFGSBOptimizer.h: Set/Get the CostFunctionConvergenceFactor. Algorithm terminates when the reduction in cost function is less than (factor * epsmcj) where epsmch is the machine precision. Typical values for factor: 1e+12 for low accuracy; 1e+7 for moderate accuracy and 1e+1 for extremely high accuracy.  1e+9 seems to work well.,       ", argstr="--costFunctionConvergenceFactor %f")
@@ -85,12 +82,8 @@ class BRAINSFitInputSpec(CommandLineInputSpec):
         desc=" From itkLBFGSBOptimizer.h: Set/Get the ProjectedGradientTolerance. Algorithm terminates when the project gradient is below the tolerance. Default lbfgsb value is 1e-5, but 1e-4 seems to work well.,       ", argstr="--projectedGradientTolerance %f")
     gui = traits.Bool(desc="Display intermediate image volumes for debugging.  NOTE:  This is not part of the standard build sytem, and probably does nothing on your installation.", argstr="--gui ")
     promptUser = traits.Bool(desc="Prompt the user to hit enter each time an image is sent to the DebugImageViewer", argstr="--promptUser ")
-    permitParameterVariation = InputMultiPath(
-        traits.Int, desc="A bit vector to permit linear transform parameters to vary under optimization.  The vector order corresponds with transform parameters, and beyond the end ones fill in as a default.  For instance, you can choose to rotate only in x (pitch) with 1,0,0;  this is mostly for expert use in turning on and off individual degrees of freedom in rotation, translation or scaling without multiplying the number of transform representations; this trick is probably meaningless when tried with the general affine transform.", sep=",", argstr="--permitParameterVariation %s")
     costMetric = traits.Enum("MMI", "MSE", "NC", "MIH", desc="The cost metric to be used during fitting. Defaults to MMI. Options are MMI (Mattes Mutual Information), MSE (Mean Square Error), NC (Normalized Correlation), MC (Match Cardinality for binary images)", argstr="--costMetric %s")
     logFileReport = traits.Either(traits.Bool, File(), hash_files=False, desc="A file to write out final information report in CSV file: MetricName,MetricValue,FixedImageName,FixedMaskName,MovingImageName,MovingMaskName", argstr="--logFileReport %s")
-    metricSeed = traits.Int(
-        desc="Seed value will be used to reinitialize the metric. To ensure consistent results, the same seed value should be used across runs. If the seed value is set to 0, the sampler will use the clock of your machine to initialize the metric, which will lead to a random initialization of the seed.", argstr="--metricSeed %d")
 
 
 class BRAINSFitOutputSpec(TraitedSpec):

--- a/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
+++ b/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
@@ -578,8 +578,6 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
       atlasToSubjectRegistrationHelper->SetSplineGridSize(splineGridSize);
       // Setting max displace
       atlasToSubjectRegistrationHelper->SetMaxBSplineDisplacement(6.0);
-      // atlasToSubjectRegistrationHelper->SetUseExplicitPDFDerivativesMode(useExplicitPDFDerivativesMode);
-      // atlasToSubjectRegistrationHelper->SetUseCachingOfBSplineWeightsMode(useCachingOfBSplineWeightsMode);
       }
     else if( m_AtlasLinearTransformChoice == "SyN" )
       {

--- a/BRAINSCommonLib/BRAINSFitHelper.cxx
+++ b/BRAINSCommonLib/BRAINSFitHelper.cxx
@@ -94,7 +94,6 @@ BRAINSFitHelper::BRAINSFitHelper() :
   m_MovingBinaryVolume(NULL),
   m_OutputFixedVolumeROI(""),
   m_OutputMovingVolumeROI(""),
-  m_PermitParameterVariation(0),
   m_SamplingPercentage(1.0), // instead or number of samples, sampling% should be used that is a number between 0 and 1.
   m_NumberOfHistogramBins(50),
   m_HistogramMatch(false),
@@ -107,7 +106,6 @@ BRAINSFitHelper::BRAINSFitHelper() :
   m_TranslationScale(1000.0),
   m_ReproportionScale(1.0),
   m_SkewScale(1.0),
-  m_UseCachingOfBSplineWeightsMode("ON"),
   m_BackgroundFillValue(0.0),
   m_TransformType(1, "Rigid"),
   m_InitializeTransformMode("Off"),
@@ -133,8 +131,7 @@ BRAINSFitHelper::BRAINSFitHelper() :
   m_NormalizeInputImages(false),
   m_InitializeRegistrationByCurrentGenericTransform(true),
   m_MaximumNumberOfEvaluations(900),
-  m_MaximumNumberOfCorrections(12),
-  m_ForceMINumberOfThreads(-1)
+  m_MaximumNumberOfCorrections(12)
 {
   m_SplineGridSize[0] = 14;
   m_SplineGridSize[1] = 10;
@@ -415,7 +412,6 @@ BRAINSFitHelper::PrintSelf(std::ostream & os, Indent indent) const
   os << indent << "TranslationScale:    " << this->m_TranslationScale << std::endl;
   os << indent << "ReproportionScale:   " << this->m_ReproportionScale << std::endl;
   os << indent << "SkewScale:           " << this->m_SkewScale << std::endl;
-  os << indent << "UseCachingOfBSplineWeightsMode: " << this->m_UseCachingOfBSplineWeightsMode << std::endl;
   os << indent << "BackgroundFillValue:            " << this->m_BackgroundFillValue << std::endl;
   os << indent << "InitializeTransformMode:        " << this->m_InitializeTransformMode << std::endl;
   os << indent << "MaskInferiorCutOffFromCenter:   " << this->m_MaskInferiorCutOffFromCenter << std::endl;
@@ -426,13 +422,6 @@ BRAINSFitHelper::PrintSelf(std::ostream & os, Indent indent) const
   for( unsigned int q = 0; q < this->m_SplineGridSize.size(); ++q )
     {
     os << this->m_SplineGridSize[q] << " ";
-    }
-  os << "]" << std::endl;
-
-  os << indent << "PermitParameterVariation:     [";
-  for( unsigned int q = 0; q < this->m_PermitParameterVariation.size(); ++q )
-    {
-    os << this->m_PermitParameterVariation[q] << " ";
     }
   os << "]" << std::endl;
 
@@ -573,7 +562,6 @@ BRAINSFitHelper::PrintCommandLine(const bool dumpTempVolumes, const std::string 
   oss << "--translationScale " << this->m_TranslationScale  << "  \\" << std::endl;
   oss << "--reproportionScale " << this->m_ReproportionScale  << "  \\" << std::endl;
   oss << "--skewScale " << this->m_SkewScale  << "  \\" << std::endl;
-  oss << "--useCachingOfBSplineWeightsMode " << this->m_UseCachingOfBSplineWeightsMode  << "  \\" << std::endl;
   oss << "--maxBSplineDisplacement " << this->m_MaxBSplineDisplacement << " \\" << std::endl;
   oss << "--projectedGradientTolerance " << this->m_ProjectedGradientTolerance << " \\" << std::endl;
   oss << "--MaximumNumberOfEvaluations " << this->m_MaximumNumberOfEvaluations << " \\" << std::endl;
@@ -593,19 +581,6 @@ BRAINSFitHelper::PrintCommandLine(const bool dumpTempVolumes, const std::string 
     }
   oss << " \\" << std::endl;
 
-  if( !this->m_PermitParameterVariation.empty() )
-    {
-    oss << "--permitParameterVariation ";
-    for( unsigned int q = 0; q < this->m_PermitParameterVariation.size(); ++q )
-      {
-      oss << this->m_PermitParameterVariation[q];
-      if( q < this->m_PermitParameterVariation.size() - 1 )
-        {
-        oss << ",";
-        }
-      }
-    oss << " \\" << std::endl;
-    }
   if( m_CurrentGenericTransform.IsNotNull() )
     {
     const std::string initialTransformString("DEBUGInitialTransform_" + suffix + ".h5");

--- a/BRAINSCommonLib/BRAINSFitHelper.h
+++ b/BRAINSCommonLib/BRAINSFitHelper.h
@@ -152,8 +152,6 @@ public:
   itkGetConstMacro(ReproportionScale,             double);
   itkSetMacro(SkewScale,                     double);
   itkGetConstMacro(SkewScale,                     double);
-  itkSetMacro(UseCachingOfBSplineWeightsMode, std::string);
-  itkGetConstMacro(UseCachingOfBSplineWeightsMode, std::string);
   itkSetMacro(CostFunctionConvergenceFactor, double);
   itkGetConstMacro(CostFunctionConvergenceFactor, double);
   itkSetMacro(ProjectedGradientTolerance,    double);
@@ -190,8 +188,6 @@ public:
   itkGetConstMacro(ObserveIterations,        bool);
   itkSetMacro(UseROIBSpline, bool);
   itkGetConstMacro(UseROIBSpline, bool);
-  itkSetMacro(MetricSeed, int);
-  itkGetConstMacro(MetricSeed, int);
 
   void SetSamplingStrategy(std::string strategy)
   {
@@ -206,16 +202,6 @@ public:
     }
   }
 
-  /** Method to set the Permission to vary by level  */
-  void SetPermitParameterVariation(std::vector<int> perms)
-  {
-    m_PermitParameterVariation.resize( perms.size() );
-    for( unsigned int i = 0; i < perms.size(); ++i )
-      {
-      m_PermitParameterVariation[i] = perms[i];
-      }
-  }
-
   itkSetMacro(HistogramMatch, bool);
   itkGetConstMacro(HistogramMatch, bool);
 
@@ -224,9 +210,6 @@ public:
 
   itkSetMacro(CostMetric, std::string);
   itkGetConstMacro(CostMetric, std::string);
-
-  itkSetMacro(ForceMINumberOfThreads, int);
-  itkGetConstMacro(ForceMINumberOfThreads, int);
 
   itkSetMacro(NormalizeInputImages, bool);
   itkSetMacro(InitializeRegistrationByCurrentGenericTransform, bool);
@@ -267,7 +250,6 @@ private:
   MovingBinaryVolumePointer m_MovingBinaryVolume;
   std::string               m_OutputFixedVolumeROI;
   std::string               m_OutputMovingVolumeROI;
-  std::vector<int>          m_PermitParameterVariation;
 
   double       m_SamplingPercentage;
   unsigned int m_NumberOfHistogramBins;
@@ -282,7 +264,6 @@ private:
   double                   m_TranslationScale;
   double                   m_ReproportionScale;
   double                   m_SkewScale;
-  std::string              m_UseCachingOfBSplineWeightsMode;
   double                   m_BackgroundFillValue;
   std::vector<std::string> m_TransformType;
   std::string              m_InitializeTransformMode;
@@ -301,15 +282,12 @@ private:
   bool                                       m_ObserveIterations;
   std::string                                m_CostMetric;
   bool                                       m_UseROIBSpline;
-  int                                        m_MetricSeed;
   itk::Object::Pointer                       m_Helper;
   SamplingStrategyType                       m_SamplingStrategy;
   bool                                       m_NormalizeInputImages;
   bool                                       m_InitializeRegistrationByCurrentGenericTransform;
   int                                        m_MaximumNumberOfEvaluations;
   int                                        m_MaximumNumberOfCorrections;
-  // DEBUG OPTION:
-  int m_ForceMINumberOfThreads;
 };  // end BRAINSFitHelper class
 
 template <class TLocalCostMetric>
@@ -399,7 +377,6 @@ BRAINSFitHelper::SetupRegistration(GenericMetricType *localCostMetric)
   myHelper->SetMovingBinaryVolume(this->m_MovingBinaryVolume);
   myHelper->SetOutputFixedVolumeROI(this->m_OutputFixedVolumeROI);
   myHelper->SetOutputMovingVolumeROI(this->m_OutputMovingVolumeROI);
-  myHelper->SetPermitParameterVariation(this->m_PermitParameterVariation);
   myHelper->SetSamplingPercentage(this->m_SamplingPercentage);
   myHelper->SetSamplingStrategy(this->m_SamplingStrategy);
   myHelper->SetNumberOfHistogramBins(this->m_NumberOfHistogramBins);
@@ -422,7 +399,6 @@ BRAINSFitHelper::SetupRegistration(GenericMetricType *localCostMetric)
   myHelper->SetPromptUserAfterDisplay(this->m_PromptUserAfterDisplay);
   myHelper->SetDebugLevel(this->m_DebugLevel);
   myHelper->SetCostMetricObject(localCostMetric);
-  myHelper->SetForceMINumberOfThreads(this->m_ForceMINumberOfThreads);
   myHelper->SetUseROIBSpline(this->m_UseROIBSpline);
   myHelper->SetInitializeRegistrationByCurrentGenericTransform(this->m_InitializeRegistrationByCurrentGenericTransform);
   myHelper->SetMaximumNumberOfEvaluations(this->m_MaximumNumberOfEvaluations);

--- a/BRAINSCommonLib/BRAINSFitHelperTemplate.h
+++ b/BRAINSCommonLib/BRAINSFitHelperTemplate.h
@@ -216,16 +216,6 @@ public:
   itkSetMacro(UseROIBSpline, bool);
   itkGetConstMacro(UseROIBSpline, bool);
 
-  /** Method to set the Permission to vary by level  */
-  void SetPermitParameterVariation(std::vector<int> perms)
-  {
-    m_PermitParameterVariation.resize( perms.size() );
-    for( unsigned int i = 0; i < perms.size(); ++i )
-      {
-      m_PermitParameterVariation[i] = perms[i];
-      }
-  }
-
   itkSetMacro(HistogramMatch, bool);
   itkGetConstMacro(HistogramMatch, bool);
 
@@ -233,9 +223,6 @@ public:
   itkGetConstMacro(RemoveIntensityOutliers, bool);
   /** Method that initiates the registration. */
   void Update(void);
-
-  itkSetMacro(ForceMINumberOfThreads, int);
-  itkGetConstMacro(ForceMINumberOfThreads, int);
 
   itkSetMacro(SamplingStrategy,SamplingStrategyType);
   itkGetConstMacro(SamplingStrategy,SamplingStrategyType);
@@ -309,13 +296,10 @@ private:
   bool                                       m_ObserveIterations;
   typename MetricType::Pointer               m_CostMetricObject;
   bool                                       m_UseROIBSpline;
-  std::vector<int>                           m_PermitParameterVariation;
   SamplingStrategyType                       m_SamplingStrategy;
   bool                                       m_InitializeRegistrationByCurrentGenericTransform;
   int                                        m_MaximumNumberOfEvaluations;
   int                                        m_MaximumNumberOfCorrections;
-  // DEBUG OPTION:
-  int m_ForceMINumberOfThreads;
 };  // end BRAINSFitHelperTemplate class
 }   // end namespace itk
 

--- a/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
+++ b/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
@@ -542,12 +542,10 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::BRAINSFitHelperTemplat
   m_ObserveIterations(true),
   m_CostMetricObject(NULL),
   m_UseROIBSpline(0),
-  m_PermitParameterVariation(0),
   m_SamplingStrategy(AffineRegistrationType::NONE),
   m_InitializeRegistrationByCurrentGenericTransform(true),
   m_MaximumNumberOfEvaluations(900),
-  m_MaximumNumberOfCorrections(12),
-  m_ForceMINumberOfThreads(-1)
+  m_MaximumNumberOfCorrections(12)
 {
   m_SplineGridSize[0] = 14;
   m_SplineGridSize[1] = 10;
@@ -575,7 +573,6 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::FitCommonCode(
 
   appMutualRegistration->SetNumberOfHistogramBins(m_NumberOfHistogramBins);
   appMutualRegistration->SetNumberOfIterations( numberOfIterations);
-  appMutualRegistration->SetPermitParameterVariation( m_PermitParameterVariation );
   appMutualRegistration->SetSamplingStrategy(m_SamplingStrategy);
   appMutualRegistration->SetSamplingPercentage(m_SamplingPercentage);
 
@@ -590,7 +587,6 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::FitCommonCode(
   appMutualRegistration->SetFixedImage(    m_FixedVolume    );
   appMutualRegistration->SetMovingImage(   m_MovingVolume   );
   appMutualRegistration->SetCostMetricObject( this->m_CostMetricObject );
-  appMutualRegistration->SetForceMINumberOfThreads( this->m_ForceMINumberOfThreads );
 
   appMutualRegistration->SetBackgroundFillValue(   m_BackgroundFillValue   );
 
@@ -1636,13 +1632,6 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::PrintSelf(std::ostream
   for( unsigned int q = 0; q < this->m_SplineGridSize.size(); ++q )
     {
     os << this->m_SplineGridSize[q] << " ";
-    }
-  os << "]" << std::endl;
-
-  os << indent << "PermitParameterVariation:     [";
-  for( unsigned int q = 0; q < this->m_PermitParameterVariation.size(); ++q )
-    {
-    os << this->m_PermitParameterVariation[q] << " ";
     }
   os << "]" << std::endl;
 

--- a/BRAINSCommonLib/genericRegistrationHelper.h
+++ b/BRAINSCommonLib/genericRegistrationHelper.h
@@ -452,8 +452,6 @@ public:
   itkSetObjectMacro(Transform, TransformType);
   typename CompositeTransformType::Pointer GetTransform(void);
 
-  // itkSetMacro( PermitParameterVariation, std::vector<int>      );
-
   itkSetObjectMacro(CostMetricObject, MetricType);
   itkGetConstObjectMacro(CostMetricObject, MetricType);
 
@@ -473,9 +471,6 @@ public:
   itkGetConstMacro(ActualNumberOfIterations, unsigned int);
   itkSetMacro(ObserveIterations,        bool);
   itkGetConstMacro(ObserveIterations,        bool);
-  // Debug option for MI metric
-  itkSetMacro(ForceMINumberOfThreads, int);
-  itkGetConstMacro(ForceMINumberOfThreads, int);
 
   itkSetMacro(SamplingStrategy,SamplingStrategyType);
   itkGetConstMacro(SamplingStrategy,SamplingStrategyType);
@@ -491,16 +486,6 @@ public:
   /** Method to return the latest modified time of this object or
     * any of its cached ivars */
   unsigned long GetMTime() const;
-
-  /** Method to set the Permission to vary by level  */
-  void SetPermitParameterVariation(std::vector<int> perms)
-  {
-    m_PermitParameterVariation.resize( perms.size() );
-    for( unsigned int i = 0; i < perms.size(); ++i )
-      {
-      m_PermitParameterVariation[i] = perms[i];
-      }
-  }
 
 protected:
   MultiModal3DMutualRegistrationHelper();
@@ -528,7 +513,6 @@ private:
 
   RegistrationPointer m_Registration;
 
-  std::vector<int> m_PermitParameterVariation;
   typename MetricType::Pointer  m_CostMetricObject;
 
   double       m_SamplingPercentage;
@@ -548,8 +532,6 @@ private:
   bool         m_ObserveIterations;
 
   SamplingStrategyType m_SamplingStrategy;
-  // DEBUG OPTION:
-  int m_ForceMINumberOfThreads;
 
   ModifiedTimeType m_InternalTransformTime;
 };

--- a/BRAINSCommonLib/genericRegistrationHelper.hxx
+++ b/BRAINSCommonLib/genericRegistrationHelper.hxx
@@ -72,7 +72,6 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
                                            // this->Initialize().
   m_Registration(0),                       // has to be provided by
                                            // this->Initialize().
-  m_PermitParameterVariation(0),
   m_CostMetricObject(NULL),
   m_SamplingPercentage(1),
   m_NumberOfHistogramBins(200),
@@ -90,7 +89,6 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
   m_FinalMetricValue(0),
   m_ObserveIterations(true),
   m_SamplingStrategy(AffineRegistrationType::NONE),
-  m_ForceMINumberOfThreads(-1),
   m_InternalTransformTime(0)
 {
   this->SetNumberOfRequiredOutputs(1);    // for the Transform

--- a/BRAINSCut/BRAINSFeatureCreators/RobustStatisticComputations/WFPerSubject.py
+++ b/BRAINSCut/BRAINSFeatureCreators/RobustStatisticComputations/WFPerSubject.py
@@ -51,7 +51,6 @@ def WFPerSubjectDef(inputListOfSubjectVolumes,
     BFitAtlasToSubject.inputs.translationScale = 1000
     BFitAtlasToSubject.inputs.reproportionScale = 1
     BFitAtlasToSubject.inputs.skewScale = 1
-    BFitAtlasToSubject.inputs.useCachingOfBSplineWeightsMode = "ON"
     BFitAtlasToSubject.inputs.maxBSplineDisplacement = 7
     BFitAtlasToSubject.inputs.projectedGradientTolerance = 1e-05
     BFitAtlasToSubject.inputs.costFunctionConvergenceFactor = 1e+09

--- a/BRAINSFit/BRAINSFit.cxx
+++ b/BRAINSFit/BRAINSFit.cxx
@@ -429,7 +429,6 @@ int main(int argc, char *argv[])
     HelperType::Pointer myHelper = HelperType::New();
     myHelper->SetTransformType(localTransformType);
     myHelper->SetFixedVolume( extractFixedVolume );
-    myHelper->SetForceMINumberOfThreads(forceMINumberOfThreads);
     myHelper->SetMovingVolume( extractMovingVolume );
     myHelper->SetHistogramMatch(histogramMatch);
     myHelper->SetRemoveIntensityOutliers(removeIntensityOutliers);
@@ -438,7 +437,6 @@ int main(int argc, char *argv[])
     myHelper->SetMovingBinaryVolume(movingMask);
     myHelper->SetOutputFixedVolumeROI(outputFixedVolumeROI);
     myHelper->SetOutputMovingVolumeROI(outputMovingVolumeROI);
-    myHelper->SetPermitParameterVariation(permitParameterVariation);
     if(numberOfSamples > 0)
       {
         const unsigned long numberOfAllSamples = extractFixedVolume->GetBufferedRegion().GetNumberOfPixels();
@@ -455,7 +453,6 @@ int main(int argc, char *argv[])
     myHelper->SetTranslationScale(translationScale);
     myHelper->SetReproportionScale(reproportionScale);
     myHelper->SetSkewScale(skewScale);
-    myHelper->SetUseCachingOfBSplineWeightsMode(useCachingOfBSplineWeightsMode);
     myHelper->SetBackgroundFillValue(backgroundFillValue);
     myHelper->SetInitializeTransformMode(localInitializeTransformMode);
     myHelper->SetMaskInferiorCutOffFromCenter(maskInferiorCutOffFromCenter);

--- a/BRAINSFit/BRAINSFit.xml
+++ b/BRAINSFit/BRAINSFit.xml
@@ -8,73 +8,81 @@
   <contributor>Hans J. Johnson, hans-johnson -at- uiowa.edu, http://www.psychiatry.uiowa.edu</contributor>
   <acknowledgements><![CDATA[Hans Johnson(1,3,4); Kent Williams(1); Gregory Harris(1), Vincent Magnotta(1,2,3);  Andriy Fedorov(5) 1=University of Iowa Department of Psychiatry, 2=University of Iowa Department of Radiology, 3=University of Iowa Department of Biomedical Engineering, 4=University of Iowa Department of Electrical and Computer Engineering, 5=Surgical Planning Lab, Harvard]]>  </acknowledgements>
   <version>3.0.0</version>
+
   <parameters advanced="false">
     <label>Input Images</label>
-
     <image>
       <name>fixedVolume</name>
       <longflag>fixedVolume</longflag>
       <label>Fixed Image Volume</label>
-      <description>The fixed image for registration by mutual information optimization.</description>
+      <description>Input fixed image (the moving image will be transformed into this image space).</description>
       <channel>input</channel>
       <default></default>
     </image>
-
     <image>
       <name>movingVolume</name>
       <longflag>movingVolume</longflag>
       <label>Moving Image Volume</label>
-      <description>The moving image for registration by mutual information optimization.</description>
+      <description>Input moving image (this image will be transformed into the fixed image space).</description>
       <default></default>
       <channel>input</channel>
     </image>
+    <double>
+      <name>samplingPercentage</name>
+      <longflag>samplingPercentage</longflag>
+      <label>Percentage Of Samples</label>
+      <description>Fraction of voxels of the fixed image that will be used for registration. The number has to be larger than zero and less or equal to one. Higher values increase the computation time but may give more accurate results. You can also limit the sampling focus with ROI masks and ROIAUTO mask generation. The default is 0.002 (use approximately 0.2% of voxels, resulting in 100000 samples in a 512x512x192 volume) to provide a very fast registration in most cases. Typical values range from 0.01 (1%) for low detail images to 0.2 (20%) for high detail images.</description>
+      <default>0.002</default>
+    </double>
+    <integer-vector>
+      <name>splineGridSize</name>
+      <longflag>splineGridSize</longflag>
+      <label>B-Spline Grid Size</label>
+      <description>Number of BSpline grid subdivisions along each axis of the fixed image, centered on the image space. Values must be 3 or higher for the BSpline to be correctly computed.</description>
+      <default>14,10,12</default>
+    </integer-vector>
   </parameters>
-  <!-- -->
-  <parameters advanced="false">
-    <label>Output Settings (At least one output must be specified.)</label>
-    <transform fileExtensions=".h5,.hdf5,.mat,.txt" type="bspline" reference="movingVolume">
-      <name>bsplineTransform</name>
-      <longflag>bsplineTransform</longflag>
-      <label>Slicer BSpline Transform</label>
-      <description>(optional) Filename to which save the estimated transform. NOTE: You must set at least one output object (either a deformed image or a transform.  NOTE: USE THIS ONLY IF THE FINAL TRANSFORM IS BSpline</description>
-      <channel>output</channel>
-    </transform>
 
+  <parameters advanced="false">
+    <label>Output Settings (At least one output must be specified)</label>
     <transform fileExtensions=".h5,.hdf5,.mat,.txt" type="linear" reference="movingVolume">
       <name>linearTransform</name>
       <longflag>linearTransform</longflag>
       <label>Slicer Linear Transform</label>
-      <description>(optional) Filename to which save the estimated transform. NOTE: You must set at least one output object (either a deformed image or a transform.  NOTE: USE THIS ONLY IF THE FINAL TRANSFORM IS ---NOT--- BSpline</description>
+      <description>(optional) Output estimated transform - in case the computed transform is not BSpline. NOTE: You must set at least one output object (transform and/or output volume).</description>
       <channel>output</channel>
     </transform>
-
+    <transform fileExtensions=".h5,.hdf5,.mat,.txt" type="bspline" reference="movingVolume">
+      <name>bsplineTransform</name>
+      <longflag>bsplineTransform</longflag>
+      <label>Slicer BSpline Transform</label>
+      <description>(optional) Output estimated transform - in case the computed transform is BSpline. NOTE: You must set at least one output object (transform and/or output volume).</description>
+      <channel>output</channel>
+    </transform>
     <image>
       <name>outputVolume</name>
       <longflag>outputVolume</longflag>
       <label>Output Image Volume</label>
-      <description>(optional) Output image for registration. NOTE: You must select either the outputTransform or the outputVolume option.</description>
+      <description>(optional) Output image: the moving image warped to the fixed image space. NOTE: You must set at least one output object (transform and/or output volume).</description>
       <channel>output</channel>
     </image>
-
- </parameters>
+  </parameters>
 
   <parameters>
-    <label>Initialization of registration</label>
-    <description>Options for initializing transform parameters to a initial starting point.</description>
-
+    <label>Transform Initialization Settings</label>
+    <description>Options for initializing transform parameters.</description>
     <transform fileExtensions=".h5,.hdf5,.mat,.txt">
       <name>initialTransform</name>
       <longflag>initialTransform</longflag>
       <label>Initialization transform</label>
-      <description>Filename of transform used to initialize the registration.  This CAN NOT be used with either CenterOfHeadLAlign, MomentsAlign, GeometryAlign, or initialTransform file.</description>
+      <description>Transform to be applied to the moving image to initialize the registration.  This can only be used if Initialize Transform Mode is Off.</description>
       <channel>input</channel>
     </transform>
-
     <string-enumeration>
       <name>initializeTransformMode</name>
       <longflag>initializeTransformMode</longflag>
       <label>Initialize Transform Mode</label>
-      <description>Determine how to initialize the transform center.  GeometryAlign on assumes that the center of the voxel lattice of the images represent similar structures.  MomentsAlign assumes that the center of mass of the images represent similar structures.  useCenterOfHeadAlign attempts to use the top of head and shape of neck to drive a center of mass estimate.  Off assumes that the physical space of the images are close, and that centering in terms of the image Origins is a good starting point.  This flag is mutually exclusive with the initialTransform flag.</description>
+      <description>Determine how to initialize the transform center.  useMomentsAlign assumes that the center of mass of the images represent similar structures.  useCenterOfHeadAlign attempts to use the top of head and shape of neck to drive a center of mass estimate. useGeometryAlign on assumes that the center of the voxel lattice of the images represent similar structures.  Off assumes that the physical space of the images are close.  This flag is mutually exclusive with the Initialization transform.</description>
       <default>Off</default>
       <element>Off</element>
       <element>useMomentsAlign</element>
@@ -82,15 +90,6 @@
       <element>useGeometryAlign</element>
       <element>useCenterOfROIAlign</element>
     </string-enumeration>
-
-    <double>
-        <name>samplingPercentage</name>
-        <longflag>samplingPercentage</longflag>
-        <label>Percentage Of Samples</label>
-        <description>This is a number in (0.0,1.0] interval that shows the percentage of the input fixed image voxels that are sampled for mutual information computation.  Increase this for a slower, more careful fit. You can also limit the sampling focus with ROI masks and ROIAUTO mask generation. The default is to use approximately 0.2% of voxels to provide a very fast registration in most cases 0.2% ~= 100000/(512*512*192). Typical values range from 1% for low detail images to 20% for high detail images.</description>
-        <default>0.002</default>
-    </double>
-
   </parameters>
 
   <parameters>
@@ -100,130 +99,123 @@
        <name>useRigid</name>
        <longflag>useRigid</longflag>
        <label>Rigid (6 DOF)</label>
-       <description>Perform a rigid registration as part of the sequential registration steps.  This family of options superceeds the use of transformType if any of them are set.</description>
+       <description>Perform a rigid registration as part of the sequential registration steps.  This family of options overrides the use of transformType if any of them are set.</description>
        <default>false</default>
     </boolean>
     <boolean>
        <name>useScaleVersor3D</name>
        <longflag>useScaleVersor3D</longflag>
        <label>Rigid+Scale(7 DOF)</label>
-       <description>Perform a ScaleVersor3D registration as part of the sequential registration steps.  This family of options superceeds the use of transformType if any of them are set.</description>
+       <description>Perform a ScaleVersor3D registration as part of the sequential registration steps.  This family of options overrides the use of transformType if any of them are set.</description>
        <default>false</default>
     </boolean>
     <boolean>
        <name>useScaleSkewVersor3D</name>
        <longflag>useScaleSkewVersor3D</longflag>
        <label>Rigid+Scale+Skew(10 DOF)</label>
-       <description>Perform a ScaleSkewVersor3D registration as part of the sequential registration steps.  This family of options superceeds the use of transformType if any of them are set.</description>
+       <description>Perform a ScaleSkewVersor3D registration as part of the sequential registration steps.  This family of options overrides the use of transformType if any of them are set.</description>
        <default>false</default>
     </boolean>
     <boolean>
        <name>useAffine</name>
        <longflag>useAffine</longflag>
        <label>Affine(12 DOF)</label>
-       <description>Perform an Affine registration as part of the sequential registration steps.  This family of options superceeds the use of transformType if any of them are set.</description>
+       <description>Perform an Affine registration as part of the sequential registration steps.  This family of options overrides the use of transformType if any of them are set.</description>
        <default>false</default>
     </boolean>
     <boolean>
        <name>useBSpline</name>
        <longflag>useBSpline</longflag>
        <label>BSpline (>27 DOF) </label>
-       <description>Perform a BSpline registration as part of the sequential registration steps.  This family of options superceeds the use of transformType if any of them are set.</description>
+       <description>Perform a BSpline registration as part of the sequential registration steps.  This family of options overrides the use of transformType if any of them are set.</description>
        <default>false</default>
     </boolean>
     <boolean>
        <name>useSyN</name>
        <longflag>useSyN</longflag>
        <label>SyN</label>
-       <description>Perform a SyN registration as part of the sequential registration steps.  This family of options superceeds the use of transformType if any of them are set.</description>
+       <description>Perform a SyN registration as part of the sequential registration steps.  This family of options overrides the use of transformType if any of them are set.</description>
        <default>false</default>
     </boolean>
     <boolean>
        <name>useComposite</name>
        <longflag>useComposite</longflag>
        <label>Composite (many DOF) </label>
-       <description>Perform a Composite registration as part of the sequential registration steps.  This family of options superceeds the use of transformType if any of them are set.</description>
+       <description>Perform a Composite registration as part of the sequential registration steps.  This family of options overrides the use of transformType if any of them are set.</description>
        <default>false</default>
     </boolean>
   </parameters>
 
-  <!-- -->
   <parameters advanced="true">
-    <label>Main Parameters</label>
-
-    <integer-vector>
-      <name>splineGridSize</name>
-      <longflag>splineGridSize</longflag>
-      <label>B-Spline Grid Size</label>
-      <description>The number of subdivisions of the BSpline Grid to be centered on the image space (in voxels).  Each dimension must have at least 3 subdivisions for the BSpline to be correctly computed. </description>
-      <default>14,10,12</default>
-    </integer-vector>
-
-    <boolean>
-       <name>useROIBSpline</name>
-       <longflag>useROIBSpline</longflag>
-       <label>Define BSpline grid over the ROI bounding box </label>
-       <description>When set, will use the bounding box of the input ROIs to define spline grid support region. Otherwise will use the whole image.</description>
-       <default>false</default>
-    </boolean>
-
-    <integer-vector>
-      <name>numberOfIterations</name>
-      <longflag>numberOfIterations</longflag>
-      <label>Max Iterations</label>
-      <description>The maximum number of iterations to try before failing to converge.  Use an explicit limit like 500 or 1000 to manage risk of divergence</description>
-      <default>1500</default>
-    </integer-vector>
-
-  </parameters>
-  <!-- -->
-  <parameters advanced="true">
-    <label>Mask Option</label>
-
+    <label>Image Mask and Pre-Processing</label>
     <string-enumeration>
       <name>maskProcessingMode</name>
       <longflag>maskProcessingMode</longflag>
-      <description>What mode to use for using the masks.  If ROIAUTO is choosen, then the mask is implicitly defined using a otsu forground and hole filling algorithm. The Region Of Interest mode (choose ROI) uses the masks to define what parts of the image should be used for computing the transform.</description>
+      <description>Specifies a mask to only consider a certain image region for the registration.  If ROIAUTO is chosen, then the mask is computed using Otsu thresholding and hole filling. If ROI is chosen then the mask has to be specified as in input.</description>
       <label>Masking Option</label>
       <default>NOMASK</default>
       <element>NOMASK</element>
       <element>ROIAUTO</element>
       <element>ROI</element>
     </string-enumeration>
-
     <image type="label">
       <name>fixedBinaryVolume</name>
       <longflag>fixedBinaryVolume</longflag>
-      <label>(ROI)Masking input fixed</label>
-      <description>Fixed Image binary mask volume, ONLY FOR MANUAL ROI mode. (Values are zero and non-zero.)</description>
+      <label>(ROI) Masking input fixed</label>
+      <description>Fixed Image binary mask volume, required if Masking Option is ROI. Image areas where the mask volume has zero value are ignored during the registration.</description>
       <channel>input</channel>
     </image>
-
     <image type="label">
       <name>movingBinaryVolume</name>
       <longflag>movingBinaryVolume</longflag>
-      <label>(ROI)Masking input moving</label>
-      <description>Moving Image binary mask volume, ONLY FOR MANUAL ROI mode. (Values are zero and non-zero.)</description>
+      <label>(ROI) Masking input moving</label>
+      <description>Moving Image binary mask volume, required if Masking Option is ROI. Image areas where the mask volume has zero value are ignored during the registration.</description>
       <channel>input</channel>
     </image>
-
     <image type="label">
       <name>outputFixedVolumeROI</name>
       <longflag>outputFixedVolumeROI</longflag>
       <label>(ROIAUTO) Output fixed mask</label>
-      <description>The ROI automatically found in fixed image, ONLY FOR ROIAUTO mode. (Values are zero and non-zero.)</description>
+      <description>ROI that is automatically computed from the fixed image. Only available if Masking Option is ROIAUTO. Image areas where the mask volume has zero value are ignored during the registration.</description>
       <channel>output</channel>
     </image>
-
     <image type="label">
       <name>outputMovingVolumeROI</name>
       <longflag>outputMovingVolumeROI</longflag>
       <label>(ROIAUTO) Output moving mask</label>
-      <description>The ROI automatically found in moving image, ONLY FOR ROIAUTO mode. (Values are zero and non-zero.)</description>
+      <description>ROI that is automatically computed from the moving image. Only available if Masking Option is ROIAUTO. Image areas where the mask volume has zero value are ignored during the registration.</description>
       <channel>output</channel>
     </image>
+    <boolean>
+       <name>useROIBSpline</name>
+       <longflag>useROIBSpline</longflag>
+       <label>Define BSpline grid over the ROI bounding box </label>
+       <description>If enabled then the bounding box of the input ROIs defines the BSpline grid support region. Otherwise the BSpline grid support region is the whole fixed image.</description>
+       <default>false</default>
+    </boolean>
+    <boolean>
+       <name>histogramMatch</name>
+       <flag>e</flag>
+       <longflag deprecatedalias="use_histogram_matching">histogramMatch</longflag>
+       <description>Apply histogram matching operation for the input images to make them more similar.  This is suitable for images of the same modality that may have different brightness or contrast, but the same overall intensity profile. Do NOT use if registering images from different modalities.</description>
+       <label>Histogram Match</label>
+       <default>false</default>
+    </boolean>
+    <integer-vector>
+      <name>medianFilterSize</name>
+      <longflag>medianFilterSize</longflag>
+      <label>Median Filter Size</label>
+      <description>Apply median filtering to reduce noise in the input volumes. The 3 values specify the radius for the optional MedianImageFilter preprocessing in all 3 directions (in voxels).</description>
+      <default>0,0,0</default>
+    </integer-vector>
+    <double>
+      <name>removeIntensityOutliers</name>
+      <longflag>removeIntensityOutliers</longflag>
+      <label>Remove Intensity Outliers value at one tail</label>
+      <description>Remove very high and very low intensity voxels from the input volumes. The parameter specifies the half percentage to decide outliers of image intensities. The default value is zero, which means no outlier removal. If the value of 0.005 is given, the 0.005% of both tails will be thrown away, so 0.01% of intensities in total would be ignored in the statistic calculation.</description>
+      <default>0.0</default>
+    </double>
   </parameters>
-
 
   <parameters advanced="true">
     <label>Advanced Output Settings</label>
@@ -231,7 +223,7 @@
       <name>outputVolumePixelType</name>
       <longflag>outputVolumePixelType</longflag>
       <label>Output Image Pixel Type</label>
-      <description>The output image Pixel Type is the scalar datatype for representation of the Output Volume.</description>
+      <description>Data type for representing a voxel of the Output Volume.</description>
       <default>float</default>
       <element>float</element>
       <element>short</element>
@@ -240,24 +232,13 @@
       <element>uint</element>
       <element>uchar</element>
     </string-enumeration>
-
-
     <double>
       <name>backgroundFillValue</name>
       <longflag>backgroundFillValue</longflag>
       <label>Background Fill Value</label>
-      <description>Background fill value for output image.</description>
+      <description>This value will be used for filling those areas of the output image that have no corresponding voxels in the input moving image.</description>
       <default>0.0</default>
     </double>
-
-    <double>
-      <name>maskInferiorCutOffFromCenter</name>
-      <longflag>maskInferiorCutOffFromCenter</longflag>
-      <label>Inferior Cut Off From Center</label>
-      <description>For use with --initializeTransformMode useCenterOfHeadAlign (and --maskProcessingMode ROIAUTO): the cut-off below the image centers, in millimeters, </description>
-      <default>1000.0</default>
-    </double>
-
     <boolean>
       <name>scaleOutputValues</name>
       <longflag>scaleOutputValues</longflag>
@@ -265,12 +246,11 @@
       <description>If true, and the voxel values do not fit within the minimum and maximum values of the desired outputVolumePixelType, then linearly scale the min/max output image voxel values to fit within the min/max range of the outputVolumePixelType.</description>
       <default>false</default>
     </boolean>
-
     <string-enumeration>
       <name>interpolationMode</name>
       <longflag>interpolationMode</longflag>
       <label>Interpolation Mode</label>
-      <description>Type of interpolation to be used when applying transform to moving volume.  Options are Linear, NearestNeighbor, BSpline, WindowedSinc, or ResampleInPlace.  The ResampleInPlace option will create an image with the same discrete voxel values and will adjust the origin and direction of the physical space interpretation.</description>
+      <description>Type of interpolation to be used when applying transform to moving volume.  Options are Linear, NearestNeighbor, BSpline, WindowedSinc, Hamming, Cosine, Welch, Lanczos, or ResampleInPlace.  The ResampleInPlace option will create an image with the same discrete voxel values and will adjust the origin and direction of the physical space interpretation.</description>
       <default>Linear</default>
       <element>NearestNeighbor</element>
       <element>Linear</element>
@@ -283,101 +263,154 @@
       <element>Lanczos</element>
       <element>Blackman</element>
     </string-enumeration>
+  </parameters>
 
+  <parameters advanced="true">
+    <label>Advanced Optimization Settings</label>
+    <integer-vector>
+      <name>numberOfIterations</name>
+      <longflag>numberOfIterations</longflag>
+      <label>Max Iterations</label>
+      <description>The maximum number of iterations to try before stopping the optimization. When using a lower value (500-1000) then the registration is forced to terminate earlier but there is a higher risk of stopping before an optimal solution is reached.</description>
+      <default>1500</default>
+    </integer-vector>
+    <double>
+      <name>maximumStepLength</name>
+      <longflag deprecatedalias="maximumStepSize">maximumStepLength</longflag>
+      <label>Maximum Step Length</label>
+      <description>Starting step length of the optimizer. In general, higher values allow for recovering larger initial misalignments but there is an increased chance that the registration will not converge.</description>
+      <default>0.05</default>
+    </double>
     <double-vector>
       <name>minimumStepLength</name>
       <longflag deprecatedalias="minimumStepSize">minimumStepLength</longflag>
       <label>Minimum Step Length</label>
-      <description>Each step in the optimization takes steps at least this big.  When none are possible, registration is complete.</description>
+      <description>Each step in the optimization takes steps at least this big.  When none are possible, registration is complete. Smaller values allows the optimizer to make smaller adjustments, but the registration time may increase.</description>
       <default>0.001</default>
     </double-vector>
-
+    <double>
+      <name>relaxationFactor</name>
+      <longflag>relaxationFactor</longflag>
+      <label>Relaxation Factor</label>
+      <description>Specifies how quickly the optimization step length is decreased during registration. The value must be larger than 0 and smaller than 1. Larger values result in slower step size decrease, which allow for recovering larger initial misalignments but it increases the registration time and the chance that the registration will not converge.</description>
+      <default>0.5</default>
+    </double>
     <double>
       <name>translationScale</name>
       <longflag deprecatedalias="spatialScale,transformScale">translationScale</longflag>
       <label>Transform Scale</label>
-      <description>How much to scale up changes in position compared to unit rotational changes in radians -- decrease this to put more rotation in the search pattern.</description>
+      <description>How much to scale up changes in position (in mm) compared to unit rotational changes (in radians) -- decrease this to allow for more rotation in the search pattern.</description>
       <default>1000.0</default>
     </double>
-
     <double>
       <name>reproportionScale</name>
       <longflag>reproportionScale</longflag>
       <label>Reproportion Scale</label>
-      <description>ScaleVersor3D 'Scale' compensation factor.  Increase this to put more rescaling in a ScaleVersor3D or ScaleSkewVersor3D search pattern.  1.0 works well with a translationScale of 1000.0</description>
+      <description>ScaleVersor3D 'Scale' compensation factor.  Increase this to allow for more rescaling in a ScaleVersor3D or ScaleSkewVersor3D search pattern.  1.0 works well with a translationScale of 1000.0</description>
       <default>1.0</default>
     </double>
-
     <double>
       <name>skewScale</name>
       <longflag>skewScale</longflag>
       <label>Skew Scale</label>
-      <description>ScaleSkewVersor3D Skew compensation factor.  Increase this to put more skew in a ScaleSkewVersor3D search pattern.  1.0 works well with a translationScale of 1000.0</description>
+      <description>ScaleSkewVersor3D Skew compensation factor.  Increase this to allow for more skew in a ScaleSkewVersor3D search pattern.  1.0 works well with a translationScale of 1000.0</description>
       <default>1.0</default>
     </double>
-
     <double>
       <name>maxBSplineDisplacement</name>
       <longflag>maxBSplineDisplacement</longflag>
       <label>Maximum B-Spline Displacement</label>
-      <description> Sets the maximum allowed displacements in image physical coordinates (mm) for BSpline control grid along each axis.  A value of 0.0 indicates that the problem should be unbounded.  NOTE:  This only constrains the BSpline portion, and does not limit the displacement from the associated bulk transform.  This can lead to a substantial reduction in computation time in the BSpline optimizer.
+      <description>Maximum allowed displacements in image physical coordinates (mm) for BSpline control grid along each axis.  A value of 0.0 indicates that the problem should be unbounded.  NOTE:  This only constrains the BSpline portion, and does not limit the displacement from the associated bulk transform.  This can lead to a substantial reduction in computation time in the BSpline optimizer.
       </description>
       <default>0.0</default>
     </double>
+  </parameters>
 
-    <boolean>
-       <name>histogramMatch</name>
-       <flag>e</flag>
-       <longflag deprecatedalias="use_histogram_matching">histogramMatch</longflag>
-       <description>Histogram Match the input images.  This is suitable for images of the same modality that may have different absolute scales, but the same overall intensity profile. Do NOT use if registering images from different modailties.</description>
-       <label>Histogram Match</label>
-       <default>false</default>
-    </boolean>
-    <!-- NOTE numberOfMatchPoints=10, numberOfHistogramBins=50 was a good comprimise for speed for synthesized T1 to T1 data set testing-->
+  <parameters advanced="true">
+    <label>Expert-only Parameters</label>
+    <integer>
+      <name>fixedVolumeTimeIndex</name>
+      <longflag>fixedVolumeTimeIndex</longflag>
+      <label>Fixed Image Time Index</label>
+      <description>The index in the time series for the 3D fixed image to fit. Only allowed if the fixed input volume is 4-dimensional.</description>
+      <default>0</default>
+    </integer>
+    <integer>
+      <name>movingVolumeTimeIndex</name>
+      <longflag>movingVolumeTimeIndex</longflag>
+      <label>Moving Image Time Index</label>
+      <description>The index in the time series for the 3D moving image to fit. Only allowed if the moving input volume is 4-dimensional</description>
+      <default>0</default>
+    </integer>
+    <!-- NOTE numberOfMatchPoints=10, numberOfHistogramBins=50 was a good compromise for speed for synthesized T1 to T1 data set testing-->
     <integer>
       <name>numberOfHistogramBins</name>
       <longflag>numberOfHistogramBins</longflag>
-      <description>The number of histogram levels</description>
-      <label>    Histogram bin count</label>
+      <description>The number of histogram levels used for mutual information metric estimation.</description>
+      <label>Histogram bin count</label>
       <default>50</default>
     </integer>
     <integer>
       <name>numberOfMatchPoints</name>
       <longflag>numberOfMatchPoints</longflag>
-      <description>the number of match points</description>
-      <label>     Histogram match point count</label>
+      <description>Number of histogram match points used for mutual information metric estimation.</description>
+      <label>Histogram match point count</label>
       <default>10</default>
     </integer>
-
-    <integer>
-        <name>numberOfSamples</name>
-        <longflag>numberOfSamples</longflag>
-        <label>Number Of Samples</label>
-        <description>The number of voxels sampled for mutual information computation.  Increase this for a slower, more careful fit.\nNOTE that it is suggested to use samplingPercentage instead of this option. However, if set to non-zero, numberOfSamples overwrites the samplingPercentage option.  </description>
-        <default>0</default>
+    <string-enumeration>
+        <name>costMetric</name>
+        <longflag>costMetric</longflag>
+        <label>Cost Metric</label>
+        <description>The cost metric to be used during fitting. Defaults to MMI. Options are MMI (Mattes Mutual Information), MSE (Mean Square Error), NC (Normalized Correlation), MC (Match Cardinality for binary images)</description>
+        <default>MMI</default>
+        <element>MMI</element>
+        <element>MSE</element>
+        <element>NC</element>
+        <element>MIH</element>
+    </string-enumeration>
+    <double>
+      <name>maskInferiorCutOffFromCenter</name>
+      <longflag>maskInferiorCutOffFromCenter</longflag>
+      <label>Inferior Cut Off From Center</label>
+      <description>If Initialize Transform Mode is set to useCenterOfHeadAlign or Masking Option is ROIAUTO then this value defines the how much is cut of from the inferior part of the image. The cut-off distance is specified in millimeters, relative to the image center. If the value is 1000 or larger then no cut-off performed.</description>
+      <default>1000.0</default>
+    </double>
+    <double>
+      <name>ROIAutoDilateSize</name>
+      <longflag>ROIAutoDilateSize</longflag>
+      <label> ROIAuto Dilate Size</label>
+      <description>This flag is only relevant when using ROIAUTO mode for initializing masks.  It defines the final dilation size to capture a bit of background outside the tissue region.  A setting of 10mm has been shown to help regularize a BSpline registration type so that there is some background constraints to match the edges of the head better.</description>
+      <default>0.0</default>
+    </double>
+    <double>
+      <name>ROIAutoClosingSize</name>
+      <longflag>ROIAutoClosingSize</longflag>
+      <label> ROIAuto Closing Size</label>
+      <description>This flag is only relevant when using ROIAUTO mode for initializing masks.  It defines the hole closing size in mm.  It is rounded up to the nearest whole pixel size in each direction. The default is to use a closing size of 9mm.  For mouse data this value may need to be reset to 0.9 or smaller.</description>
+      <default>9.0</default>
+    </double>
+   <integer>
+      <name>numberOfSamples</name>
+      <longflag>numberOfSamples</longflag>
+      <label>Number Of Samples</label>
+      <description>The number of voxels sampled for mutual information computation.  Increase this for higher accuracy, at the cost of longer computation time.\nNOTE that it is suggested to use samplingPercentage instead of this option. However, if set to non-zero, numberOfSamples overwrites the samplingPercentage option.  </description>
+      <default>0</default>
     </integer>
-
-  </parameters>
-
-  <parameters advanced="true">
-    <label>Special Modes Parameters</label>
-
     <transform fileExtensions=".h5,.hdf5,.mat,.txt" type="linear">
       <name>strippedOutputTransform</name>
       <longflag>strippedOutputTransform</longflag>
       <label>Stripped Output Transform</label>
-      <description>File name for the rigid component of the estimated affine transform. Can be used to rigidly register the moving image to the fixed image. NOTE:  This value is overwritten if either bsplineTransform or linearTransform is set.</description>
+      <description>Rigid component of the estimated affine transform. Can be used to rigidly register the moving image to the fixed image. NOTE:  This value is overridden if either bsplineTransform or linearTransform is set.</description>
       <channel>output</channel>
     </transform>
-
     <string-vector>
       <name>transformType</name>
       <longflag>transformType</longflag>
       <label>Transform Type</label>
-      <description>Specifies a list of registration types to be used.  The valid types are, Rigid, ScaleVersor3D, ScaleSkewVersor3D, Affine, BSpline and SyN.  Specifiying more than one in a comma separated list will initialize the next stage with the previous results. If registrationClass flag is used, it overrides this parameter setting.</description>
+      <description>Specifies a list of registration types to be used.  The valid types are, Rigid, ScaleVersor3D, ScaleSkewVersor3D, Affine, BSpline and SyN.  Specifying more than one in a comma separated list will initialize the next stage with the previous results. If registrationClass flag is used, it overrides this parameter setting.</description>
       <default></default>
     </string-vector>
-
+    <!--Note: Due to how transforms are currently read into 3D Slicer, we need a different output parameter for linear and bspline transform and therefore we cannot use this general outputTransform parameter.-->
     <transform fileExtensions=".h5,.hdf5,.mat,.txt" reference="movingVolume">
       <name>outputTransform</name>
       <longflag>outputTransform</longflag>
@@ -385,106 +418,17 @@
       <description>(optional) Filename to which save the (optional) estimated transform. NOTE: You must select either the outputTransform or the outputVolume option.</description>
       <channel>output</channel>
     </transform>
-
-    <integer>
-      <name>fixedVolumeTimeIndex</name>
-      <longflag>fixedVolumeTimeIndex</longflag>
-      <label>Fixed Image Time Index</label>
-      <description>The index in the time series for the 3D fixed image to fit, if 4-dimensional.</description>
-      <default>0</default>
-    </integer>
-
-    <integer>
-      <name>movingVolumeTimeIndex</name>
-      <longflag>movingVolumeTimeIndex</longflag>
-      <label>Moving Image Time Index</label>
-      <description>The index in the time series for the 3D moving image to fit, if 4-dimensional.</description>
-      <default>0</default>
-    </integer>
-
-    <integer-vector>
-      <name>medianFilterSize</name>
-      <longflag>medianFilterSize</longflag>
-      <label>Median Filter Size</label>
-      <description>The radius for the optional MedianImageFilter preprocessing in all 3 directions (in voxels).</description>
-      <default>0,0,0</default>
-    </integer-vector>
-
-    <double>
-      <name>removeIntensityOutliers</name>
-      <longflag>removeIntensityOutliers</longflag>
-      <label>Remove Intensity Outliers value at one tail</label>
-      <description>The half percentage to decide outliers of image intensities. The default value is zero, which means no outlier removal. If the value of 0.005 is given, the moduel will throw away 0.005 % of both tails, so 0.01% of intensities in total would be ignored in its statistic calculation. </description>
-      <default>0.0</default>
-    </double>
-
     <boolean>
       <name>initializeRegistrationByCurrentGenericTransform</name>
       <longflag>initializeRegistrationByCurrentGenericTransform</longflag>
       <label>Pass warped moving image to BSpline registration filter</label>
-      <description>If this flag is ON, the current generic composite transform, resulted from the linear registration stages, is set to initialize the follow nonlinear registration process. However, by the default behaviour, the moving image is first warped based on the existant transform before it is passed to the BSpline registration filter. It is done to speed up the BSpline registration by reducing the computations of composite transform jacobian.</description>
+      <description>If this flag is ON, the current generic composite transform, resulted from the linear registration stages, is set to initialize the follow nonlinear registration process. However, by the default behaviour, the moving image is first warped based on the existant transform before it is passed to the BSpline registration filter. It is done to speed up the BSpline registration by reducing the computations of composite transform Jacobian.</description>
       <default>0</default>
     </boolean>
-
   </parameters>
-  <!-- -->
-  <!-- -->
+
   <parameters advanced="true">
-    <label>Registration Debugging Parameters</label>
-
-    <string-enumeration>
-      <name>useCachingOfBSplineWeightsMode</name>
-      <longflag>useCachingOfBSplineWeightsMode</longflag>
-      <description>This is a 5x speed advantage at the expense of requiring much more memory.  Only relevant when transformType is BSpline.</description>
-      <label>Caching BSpline Weights Mode</label>
-      <default>ON</default>
-      <element>ON</element>
-      <element>OFF</element>
-    </string-enumeration>
-
-    <string-enumeration>
-      <name>useExplicitPDFDerivativesMode</name>
-      <longflag>useExplicitPDFDerivativesMode</longflag>
-      <description>This option is not used in ITKv4 optimizers. There is no need to set that; however, this flag is not removed to keep backward compatibility.</description>
-      <label>Explicit PDF Derivatives Mode</label>
-      <default>AUTO</default>
-      <element>AUTO</element>
-      <element>ON</element>
-      <element>OFF</element>
-    </string-enumeration>
-
-    <double>
-      <name>ROIAutoDilateSize</name>
-      <longflag>ROIAutoDilateSize</longflag>
-      <label> ROIAuto Dilate Size</label>
-      <description>This flag is only relavent when using ROIAUTO mode for initializing masks.  It defines the final dilation size to capture a bit of background outside the tissue region.  A setting of 10mm has been shown to help regularize a BSpline registration type so that there is some background constraints to match the edges of the head better.</description>
-      <default>0.0</default>
-    </double>
-
-    <double>
-      <name>ROIAutoClosingSize</name>
-      <longflag>ROIAutoClosingSize</longflag>
-      <label> ROIAuto Closing Size</label>
-      <description>This flag is only relavent when using ROIAUTO mode for initializing masks.  It defines the hole closing size in mm.  It is rounded up to the nearest whole pixel size in each direction. The default is to use a closing size of 9mm.  For mouse data this value may need to be reset to 0.9 or smaller.</description>
-      <default>9.0</default>
-    </double>
-
-    <double>
-      <name>relaxationFactor</name>
-      <longflag>relaxationFactor</longflag>
-      <label>Relaxation Factor</label>
-      <description>Internal debugging parameter, and should probably never be used from the command line.  This will be removed in the future.</description>
-      <default>0.5</default>
-    </double>
-
-    <double>
-      <name>maximumStepLength</name>
-      <longflag deprecatedalias="maximumStepSize">maximumStepLength</longflag>
-      <label>Maximum Step Length</label>
-      <description>Internal debugging parameter, and should probably never be used from the command line.  This will be removed in the future.</description>
-      <default>0.05</default>
-    </double>
-
+    <label>Debugging Parameters</label>
     <integer>
       <name>failureExitCode</name>
       <longflag>failureExitCode</longflag>
@@ -492,7 +436,6 @@
       <description>If the fit fails, exit with this status code.  (It can be used to force a successfult exit status of (0) if the registration fails due to reaching the maximum number of iterations.</description>
       <default>-1</default>
     </integer>
-
     <boolean>
       <name>writeTransformOnFailure</name>
       <longflag>writeTransformOnFailure</longflag>
@@ -500,7 +443,6 @@
       <description>Flag to save the final transform even if the numberOfIterations are reached without convergence. (Intended for use when --failureExitCode 0 )</description>
       <default>0</default>
     </boolean>
-
     <integer>
       <name>numberOfThreads</name>
       <longflag deprecatedalias="debugNumberOfThreads" >numberOfThreads</longflag>
@@ -508,14 +450,6 @@
       <description>Explicitly specify the maximum number of threads to use. (default is auto-detected)</description>
       <default>-1</default>
     </integer>
-    <integer>
-      <name>forceMINumberOfThreads</name>
-      <longflag>forceMINumberOfThreads</longflag>
-      <label>Debug MI metric Number Of Threads</label>
-      <description>Force the the maximum number of threads to use for non thread safe MI metric.</description>
-      <default>-1</default>
-    </integer>
-
     <integer>
       <name>debugLevel</name>
       <label>Debug option</label>
@@ -526,14 +460,14 @@
     <double>
       <name>costFunctionConvergenceFactor</name>
       <longflag>costFunctionConvergenceFactor</longflag>
-      <description> From itkLBFGSBOptimizer.h: Set/Get the CostFunctionConvergenceFactor. Algorithm terminates when the reduction in cost function is less than (factor * epsmcj) where epsmch is the machine precision. Typical values for factor: 1e+12 for low accuracy; 1e+7 for moderate accuracy and 1e+1 for extremely high accuracy.  1e+9 seems to work well.
+      <description>From itkLBFGSBOptimizer.h: Set/Get the CostFunctionConvergenceFactor. Algorithm terminates when the reduction in cost function is less than (factor * epsmcj) where epsmch is the machine precision. Typical values for factor: 1e+12 for low accuracy; 1e+7 for moderate accuracy and 1e+1 for extremely high accuracy.  1e+9 seems to work well.
       </description>
       <default>2e+13</default>
     </double>
     <double>
       <name>projectedGradientTolerance</name>
       <longflag>projectedGradientTolerance</longflag>
-      <description> From itkLBFGSBOptimizer.h: Set/Get the ProjectedGradientTolerance. Algorithm terminates when the project gradient is below the tolerance. Default lbfgsb value is 1e-5, but 1e-4 seems to work well.
+      <description>From itkLBFGSBOptimizer.h: Set/Get the ProjectedGradientTolerance. Algorithm terminates when the project gradient is below the tolerance. Default lbfgsb value is 1e-5, but 1e-4 seems to work well.
       </description>
       <default>1e-5</default>
     </double>
@@ -549,7 +483,6 @@
       <description>Maximum number of corrections in lbfgsb optimizer.</description>
       <default>25</default>
     </integer>
-
     <boolean>
       <name>UseDebugImageViewer</name>
       <flag>G</flag>
@@ -564,37 +497,13 @@
       <description>Prompt the user to hit enter each time an image is sent to the DebugImageViewer</description>
       <default>false</default>
     </boolean>
-
     <string-enumeration>
-        <name>metricSamplingStrategy</name>
-        <longflag>metricSamplingStrategy</longflag>
-        <label>Set Sampling Strategy</label>
-        <description>ONLY Random SUPPORTED NOW It defines the method that registration filter uses to sample the input fixed image={Random}</description>
-        <default>Random</default>
-        <element>Random</element>
-    </string-enumeration>
-
-  </parameters>
-  <parameters advanced="true">
-    <label>Risky Expert-only Parameters</label>
-
-    <integer-vector>
-      <name>permitParameterVariation</name>
-      <longflag>permitParameterVariation</longflag>
-      <label>Selective Permission for Transform Parameters to Vary</label>
-      <description>A bit vector to permit linear transform parameters to vary under optimization.  The vector order corresponds with transform parameters, and beyond the end ones fill in as a default.  For instance, you can choose to rotate only in x (pitch) with 1,0,0;  this is mostly for expert use in turning on and off individual degrees of freedom in rotation, translation or scaling without multiplying the number of transform representations; this trick is probably meaningless when tried with the general affine transform.</description>
-      <default></default>
-    </integer-vector>
-    <string-enumeration>
-        <name>costMetric</name>
-        <longflag>costMetric</longflag>
-        <label>Cost Metric</label>
-  <description>The cost metric to be used during fitting. Defaults to MMI. Options are MMI (Mattes Mutual Information), MSE (Mean Square Error), NC (Normalized Correlation), MC (Match Cardinality for binary images)</description>
-        <default>MMI</default>
-        <element>MMI</element>
-        <element>MSE</element>
-        <element>NC</element>
-        <element>MIH</element>
+      <name>metricSamplingStrategy</name>
+      <longflag>metricSamplingStrategy</longflag>
+      <label>Set Sampling Strategy</label>
+      <description>It defines the method that registration filter uses to sample the input fixed image. Only Random is supported for now.</description>
+      <default>Random</default>
+      <element>Random</element>
     </string-enumeration>
     <file>
       <name>logFileReport</name>
@@ -603,15 +512,6 @@
       <description>A file to write out final information report in CSV file: MetricName,MetricValue,FixedImageName,FixedMaskName,MovingImageName,MovingMaskName</description>
       <channel>output</channel>
     </file>
-
-    <integer>
-      <name>metricSeed</name>
-      <longflag>metricSeed</longflag>
-      <label>Image similarity metric seed</label>
-      <description>Seed value will be used to reinitialize the metric. To ensure consistent results, the same seed value should be used across runs. If the seed value is set to 0, the sampler will use the clock of your machine to initialize the metric, which will lead to a random initialization of the seed.</description>
-      <default>76926294</default>
-    </integer>
-
   </parameters>
 
 </executable>

--- a/BRAINSFit/TestSuite/CMakeLists.txt
+++ b/BRAINSFit/TestSuite/CMakeLists.txt
@@ -659,7 +659,6 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   --maskProcessingMode ROIAUTO
   --initializeTransformMode useCenterOfHeadAlign
   --transformType Rigid,ScaleVersor3D
-  --permitParameterVariation 0,0,0,1,1,1
   --fixedVolume DATA{${TestData_DIR}/test.nii.gz}
   --movingVolume DATA{${TestData_DIR}/translation.rescale.test.nii.gz}
   --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nii.gz
@@ -686,7 +685,6 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   --maskProcessingMode ROIAUTO
   --initialTransform DATA{${TestData_DIR}/Transforms_h5/Initializer_BRAINSFitTest_TranslationRescaleHeadMasks.${XFRM_EXT}}
   --transformType ScaleVersor3D
-  --permitParameterVariation 0,0,0,1,1,1,1,1,1
   --fixedVolume DATA{${TestData_DIR}/test.nii.gz}
   --movingVolume DATA{${TestData_DIR}/translation.rescale.test.nii.gz}
   --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nii.gz
@@ -1604,7 +1602,6 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   --splineGridSize 3,3,3
   --initializeTransformMode useCenterOfROIAlign
   --maskProcessingMode ROI
-  --forceMINumberOfThreads 1
   --numberOfThreads 1
   --fixedVolume DATA{${TestData_DIR}/ProstateIntraop.nrrd}
   --fixedBinaryVolume DATA{${TestData_DIR}/ProstateIntraopMask.nrrd}


### PR DESCRIPTION
The following parameters are cleaned from the code and xml file:

useCachingOfBSplineWeightsMode
metricSeed
forceMINumberOfThreads
permitParameterVariation
useExplicitPDFDerivativesMode
