### PR TITLE
BUG: Unnecessary computation of ListOfClassStatistics

### DIFF
--- a/BRAINSABC/brainseg/BRAINSABCUtilities.h
+++ b/BRAINSABC/brainseg/BRAINSABCUtilities.h
@@ -83,7 +83,7 @@ class RegionStats
 public:
   typedef vnl_matrix<FloatingPrecision>         MatrixType;
   typedef vnl_matrix_inverse<FloatingPrecision> MatrixInverseType;
-  typedef std::map<std::string,double>          MeanMapType;;
+  typedef std::map<std::string,double>          MeanMapType;
   RegionStats() : m_Means(), m_Covariance(), m_Weighting(0.0)
   {
   }

--- a/BRAINSABC/brainseg/EMSegmentationFilter.hxx
+++ b/BRAINSABC/brainseg/EMSegmentationFilter.hxx
@@ -2480,10 +2480,6 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
                   this->m_SampleSpacing, this->m_DebugLevel,
                   this->m_OutputDebugDir);
     }
-  this->m_ListOfClassStatistics.resize(0); // Reset this to empty for debugging
-                                           // purposes to induce failures when
-                                           // being re-used.
-  this->m_ListOfClassStatistics = this->ComputeDistributions(SubjectCandidateRegions, this->m_Posteriors);
   this->WritePartitionTable(0 + 100);
 }
 


### PR DESCRIPTION
m_ListOfClassStatistics is computed at the end of EMLoop function, but
it is not called or used after that.