### PR TITLE
Change FSLToNrrd default to transposeInputBVectors=true?

### DIFF
--- a/DWIConvert/DWIConvert.xml
+++ b/DWIConvert/DWIConvert.xml
@@ -159,7 +159,7 @@
       <name>transpose</name>
       <longflag>transposeInputBVectors</longflag>
       <label>Transpose Input BVectors</label>
-      <default>false</default>
+      <default>true</default>
       <description><![CDATA[FSL input BVectors are expected to be encoded in the input file as one vector per line. If it is not the case, use this option to transpose the file as it is read]]></description>
     </boolean>
   </parameters>


### PR DESCRIPTION
This seems like the path-of-least-surprise since it is [how fsl itself represents bvecs](http://fsl.fmrib.ox.ac.uk/fslcourse/fsl_course_data/fdt1/subj1/bvecs), what dcm2nii does (tested on my own data), what [BrainSuite](http://brainsuite.org/processing/diffusion/file-formats/#bvec) expects, etc. 

We ran into some temporary confusion until noticing this option (it is not yet documented in the module doc), [as have other slicer users](http://slicer-users.65878.n3.nabble.com/Transpose-input-bvecs-dwiconvert-td4028779.html).

Thanks!
cc @ljod