### PR TITLE
ENH: Write output transforms of BFit and BABCD in float

### DIFF
--- a/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
+++ b/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
@@ -353,7 +353,7 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
         this->m_IntraSubjectTransforms[mapOfModalImageListsIt->first].push_back(p);
         // Write out intermodal matricies
         muLogMacro(<< "Writing " << (*isNamesIt) << "." << std::endl);
-        itk::WriteTransformToDisk<double>(p, (*isNamesIt));
+        itk::WriteTransformToDisk<double, float>(p, (*isNamesIt));
         }
       ++currModeImageListIt;
       ++isNamesIt;
@@ -783,7 +783,7 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
 */
     // End generating the best initial transform for atlas T1 to subject T1
     muLogMacro(<< "Writing " << this->m_AtlasToSubjectTransformFileName << "." << std::endl);
-    itk::WriteTransformToDisk<double>(m_AtlasToSubjectTransform, this->m_AtlasToSubjectTransformFileName);
+    itk::WriteTransformToDisk<double, float>(m_AtlasToSubjectTransform, this->m_AtlasToSubjectTransformFileName);
     }
 }
 

--- a/BRAINSABC/brainseg/BRAINSABC.cxx
+++ b/BRAINSABC/brainseg/BRAINSABC.cxx
@@ -1355,7 +1355,7 @@ int main(int argc, char * *argv)
         muLogMacro(<< "Writing final atlas to subject template... " << postSegmentationTransformFileName << std::endl );
         GenericTransformType::Pointer atlasToSubjectPostSegmentationTransform =
           segfilter->GetTemplateGenericTransform();
-        itk::WriteTransformToDisk<double>(atlasToSubjectPostSegmentationTransform, postSegmentationTransformFileName);
+        itk::WriteTransformToDisk<double,float>(atlasToSubjectPostSegmentationTransform, postSegmentationTransformFileName);
         // TODO:  Need to write a short circuit so that if this final transform
         // filename exists, it will just read it in and use it directly
         // without doing all the iterations.

--- a/BRAINSCommonLib/BRAINSFitHelper.cxx
+++ b/BRAINSCommonLib/BRAINSFitHelper.cxx
@@ -139,7 +139,8 @@ BRAINSFitHelper::BRAINSFitHelper() :
   m_InitializeRegistrationByCurrentGenericTransform(true),
   m_MaximumNumberOfEvaluations(900),
   m_MaximumNumberOfCorrections(12),
