### PR TITLE
COMP: Fixed outdated builds on VS2012

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -390,9 +390,19 @@ ExternalProject_Add(${proj}
 
 # This custom external project step forces the build and later
 # steps to run whenever a top level build is done...
+#
+# BUILD_ALWAYS flag is available in CMake 3.1 that allows force build
+# of external projects without this workaround. Remove this workaround
+# and use the CMake flag instead, when BRAINSTools's required minimum CMake
+# version will be at least 3.1.
+#
+if(CMAKE_CONFIGURATION_TYPES)
+  set(BUILD_STAMP_FILE "${CMAKE_CURRENT_BINARY_DIR}/${proj}-prefix/src/${proj}-stamp/${CMAKE_CFG_INTDIR}/${proj}-build")
+else()
+  set(BUILD_STAMP_FILE "${CMAKE_CURRENT_BINARY_DIR}/${proj}-prefix/src/${proj}-stamp/${proj}-build")
+endif()
 ExternalProject_Add_Step(${proj} forcebuild
-  COMMAND ${CMAKE_COMMAND} -E remove
-    ${CMAKE_CURRENT_BINARY_DIR}/${proj}-prefix/src/${proj}-stamp/${proj}-build
+  COMMAND ${CMAKE_COMMAND} -E remove ${BUILD_STAMP_FILE}
   COMMENT "Forcing build step for '${proj}'"
   DEPENDEES build
   ALWAYS 1


### PR DESCRIPTION
High-level build did not build external projects in VS2012.
The `BUILD_ALWAYS` flag is a relatively new CMake feature (added in 3.1),
therefore the following workaround was added into `SuperBuild.cmake`:

```
ExternalProject_Add_Step(${proj} forcebuild
  COMMAND ${CMAKE_COMMAND} -E remove
    ${CMAKE_CURRENT_BINARY_DIR}/${proj}-prefix/src/${proj}-stamp/${proj}-build
  COMMENT "Forcing build step for '${proj}'"
  DEPENDEES build
  ALWAYS 1
  )
```

This does not work with Visual Studio, where the stamp file is in Debug/Release/etc. subdirectory:
`${CMAKE_CURRENT_BINARY_DIR}/${proj}-prefix/src/${proj}-stamp/${CMAKE_CFG_INTDIR}/${proj}CTK-build`

Co-authored-by: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>