### PR TITLE
ENH: Update the ITK tag

### DIFF
--- a/SuperBuild/External_ITKv4.cmake
+++ b/SuperBuild/External_ITKv4.cmake
@@ -38,7 +38,7 @@ if(NOT DEFINED ITK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   endif()
 
   set(${proj}_REPOSITORY ${git_protocol}://itk.org/ITK.git)
-  set(${proj}_GIT_TAG 6aa0d0143888bd7a72dfab1bcc9897b0159c0f28 ) # 2014-09-14 Mattes Improvements
+  set(${proj}_GIT_TAG 85110071ee61aaf04238705e05062adb0876e0c2 ) # 2014-10-13
   #set(${proj}_REPOSITORY https://github.com/BRAINSia/ITK.git)
   #set(${proj}_GIT_TAG f7ca03e63e1e1b12604458846510f772d318470d )
 #  message("COMMON_EXTERNAL_PROJECT_ARGS:


### PR DESCRIPTION
Many BRAINSFit tests are failing on the dashboard because of an ITK bug
that is fixed in the latest version. Therefore, ITK tag needed to be
updated to include all new improvements.
