### PR TITLE
COMP: Fixes some CMake dependency issues with the FindVTKUtil module

### DIFF
--- a/CMake/FindVTKUtil.cmake
+++ b/CMake/FindVTKUtil.cmake
@@ -1,21 +1,26 @@
 #
 # find and incorporate the VTK library
 macro(FindVTKUtil)
-  if(BRAINSTools_REQUIRES_VTK)
-    #  message("VTK_DIR:${VTK_DIR}")
-    find_package(VTK COMPONENTS
-      vtkCommonSystem
-      vtkCommonCore
-      vtkCommonSystem
-      vtkCommonMath
-      vtkCommonMisc
-      vtkCommonTransforms
-      ${ARGN}
-      REQUIRED)
-    include(${VTK_USE_FILE})
-    #  message("VTK_USE_FILE:${VTK_USE_FILE}")
-    #  message("VTK_INCLUDE_DIRS:${VTK_INCLUDE_DIRS}")
-    include_directories(${VTK_INCLUDE_DIRS})
-    link_directories(${VTK_LIBRARY_DIRS})
+  if(NOT BRAINSTools_REQUIRES_VTK)
+    message( FATAL_ERROR "You have requested the FindVTKUtil macro, but "
+                         "the requesting module is not listed as requiring vtk "
+                         "under Common.cmake as \"set(BRAINSTools_REQUIRES_VTK ON)\" "
+                         "please add the requesting module to the list in Common.cmake" )
   endif()
+
+  #  message("VTK_DIR:${VTK_DIR}")
+  find_package(VTK COMPONENTS
+    vtkCommonSystem
+    vtkCommonCore
+    vtkCommonSystem
+    vtkCommonMath
+    vtkCommonMisc
+    vtkCommonTransforms
+    ${ARGN}
+    REQUIRED)
+  include(${VTK_USE_FILE})
+  #  message("VTK_USE_FILE:${VTK_USE_FILE}")
+  #  message("VTK_INCLUDE_DIRS:${VTK_INCLUDE_DIRS}")
+  include_directories(${VTK_INCLUDE_DIRS})
+  link_directories(${VTK_LIBRARY_DIRS})
 endmacro()

--- a/Common.cmake
+++ b/Common.cmake
@@ -82,7 +82,7 @@ option(USE_BRAINSPosteriorToContinuousClass             "Build BRAINSPosteriorTo
 option(USE_DebugImageViewer "Build DebugImageViewer" OFF)
 option(BRAINS_DEBUG_IMAGE_WRITE "Enable writing out intermediate image results" OFF)
 
-if(Slicer_BUILD_BRAINSTOOLS OR USE_AutoWorkup OR USE_GTRACT OR USE_BRAINSTalairach OR USE_BRAINSSurfaceTools)
+if(Slicer_BUILD_BRAINSTOOLS OR USE_AutoWorkup OR USE_GTRACT OR USE_BRAINSTalairach OR USE_BRAINSSurfaceTools OR USE_BRAINSConstellationDetector OR USE_BRAINSDemonWarp OR USE_ConvertBetweenFileFormats )
   set(BRAINSTools_REQUIRES_VTK ON)
 endif()
 


### PR DESCRIPTION
If a specific module was not listed in Common.cmake to turn on the
BRAINSTools_REQUIRES_VTK variable, then calling the FindVTKUtil macro
would do nothing, and no errors or warnings would be generated. Now if
a module tries to use FindVTKUtil but it isn't on the list, then there
will be an error with an explanation. Also, two modules were added to
the list to turn on BRAINSTools_REQUIRES_VTK