### PR TITLE
ENH: add reading from landmark file to BRAINSTalairach

### DIFF
--- a/BRAINSTalairach/BRAINSTalairach.xml
+++ b/BRAINSTalairach/BRAINSTalairach.xml
@@ -88,6 +88,14 @@
       <default>0</default>
     </boolean>
 
+    <file>
+      <name>inputLandmarksFile</name>
+      <longflag>inputLandmarksFile</longflag>
+      <description>input landmarks file: *.fcsv</description>
+      <label>input landmarks filename</label>
+      <channel>input</channel>
+    </file>
+
     <image>
       <name>inputVolume</name>
       <longflag>inputVolume</longflag>


### PR DESCRIPTION
A new flag called "inputLandmarksFile" is added to BRAINSTalairach.
Using this flag, all needed reference points (AC, PC, IRP and SLA) can
be passed to the program using an fcsv file.
Previously, the only option was passing the landmark coordinates directly
using their corresponding flags.