-  m_SyNFull(true)
+  m_SyNFull(true),
+  m_WriteOutputTransformInFloat(false)
 {
   m_SplineGridSize[0] = 14;
   m_SplineGridSize[1] = 10;
@@ -405,7 +406,7 @@ BRAINSFitHelper::Update(void)
   GenericMetricType::Pointer metric;
   if( this->m_CostMetricName == "MMI" )
     {
-    typedef itk::MattesMutualInformationImageToImageMetricv4<FixedImageType, MovingImageType, FixedImageType, double> MIMetricType;
+    typedef itk::MattesMutualInformationImageToImageMetricv4<FixedImageType, MovingImageType, FixedImageType, RealType> MIMetricType;
     MIMetricType::Pointer mutualInformationMetric = MIMetricType::New();
     //The next line was a hack for early ITKv4 mattes mutual informaiton
     //that was using a lot of memory
@@ -422,7 +423,7 @@ BRAINSFitHelper::Update(void)
     }
   else if( this->m_CostMetricName == "MSE" )
     {
-    typedef itk::MeanSquaresImageToImageMetricv4<FixedImageType, MovingImageType, FixedImageType, double> MSEMetricType;
+    typedef itk::MeanSquaresImageToImageMetricv4<FixedImageType, MovingImageType, FixedImageType, RealType> MSEMetricType;
     MSEMetricType::Pointer meanSquareMetric = MSEMetricType::New();
     meanSquareMetric = meanSquareMetric;
     metric = meanSquareMetric;
@@ -432,7 +433,7 @@ BRAINSFitHelper::Update(void)
     }
   else if( this->m_CostMetricName == "NC" )
     {
-    typedef itk::CorrelationImageToImageMetricv4<FixedImageType, MovingImageType, FixedImageType, double> corrMetricType;
+    typedef itk::CorrelationImageToImageMetricv4<FixedImageType, MovingImageType, FixedImageType, RealType> corrMetricType;
     corrMetricType::Pointer corrMetric = corrMetricType::New();
     metric = corrMetric;
 
@@ -441,7 +442,7 @@ BRAINSFitHelper::Update(void)
     }
   else if( this->m_CostMetricName == "MIH" )
     {
-    typedef itk::JointHistogramMutualInformationImageToImageMetricv4<FixedImageType, MovingImageType, FixedImageType, double> MutualInformationMetricType;
+    typedef itk::JointHistogramMutualInformationImageToImageMetricv4<FixedImageType, MovingImageType, FixedImageType, RealType> MutualInformationMetricType;
     MutualInformationMetricType::Pointer mutualInformationMetric = MutualInformationMetricType::New();
     mutualInformationMetric = mutualInformationMetric;
     mutualInformationMetric->SetNumberOfHistogramBins( this->m_NumberOfHistogramBins );
@@ -763,7 +764,14 @@ BRAINSFitHelper::PrintCommandLine(const bool dumpTempVolumes, const std::string 
   if( m_CurrentGenericTransform.IsNotNull() )
     {
     const std::string initialTransformString("DEBUGInitialTransform_" + suffix + ".h5");
-    WriteBothTransformsToDisk(this->m_CurrentGenericTransform.GetPointer(), initialTransformString, "");
+    if( this->m_WriteOutputTransformInFloat )
+      {
+      WriteBothTransformsToDisk<double,float>(this->m_CurrentGenericTransform.GetPointer(), initialTransformString, "");
+      }
+    else
+      {
+      WriteBothTransformsToDisk<double,double>(this->m_CurrentGenericTransform.GetPointer(), initialTransformString, "");
+      }
     oss << "--initialTransform " << initialTransformString  << "  \\" << std::endl;
     }
     {

--- a/BRAINSCommonLib/BRAINSFitHelper.h
+++ b/BRAINSCommonLib/BRAINSFitHelper.h
@@ -70,6 +70,7 @@ public:
   typedef SmartPointer<Self>       Pointer;
   typedef SmartPointer<const Self> ConstPointer;
 
+  typedef double                         RealType;
   typedef float                         PixelType;
   typedef itk::Image<PixelType, 3>      FixedImageType;
   typedef FixedImageType::ConstPointer  FixedImageConstPointer;
@@ -83,7 +84,7 @@ public:
   itkStaticConstMacro(FixedImageDimension, unsigned int, FixedImageType::ImageDimension);
   itkStaticConstMacro(MovingImageDimension, unsigned int, MovingImageType::ImageDimension);
 
-  typedef itk::CompositeTransform<double, MovingImageDimension>       CompositeTransformType;
+  typedef itk::CompositeTransform<RealType, MovingImageDimension>       CompositeTransformType;
 
   typedef SpatialObject<itkGetStaticConstMacro(FixedImageDimension)>  FixedBinaryVolumeType;
   typedef SpatialObject<itkGetStaticConstMacro(MovingImageDimension)> MovingBinaryVolumeType;
@@ -96,7 +97,7 @@ public:
   typedef HelperType::MultiMetricType                        MultiMetricType;
 
   typedef itk::ImageRegistrationMethodv4<FixedImageType, MovingImageType>  AffineRegistrationType;
-  typedef itk::AffineTransform<double, 3>                                  AffineTransformType;
+  typedef itk::AffineTransform<RealType, 3>                                AffineTransformType;
   typedef AffineRegistrationType::MetricSamplingStrategyType               SamplingStrategyType;
 
   /** Method for creation through the object factory. */
@@ -147,8 +148,8 @@ public:
     WINDOWSINC_INTERP = 1
     } InterpolationType;
 
-  itkSetMacro(SamplingPercentage,                double);
-  itkGetConstMacro(SamplingPercentage,           double);
+  itkSetMacro(SamplingPercentage,                RealType);
+  itkGetConstMacro(SamplingPercentage,           RealType);
   itkSetMacro(NumberOfHistogramBins,             unsigned int);
   itkGetConstMacro(NumberOfHistogramBins,        unsigned int);
   itkSetMacro(NumberOfMatchPoints,               unsigned int);
@@ -203,6 +204,8 @@ public:
   itkGetConstMacro(ObserveIterations,        bool);
   itkSetMacro(UseROIBSpline, bool);
   itkGetConstMacro(UseROIBSpline, bool);
+  itkSetMacro(WriteOutputTransformInFloat, bool);
+  itkGetConstMacro(WriteOutputTransformInFloat, bool);
 
   void SetSamplingStrategy(std::string strategy)
   {
@@ -280,7 +283,7 @@ private:
   std::string               m_OutputFixedVolumeROI;
   std::string               m_OutputMovingVolumeROI;
 
-  double       m_SamplingPercentage;
+  RealType     m_SamplingPercentage;
   unsigned int m_NumberOfHistogramBins;
   bool         m_HistogramMatch;
   float        m_RemoveIntensityOutliers;
@@ -320,6 +323,7 @@ private:
   int                                        m_MaximumNumberOfEvaluations;
   int                                        m_MaximumNumberOfCorrections;
   bool                                       m_SyNFull;
+  bool                                       m_WriteOutputTransformInFloat;
 };  // end BRAINSFitHelper class
 
 template <class TLocalCostMetric>

--- a/BRAINSCommonLib/BRAINSFitHelperTemplate.h
+++ b/BRAINSCommonLib/BRAINSFitHelperTemplate.h
@@ -89,6 +89,8 @@ public:
   typedef SmartPointer<Self>       Pointer;
   typedef SmartPointer<const Self> ConstPointer;
 
+  typedef double RealType;
+
   typedef typename FixedImageType::ConstPointer FixedImageConstPointer;
   typedef typename FixedImageType::Pointer      FixedImagePointer;
 
@@ -99,30 +101,30 @@ public:
   itkStaticConstMacro(FixedImageDimension, unsigned int, FixedImageType::ImageDimension);
   itkStaticConstMacro(MovingImageDimension, unsigned int, MovingImageType::ImageDimension);
 
-  typedef itk::ObjectToObjectMetricBaseTemplate<double>                       MetricType;
+  typedef itk::ObjectToObjectMetricBaseTemplate<RealType>                       MetricType;
   typedef typename itk::ObjectToObjectMultiMetricv4< FixedImageDimension,
                                                      MovingImageDimension,
                                                      FixedImageType,
-                                                     double>                  MultiMetricType;
+                                                     RealType>                  MultiMetricType;
   typedef typename itk::ImageToImageMetricv4< FixedImageType,
                                               MovingImageType,
                                               FixedImageType,
-                                              double >                        ImageMetricType;
+                                              RealType >                        ImageMetricType;
 
-  typedef itk::CompositeTransform<double, MovingImageDimension>     CompositeTransformType;
-  typedef typename CompositeTransformType::Pointer                  CompositeTransformPointer;
-  typedef IdentityTransform<double, MovingImageDimension>           IdentityTransformType;
+  typedef itk::CompositeTransform<RealType, MovingImageDimension>     CompositeTransformType;
+  typedef typename CompositeTransformType::Pointer                    CompositeTransformPointer;
+  typedef IdentityTransform<RealType, MovingImageDimension>           IdentityTransformType;
 
   typedef SpatialObject<itkGetStaticConstMacro(FixedImageDimension)>  FixedBinaryVolumeType;
   typedef SpatialObject<itkGetStaticConstMacro(MovingImageDimension)> MovingBinaryVolumeType;
   typedef typename FixedBinaryVolumeType::Pointer                     FixedBinaryVolumePointer;
   typedef typename MovingBinaryVolumeType::Pointer                    MovingBinaryVolumePointer;
 
-  typedef itk::ImageRegistrationMethodv4<FixedImageType, MovingImageType>  AffineRegistrationType;
-  typedef itk::TranslationTransform<double, MovingImageDimension>          TranslationTransformType;
-  typedef itk::AffineTransform<double, MovingImageDimension>               AffineTransformType;
-  typedef itk::ScalableAffineTransform<double, MovingImageDimension>       ScalableAffineTransformType;
-  typedef typename AffineRegistrationType::MetricSamplingStrategyType      SamplingStrategyType;
+  typedef itk::ImageRegistrationMethodv4<FixedImageType, MovingImageType>    AffineRegistrationType;
+  typedef itk::TranslationTransform<RealType, MovingImageDimension>          TranslationTransformType;
+  typedef itk::AffineTransform<RealType, MovingImageDimension>               AffineTransformType;
+  typedef itk::ScalableAffineTransform<RealType, MovingImageDimension>       ScalableAffineTransformType;
+  typedef typename AffineRegistrationType::MetricSamplingStrategyType        SamplingStrategyType;
 
   typedef typename AffineTransformType::Superclass                         MatrixOffsetTransformBaseType;
   typedef typename MatrixOffsetTransformBaseType::Pointer                  MatrixOffsetTransformBasePointer;
@@ -170,8 +172,8 @@ public:
     WINDOWSINC_INTERP = 1
     } InterpolationType;
 
-  itkSetMacro(SamplingPercentage,            double);
-  itkGetConstMacro(SamplingPercentage,       double);
+  itkSetMacro(SamplingPercentage,            RealType);
+  itkGetConstMacro(SamplingPercentage,       RealType);
   itkSetMacro(NumberOfHistogramBins,         unsigned int);
   itkGetConstMacro(NumberOfHistogramBins,    unsigned int);
   itkSetMacro(NumberOfMatchPoints,           unsigned int);
@@ -294,7 +296,7 @@ private:
   std::string               m_OutputFixedVolumeROI;
   std::string               m_OutputMovingVolumeROI;
 
-  double       m_SamplingPercentage;
+  RealType     m_SamplingPercentage;
   unsigned int m_NumberOfHistogramBins;
   bool         m_HistogramMatch;
   float        m_RemoveIntensityOutliers;

--- a/BRAINSCommonLib/BRAINSFitSyN.h
+++ b/BRAINSCommonLib/BRAINSFitSyN.h
@@ -25,23 +25,24 @@
 
 namespace // put in anon namespace to suppress shadow declaration warnings.
 {
-typedef  ants::RegistrationHelper<double,3>                SyNRegistrationHelperType;
+typedef  double                                            RealType;
+typedef  ants::RegistrationHelper<RealType,3>              SyNRegistrationHelperType;
 typedef  SyNRegistrationHelperType::ImageType              ImageType;
-typedef  itk::CompositeTransform<double,3>                 CompositeTransformType;
+typedef  SyNRegistrationHelperType::CompositeTransformType CompositeTransformType;
 }
 
 template <class FixedImageType, class MovingimageType>
-typename itk::CompositeTransform<double,3>::Pointer
+typename CompositeTransformType::Pointer
 simpleSynReg( typename FixedImageType::Pointer & infixedImage,
               typename MovingimageType::Pointer & inmovingImage,
-              typename itk::CompositeTransform<double,3>::Pointer compositeInitialTransform,
-              typename itk::CompositeTransform<double,3>::Pointer & internalSavedState,
+              typename CompositeTransformType::Pointer compositeInitialTransform,
+              typename CompositeTransformType::Pointer & internalSavedState,
               typename FixedImageType::Pointer & infixedImage2 = NULL,
               typename MovingimageType::Pointer & inmovingImage2 = NULL,
-              double samplingPercentage = 1.0,
+              RealType samplingPercentage = 1.0,
               std::string whichMetric = "cc",
               const bool synFull = true,
-              typename itk::CompositeTransform<double,3>::Pointer restoreState = ITK_NULLPTR )
+              typename CompositeTransformType::Pointer restoreState = ITK_NULLPTR )
 {
   typename SyNRegistrationHelperType::Pointer regHelper = SyNRegistrationHelperType::New();
     {
@@ -85,8 +86,8 @@ simpleSynReg( typename FixedImageType::Pointer & infixedImage,
     }
 
     {
-    std::vector<double> convergenceThresholdList;
-    const double        convergenceThreshold = 1e-6;
+    std::vector<RealType> convergenceThresholdList;
+    const RealType        convergenceThreshold = 1e-6;
     convergenceThresholdList.push_back(convergenceThreshold);
     regHelper->SetConvergenceThresholds( convergenceThresholdList );
     }
@@ -160,7 +161,7 @@ simpleSynReg( typename FixedImageType::Pointer & infixedImage,
     // - Metric type (MMI->mattes, MSE->meansquares, NC->cc, MIH->mi)
     typename SyNRegistrationHelperType::MetricEnumeration curMetric = regHelper->StringToMetricType(whichMetric);
     // - Metric weight
-    const double weighting = 1.0;
+    const RealType weighting = 1.0;
     // - Sampling strategy (alway random)
     typename SyNRegistrationHelperType::SamplingStrategy samplingStrategy = SyNRegistrationHelperType::random;
     // - Sampling percentage (defined by input)

--- a/BRAINSCommonLib/GenericTransformImage.h
+++ b/BRAINSCommonLib/GenericTransformImage.h
@@ -68,6 +68,10 @@ namespace itk
   * WriteTransformToDisk<TScalarType>(myAffine.GetPointer(), "myAffineFile.mat");
   * \endcode
   */
+template<class TInputScalarType, class TWriteScalarType>
+extern void WriteTransformToDisk( itk::Transform<TInputScalarType, 3, 3> const *const genericTransformToWrite,
+                                 const std::string & outputTransform);
+
 template<class TScalarType>
 extern void WriteTransformToDisk( itk::Transform<TScalarType, 3, 3> const *const genericTransformToWrite,
                                  const std::string & outputTransform);
@@ -106,6 +110,10 @@ extern void WriteTransformToDisk( itk::Transform<TScalarType, 3, 3> const *const
   * \endcode
   */
 
+template<class TScalarType>
+extern typename itk::Transform<TScalarType, 3, 3>::Pointer
+ReadTransformFromDisk(const std::string & initialTransform);
+
 extern itk::Transform<double, 3, 3>::Pointer ReadTransformFromDisk(const std::string & initialTransform);
 
 /**
@@ -133,7 +141,8 @@ ComputeRigidTransformFromGeneric(const itk::Transform<double, 3, 3>::ConstPointe
   * \brief Special purpose convenience function -- should not have a public
   *interface.
   */
-extern int WriteBothTransformsToDisk(const itk::Transform<double, 3, 3>::ConstPointer genericTransformToWrite,
+template<class TInputScalarType, class TWriteScalarType>
+extern int WriteBothTransformsToDisk(const typename itk::Transform<TInputScalarType, 3, 3>::ConstPointer genericTransformToWrite,
                                      const std::string & outputTransform, const std::string & strippedOutputTransform);
 
 /**
@@ -141,7 +150,8 @@ extern int WriteBothTransformsToDisk(const itk::Transform<double, 3, 3>::ConstPo
   * \brief Special purpose convenience function -- should not have a public
   *interface.
   */
-extern int WriteStrippedRigidTransformToDisk(const itk::Transform<double, 3, 3>::ConstPointer genericTransformToWrite,
+template<class TInputScalarType, class TWriteScalarType>
+extern int WriteStrippedRigidTransformToDisk(const typename itk::Transform<TInputScalarType, 3, 3>::ConstPointer genericTransformToWrite,
                                              const std::string & strippedOutputTransform);
 }
 

--- a/BRAINSFit/BRAINSFit.cxx
+++ b/BRAINSFit/BRAINSFit.cxx
@@ -524,6 +524,7 @@ int main(int argc, char *argv[])
     myHelper->SetInitializeRegistrationByCurrentGenericTransform(initializeRegistrationByCurrentGenericTransform);
     myHelper->SetMaximumNumberOfEvaluations(maximumNumberOfEvaluations);
     myHelper->SetMaximumNumberOfCorrections(maximumNumberOfCorrections);
+    myHelper->SetWriteOutputTransformInFloat(writeOutputTransformInFloat);
 
     //HACK: create a flag for normalization
     bool NormalizeInputImages = false;
@@ -691,8 +692,18 @@ int main(int argc, char *argv[])
       itkUtil::WriteImage<WriteOutImageType>(CastImage, outputVolume);
       }
     }
-    itk::WriteBothTransformsToDisk(currentGenericTransform.GetPointer(),
-                                   localOutputTransform, strippedOutputTransform);
+    if( writeOutputTransformInFloat )
+      {
+      std::cout << "Write the output transform in single (float) precision..." << std::endl;
+      itk::WriteBothTransformsToDisk<double,float>(currentGenericTransform.GetPointer(),
+                                                   localOutputTransform, strippedOutputTransform);
+      }
+    else
+      {
+      itk::WriteBothTransformsToDisk<double,double>(currentGenericTransform.GetPointer(),
+                                                    localOutputTransform, strippedOutputTransform);
+      }
+
 
   return 0;
 }

--- a/BRAINSFit/BRAINSFit.xml
+++ b/BRAINSFit/BRAINSFit.xml
@@ -442,6 +442,13 @@
       <description>If this flag is ON, the current generic composite transform, resulted from the linear registration stages, is set to initialize the follow nonlinear registration process. However, by the default behaviour, the moving image is first warped based on the existant transform before it is passed to the BSpline registration filter. It is done to speed up the BSpline registration by reducing the computations of composite transform Jacobian.</description>
       <default>0</default>
     </boolean>
+    <boolean>
+      <name>writeOutputTransformInFloat</name>
+      <longflag>writeOutputTransformInFloat</longflag>
+      <label>writes the output registration transforms in single precision</label>
+      <description>By default, the output registration transforms (either the output composite transform or each transform component) are written to the disk in double precision. If this flag is ON, the output transforms will be written in single (float) precision. It is especially important if the output transform is a displacement field transform, or it is a composite transform that includes several displacement fields.</description>
+      <default>false</default>
+    </boolean>
   </parameters>
 
   <parameters advanced="true">

--- a/BRAINSFit/TestSuite/CMakeLists.txt
+++ b/BRAINSFit/TestSuite/CMakeLists.txt
@@ -49,6 +49,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   --movingBinaryVolume DATA{${TestData_DIR}/rotation.test_mask.nii.gz}
   --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nii.gz
   --outputTransform ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.${XFRM_EXT}
+  --writeOutputTransformInFloat
   --debugLevel 50
 )
 
@@ -103,6 +104,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   --movingBinaryVolume DATA{${TestData_DIR}/scale.test_mask.nii.gz}
   --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nii.gz
   --outputTransform ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.${XFRM_EXT}
+  --writeOutputTransformInFloat
 )
 
 set(BRAINSFitTestName BRAINSFitTest_AffineScaleNoMasks)
@@ -156,6 +158,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   --movingBinaryVolume DATA{${TestData_DIR}/translation.test_mask.nii.gz}
   --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nii.gz
   --outputTransform ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.${XFRM_EXT}
+  --writeOutputTransformInFloat
 )
 
 set(BRAINSFitTestName BRAINSFitTest_AffineTranslationNoMasks)
