### PR TITLE
COMP: Fixes sign compare warning on linux

### DIFF
--- a/BRAINSConstellationDetector/src/landmarksConstellationCommon.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationCommon.cxx
@@ -703,7 +703,7 @@ SImageType::PointType GetImageCenterPhysicalPoint(SImageType::Pointer & image)
 
   itk::ContinuousIndex<double, 3> centerIndex;
 
-  for( int q = 0; q < SImageType::ImageDimension; ++q )
+  for( size_t q = 0; q < SImageType::ImageDimension; ++q )
     {
     centerIndex[q] = 0.5 * ( imageOverallSize[q] - 1 );
     }


### PR DESCRIPTION
@hjmjohnson This fixes a sign compare warning that was showing up on the nightly dashboard.