### PR TITLE
Updated information for mac OS X developers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@ The BRAINSTools is a harness to assist in building the many of the BRAINSTools u
 
 Developers should run the "./Utilities/SetupForDevelopment.sh" script to get started.
 
+If developing on Mac OS X, make sure the xcode command line tools are installed with the command:
+xcode-select --install
+
 For more information on the individual BRAINSTools, please see the following link:
 https://github.com/BRAINSia/BRAINSTools/wiki
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ The BRAINSTools is a harness to assist in building the many of the BRAINSTools u
 
 Developers should run the "./Utilities/SetupForDevelopment.sh" script to get started.
 
-For more information on the individual BRAINSTools, please see the following link:  
+For more information on the individual BRAINSTools, please see the following link:
 https://github.com/BRAINSia/BRAINSTools/wiki
 
 ## Building ##


### PR DESCRIPTION
When building on mac OS X, command line tools need to be installed in xcode for a successful build. Also, I changed the format of the README file to a markup document. The README file was updated to reflect this.

Alex