@@ -210,6 +213,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nii.gz
   --outputTransform ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.${XFRM_EXT}
   --maxBSplineDisplacement 7.3
+  --writeOutputTransformInFloat
 )
 
 set(BRAINSFitTestName BRAINSFitTest_BSplineOnlyRescaleHeadMasks)
@@ -270,6 +274,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nii.gz
   --outputTransform ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.${XFRM_EXT}
   --maxBSplineDisplacement 7.3
+  --writeOutputTransformInFloat
 )
 
 
@@ -323,7 +328,8 @@ ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nii.gz
   --transformType Rigid --initializeTransformMode useMomentsAlign --translationScale 1000
   --outputTransform ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.${XFRM_EXT}
   --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nii.gz
-  )
+  --writeOutputTransformInFloat
+)
 
 set(BRAINSFitTestName BRAINSFitTest_RigidMedianRotationNoMasks)
 ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
@@ -374,6 +380,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   --movingVolume DATA{${TestData_DIR}/rotation.geom.test.nii.gz}
   --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nii.gz
   --outputTransform ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.${XFRM_EXT}
+  --writeOutputTransformInFloat
 )
 
 set(BRAINSFitTestName BRAINSFitTest_RigidRotaRotaRotNoMasks)
@@ -425,6 +432,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   --movingVolume DATA{${TestData_DIR}/rotation.test.nii.gz}
   --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nii.gz
   --outputTransform ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.${XFRM_EXT}
