### PR TITLE
COMP: Fixes Unused parameter warning on Linux in BRAINSCut

### DIFF
--- a/BRAINSCut/BRAINSCutTrainModel.cxx
+++ b/BRAINSCut/BRAINSCutTrainModel.cxx
@@ -137,7 +137,7 @@ BRAINSCutTrainModel
 
 void
 BRAINSCutTrainModel
-::TrainWithUpdate( cv::Ptr<OpenCVMLPType> myTrainer, bool update, pairedTrainingSetType& currentTrainData )
+::TrainWithUpdate( cv::Ptr<OpenCVMLPType> myTrainer, pairedTrainingSetType& currentTrainData )
 {
   // TODO change subset number properly
   myTrainer->setBackpropMomentumScale(0.1);
@@ -270,7 +270,6 @@ BRAINSCutTrainModel
     {
     unsigned int subSetNo =  (currentIteration - 1) % this->m_trainingDataSet->GetNumberOfSubSet();
     TrainWithUpdate( trainner,
-                     (currentIteration > 1), // after first iteration, update
                      *(this->m_trainingDataSet->GetTrainingSubSet(subSetNo) ) );
     SaveANNTrainModelAtIteration( trainner, currentIteration );
     printANNTrainInformation( trainner, currentIteration );

--- a/BRAINSCut/BRAINSCutTrainModel.h
+++ b/BRAINSCut/BRAINSCutTrainModel.h
@@ -43,7 +43,7 @@ public:
   void TrainRandomForestAt( const int depth, const int numberOfTree );
 
   /** inline functions */
-  inline void TrainWithUpdate(cv::Ptr<OpenCVMLPType> myTrainer, bool update, pairedTrainingSetType& currentTrainData);
+  inline void TrainWithUpdate(cv::Ptr<OpenCVMLPType> myTrainer, pairedTrainingSetType& currentTrainData);
 
   inline void SaveANNTrainModelAtIteration( cv::Ptr<OpenCVMLPType> myTrainer, unsigned int No);
 


### PR DESCRIPTION
This fixes the unused parameter warning on medusa.
@hjmjohnson 
@reginakim 
The unused parameter seems to be the result of an unimplemented functionality.