### PR TITLE
STYLE: Reconcile orphan module categories for DWICleanup and LabelSta…

### DIFF
--- a/BRAINSDWICleanup/BRAINSDWICleanup.xml
+++ b/BRAINSDWICleanup/BRAINSDWICleanup.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-  <executable>
+<executable>
+  <category>Diffusion.Diffusion Weighted Images</category>
   <title>BRAINSDWICleanup</title>
 
   <description>Remove bad gradients/volumes from DWI NRRD file.</description>
@@ -40,4 +41,4 @@
     </integer-vector>
   </parameters>
 
-  </executable>
+</executable>

--- a/BRAINSLabelStats/BRAINSLabelStats.xml
+++ b/BRAINSLabelStats/BRAINSLabelStats.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
-  <category>BRAINS.LabelStatistics</category>
+  <category>Quantification</category>
   <title>Label Statistics (BRAINS)</title>
   <description>Compute image statistics within each label of a label map. </description>
   <version>4.5.0</version>


### PR DESCRIPTION
…tistics

The above two modules were in Slicer module categories that only contained one module, thus adding two extra categories to the already hard-to-navigate module list. According to a recent Slicer developer hangout discussion, DWICleanup was moved to Diffusion / Diffusion Weighted Images, and LabelStatistics to Quantification. Integrating it into Slicer for the release of 4.5 will make the module list a bit cleaner.