+  --writeOutputTransformInFloat
 )
 
 set(BRAINSFitTestName BRAINSFitTest_RigidRotationMasks)
@@ -479,7 +487,9 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   --movingVolume DATA{${TestData_DIR}/rotation.test.nii.gz}
   --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nii.gz
   --outputTransform ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.${XFRM_EXT}
+  --writeOutputTransformInFloat
 )
+
 set(BRAINSFitTestName BRAINSFitTest_RigidRotationNoMasksRiginInPlaceInterp)
 ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   COMMAND ${LAUNCH_EXE} $<TARGET_FILE:BRAINSFitTestDriver>
@@ -531,6 +541,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${BRAINSFitTestName}
   --movingVolume DATA{${TestData_DIR}/rotation.rescale.test.nii.gz}
   --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.test.nii.gz
   --outputTransform ${CMAKE_CURRENT_BINARY_DIR}/${BRAINSFitTestName}.${XFRM_EXT}
+  --writeOutputTransformInFloat
 )
 
 set(BRAINSFitTestName BRAINSFitTest_ScaleSkewVersorRotationMasks)

--- a/BRAINSTransformConvert/BRAINSTransformConvert.cxx
+++ b/BRAINSTransformConvert/BRAINSTransformConvert.cxx
@@ -231,7 +231,7 @@ DoConversion( int argc, char *argv[] )
   typedef itk::Transform< TScalarType, 3, 3 >                       GenericTransformType;
   typedef itk::BSplineDeformableTransform < TScalarType, 3, 3>      BSplineTransformType;
 
-  typedef itk::AffineTransform< TScalarType, 3 >            LocalAffineTransformTYpe;
+  typedef itk::AffineTransform< TScalarType, 3 >            LocalAffineTransformType;
   typedef itk::VersorRigid3DTransform< TScalarType >        LocalVersorRigid3DTransformType;
   typedef itk::ScaleVersor3DTransform< TScalarType >        LocalScaleVersor3DTransformType;
   typedef itk::ScaleSkewVersor3DTransform< TScalarType >    LocalScaleSkewVersor3DTransformType;
@@ -418,7 +418,7 @@ DoConversion( int argc, char *argv[] )
 
   if( outputTransformType == "Affine" )
     {
-    typename LocalAffineTransformTYpe::Pointer affineXfrm = LocalAffineTransformTYpe::New();
+    typename LocalAffineTransformType::Pointer affineXfrm = LocalAffineTransformType::New();
     if( ExtractTransform<TScalarType>(affineXfrm, inputXfrm.GetPointer() ) == false )
       {
       TransformConvertError<TScalarType>(inputXfrm, "Affine Transform");
@@ -459,7 +459,8 @@ DoConversion( int argc, char *argv[] )
 
   if( inputTransformTypeName.find("CompositeTransform") == std::string::npos ) // Input composite is assumed to be a state file
                                                                                // not a transform, so it is converted differently
-                                                                               // and is already written to the disk.
+                                                                               // and is already written to the disk, so here we
+                                                                               // only consider cases that are not composite transforms.
     {
     if( outputTransformType == "Same" )
       {


### PR DESCRIPTION
By default the output registration transforms (either the output
composite transform or each transform component) are written to the
disk in double precision.
This patch provides a new flag to BRAINSFit called
"writeOutputTransformInFloat". If this flag is ON, the output transforms
will be written in single (float) precision. It is especially important
if the output transform is a displacement field transform, or it is a
composite transform that includes several displacement fields.