### PR TITLE
ENH: Generate pure plugs mask and its incorporation in BABC

### DIFF
--- a/BRAINSABC/TestSuite/CMakeLists.txt
+++ b/BRAINSABC/TestSuite/CMakeLists.txt
@@ -40,6 +40,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME BRAINSABCSmallTest
    --outputVolumes ${CMAKE_CURRENT_BINARY_DIR}/BRAINSABCSmallT1_1.nii.gz
    --outputVolumes ${CMAKE_CURRENT_BINARY_DIR}/BRAINSABCSmallT2_1.nii.gz
    --posteriorTemplate ${CMAKE_CURRENT_BINARY_DIR}/BRAINSABCSmallPOST_%s.nii.gz
+   --purePlugsThreshold 0.2
 )
 
 if( ${BRAINSTools_MAX_TEST_LEVEL} GREATER 5) #These test takes way to long to run all the time

--- a/BRAINSABC/brainseg/BRAINSABC.xml
+++ b/BRAINSABC/brainseg/BRAINSABC.xml
@@ -90,11 +90,9 @@
     <name>subjectIntermodeTransformType</name>
     <label>Atlas to Subject Transform Type</label>
     <longflag>subjectIntermodeTransformType</longflag>
-    <description> What type of linear transform type do you want to use to register the atlas to the reference subject image.</description>
+    <description> What type of transform type do you want to run intra subject registeration. Only Identity and Rigid are allowed.</description>
     <element>Identity</element>
     <element>Rigid</element>
-    <element>Affine</element>
-    <element>BSpline</element>
     <default>Rigid</default>
   </string-enumeration>
   </parameters>
@@ -243,6 +241,24 @@
       <longflag>useKNN</longflag>
       <default>false</default>
     </boolean>
+
+    <float>
+      <name>purePlugsThreshold</name>
+      <longflag>purePlugsThreshold</longflag>
+      <label>Threshold Value For PurePlugsMask Computation</label>
+      <channel>input</channel>
+      <description>If this threshold value is greater than zero, only pure samples are used to compute the distributions in EM classification, and only pure samples are used for KNN training. The default value is set to 0, that means not using pure plugs. However, a value of 0.2 is suggested if you want to activate using pure plugs option.</description>
+      <default>0.0</default>
+    </float>
+
+    <integer-vector>
+      <name>numberOfSubSamplesInEachPlugArea</name>
+      <longflag>numberOfSubSamplesInEachPlugArea</longflag>
+      <label>Number of sub-samples taken at each direction inside the plug area to decide whether it is a pure plug or not</label>
+      <channel>input</channel>
+      <description>Number of continous index samples taken at each direction of lattice space for each plug volume.</description>
+      <default>0,0,0</default>
+    </integer-vector>
 
     <boolean>
       <name>atlasWarpingOff</name>

--- a/BRAINSABC/brainseg/BRAINSABCUtilities.cxx
+++ b/BRAINSABC/brainseg/BRAINSABCUtilities.cxx
@@ -41,80 +41,167 @@ template void NormalizeProbListInPlace<FloatImageType>(std::vector<FloatImageTyp
 
 template void ZeroNegativeValuesInPlace<FloatImageType>(  std::vector<FloatImageType::Pointer> & );
 
-std::vector<CorrectIntensityImageType::Pointer> CorrectBias(
-  const unsigned int degree,
-  const unsigned int CurrentEMIteration,
-  const std::vector<ByteImageType::Pointer> &
-  CandidateRegions,
-  const std::vector<CorrectIntensityImageType::Pointer> &
-  inputImages,
-  const ByteImageType::Pointer currentBrainMask,
-  const ByteImageType::Pointer currentTissueMask,
-  const std::vector<FloatImageType::Pointer> & probImages,
-  const std::vector<bool> & probUseForBias,
-  const FloatingPrecision sampleSpacing,
-  const int DebugLevel,
-  const std::string& OutputDebugDir
-  )
+MapOfFloatImageVectors
+ResampleImageListToFirstKeyImage(const std::string & resamplerInterpolatorType,
+                                 const MapOfFloatImageVectors & inputImageMap)
 {
-  std::vector<CorrectIntensityImageType::Pointer> correctedImages(inputImages.size() );
+  muLogMacro(<< "Resampling input image map to the first key image." << std::endl);
 
-  if( degree == 0 )
-    {
-    muLogMacro(<< "Skipping Bias correction, polynomial degree = " << degree <<  std::endl);
-    return inputImages;
-    }
-  muLogMacro(<< "Bias correction, polynomial degree = " << degree <<  std::endl);
+  FloatImageType::ConstPointer KeyImageFirstRead =
+    GetMapVectorFirstElement(inputImageMap).GetPointer();
 
-  // Perform bias correction
-  const unsigned int                   numClasses = probImages.size();
-  std::vector<FloatImageType::Pointer> biasPosteriors;
-  std::vector<ByteImageType::Pointer>  biasCandidateRegions;
-  biasPosteriors.clear();
-  biasCandidateRegions.clear();
+  // Clear image list
+  MapOfFloatImageVectors outputImageMap;
+
+  // Resample the other images
+  for(MapOfFloatImageVectors::const_iterator inputImageMapIter = inputImageMap.begin();
+      inputImageMapIter != inputImageMap.end(); ++inputImageMapIter)
     {
-    for( unsigned int iclass = 0; iclass < numClasses; iclass++ )
+    FloatImageVector::const_iterator currImageIter = inputImageMapIter->second.begin();
+    unsigned int i(0);
+    while( currImageIter != inputImageMapIter->second.end() )
       {
-      const unsigned iprior = iclass;
-      if( probUseForBias[iprior] == 1 )
+      FloatImageType::Pointer tmp =
+        ResampleImageWithIdentityTransform<FloatImageType>( resamplerInterpolatorType,
+                                                            0,
+                                                            (*currImageIter).GetPointer(),
+                                                            KeyImageFirstRead.GetPointer() );
+      // Add the image
+      outputImageMap[inputImageMapIter->first].push_back( tmp );
+      ++currImageIter;
+      ++i;
+      }
+    }
+  return outputImageMap;
+}
+
+MapOfFloatImageVectors
+ResampleInPlaceImageList(const std::string & resamplerInterpolatorType,
+                         const MapOfFloatImageVectors & inputImageMap,
+                         MapOfTransformLists & intraSubjectTransforms)
+{
+  muLogMacro(<< "ResampleInPlaceImageList..." << std::endl);
+  /*
+   * This function, first, transforms all inputImageMap to the space of the first image of the map
+   * using rigid transforms (intraSubjectTransforms) and Resampling InPlace interoplation.
+   * Then, it resamples all images within one modality to the voxel lattice of the fist image of that modality channel
+   * using resamplerInterpolatorType and Identity transform.
+   */
+
+  MapOfFloatImageVectors resampleInPlaceImageMap;
+  MapOfFloatImageVectors outputImageMap;
+
+  PrintMapOfImageVectors(inputImageMap);
+
+  // ResampleInPlace all images to the physical space of the first image
+  //
+  for(MapOfFloatImageVectors::const_iterator inputImageMapIter = inputImageMap.begin();
+      inputImageMapIter != inputImageMap.end(); ++inputImageMapIter)
+    {
+    FloatImageVector::const_iterator currModalIter = inputImageMapIter->second.begin();
+    unsigned int i(0);
+    TransformList::iterator xfrmIt = intraSubjectTransforms[inputImageMapIter->first].begin();
+    while( currModalIter != inputImageMapIter->second.end() )
+      {
+      muLogMacro(<< "ResamplingInPlace input image " << inputImageMapIter->first << " #" << i
+                 << " to the physical space of the first image." << std::endl);
+      typedef itk::ResampleInPlaceImageFilter<FloatImageType, FloatImageType>  ResampleIPFilterType;
+      typedef ResampleIPFilterType::Pointer                                    ResampleIPFilterPointer;
+
+      typedef itk::VersorRigid3DTransform<double>   VersorRigid3DTransformType;
+      const VersorRigid3DTransformType::ConstPointer tempRigidTransform =
+        dynamic_cast<VersorRigid3DTransformType const *>( (*xfrmIt).GetPointer() );
+      if( tempRigidTransform.IsNull() )
         {
-        // Focus only on FG classes, more accurate if bg classification is bad
-        // but sacrifices accuracy in border regions (tend to overcorrect)
-        biasPosteriors.push_back(probImages[iclass]);
-        biasCandidateRegions.push_back(CandidateRegions[iclass]);
+        std::cerr << "Error in type conversion. " << __FILE__ << __LINE__ << std::endl;
+        std::cerr << "ResampleInPlace is only allowed with rigid transform type." << std::endl;
+        throw;
         }
+
+      ResampleIPFilterPointer resampleIPFilter = ResampleIPFilterType::New();
+      resampleIPFilter->SetInputImage( (*currModalIter) );
+      resampleIPFilter->SetRigidTransform( tempRigidTransform );
+      resampleIPFilter->Update();
+      FloatImageType::Pointer tmp = resampleIPFilter->GetOutput();
+
+      // Add the image
+      resampleInPlaceImageMap[inputImageMapIter->first].push_back(tmp);
+      ++currModalIter;
+      ++xfrmIt;
+      ++i;
       }
     }
 
-  itk::TimeProbe BiasCorrectorTimer;
-  BiasCorrectorTimer.Start();
-  typedef LLSBiasCorrector<CorrectIntensityImageType, FloatImageType> BiasCorrectorType;
-  typedef BiasCorrectorType::Pointer                                  BiasCorrectorPointer;
+  // Resample each intra subject image to the first image of its modality
+  //
+  muLogMacro(<< "Resampling each intra subject image to the first image of its modality using "
+             << resamplerInterpolatorType << " interpolation." << std::endl);
+  const FloatImageType::PixelType outsideFOVCode = vnl_huge_val( static_cast<FloatImageType::PixelType>( 1.0f ) );
 
-  BiasCorrectorPointer biascorr = BiasCorrectorType::New();
-  biascorr->SetMaxDegree(degree);
-  // biascorr->SetMaximumBiasMagnitude(5.0);
-  // biascorr->SetSampleSpacing(2.0*SampleSpacing);
-  biascorr->SetSampleSpacing(1);
-  biascorr->SetWorkingSpacing(sampleSpacing);
-  biascorr->SetForegroundBrainMask(currentBrainMask);
-  biascorr->SetAllTissueMask(currentTissueMask);
-  biascorr->SetProbabilities(biasPosteriors, biasCandidateRegions);
-  biascorr->SetDebugLevel(DebugLevel);
-  biascorr->SetOutputDebugDir(OutputDebugDir);
-
-  if( DebugLevel > 0 )
+  for(MapOfFloatImageVectors::iterator inputRIPImageMapIter = resampleInPlaceImageMap.begin();
+      inputRIPImageMapIter != resampleInPlaceImageMap.end(); ++inputRIPImageMapIter)
     {
-    biascorr->DebugOn();
+    FloatImageVector::iterator currModalIter = inputRIPImageMapIter->second.begin();
+    FloatImageType::Pointer currModalityKeySubjectImage = (*currModalIter).GetPointer(); // the first image of current modality
+
+    while( currModalIter != inputRIPImageMapIter->second.end() )
+      {
+      if( (*currModalIter).GetPointer() == currModalityKeySubjectImage.GetPointer() ) // if the current intra subject image
+          // is the first image in current modality list
+        {
+        outputImageMap[inputRIPImageMapIter->first].push_back( (*currModalIter).GetPointer() );
+        }
+      else // resample the current intra subject image to the first image of the current modality
+        {
+        FloatImageType::Pointer tmp =
+          ResampleImageWithIdentityTransform<FloatImageType>( resamplerInterpolatorType,
+                                                             outsideFOVCode,
+                                                             (*currModalIter).GetPointer(),
+                                                             currModalityKeySubjectImage.GetPointer() );
+
+        // Zero the mask region outside FOV and also the intensities with
+        // outside
+        // FOV code
+        typedef itk::ImageRegionIterator<FloatImageType> InternalIteratorType;
+        InternalIteratorType    tmpIt( tmp, tmp->GetLargestPossibleRegion() );
+
+        //TODO:  This code below with masking does not make sense.
+        //        intraSubjectFOVIntersectionMask does not seem to do anything.
+        // HACK:  We can probably remove the mask generation from here.
+        // The FOV mask, regions where intensities in all channels do not
+        // match FOV code
+        ByteImageType::Pointer intraSubjectFOVIntersectionMask = ByteImageType::New();
+        intraSubjectFOVIntersectionMask->CopyInformation( currModalityKeySubjectImage.GetPointer() );
+        intraSubjectFOVIntersectionMask->SetRegions( currModalityKeySubjectImage.GetPointer()->GetLargestPossibleRegion() );
+        intraSubjectFOVIntersectionMask->Allocate();
+        intraSubjectFOVIntersectionMask->FillBuffer(1);
+
+        typedef itk::ImageRegionIterator<ByteImageType> MaskIteratorType;
+        MaskIteratorType maskIt( intraSubjectFOVIntersectionMask,
+                                intraSubjectFOVIntersectionMask->GetLargestPossibleRegion() );
+        maskIt.GoToBegin();
+        tmpIt.GoToBegin();
+        while( !maskIt.IsAtEnd() )
+          {
+          if( tmpIt.Get() == outsideFOVCode )  // Voxel came from outside
+            // the original FOV during
+            // registration, so
+            // invalidate it.
+            {
+            maskIt.Set(0); // Set it as an invalid voxel in
+            // intraSubjectFOVIntersectionMask
+            tmpIt.Set(0);  // Set image intensity value to zero.
+            }
+          ++maskIt;
+          ++tmpIt;
+          }
+
+        // Add the image
+        outputImageMap[inputRIPImageMapIter->first].push_back(tmp);
+        }
+      ++currModalIter;
+      }
     }
-  BiasCorrectorType::MapOfInputImageVectors bcInput;
-  bcInput["first"] = inputImages;
-  biascorr->SetInputImages(bcInput);
-  correctedImages = biascorr->CorrectImages(CurrentEMIteration)["first"];
 
-  BiasCorrectorTimer.Stop();
-  itk::RealTimeClock::TimeStampType elapsedTime = BiasCorrectorTimer.GetTotal();
-  muLogMacro(<< "Computing BiasCorrection took " << elapsedTime << " " << BiasCorrectorTimer.GetUnit() << std::endl);
-
-  return correctedImages;
+  return outputImageMap;
 }

--- a/BRAINSABC/brainseg/CMakeLists.txt
+++ b/BRAINSABC/brainseg/CMakeLists.txt
@@ -52,6 +52,7 @@ set(ALL_PROGS_LIST
   BRAINSABC
   ESLR
   GenerateLabelMapFromProbabilityMap
+  GeneratePurePlugMask
   )
 foreach( prog ${ALL_PROGS_LIST} )
   StandardBRAINSBuildMacro( NAME ${prog}

--- a/BRAINSABC/brainseg/EMSegmentationFilter.h
+++ b/BRAINSABC/brainseg/EMSegmentationFilter.h
@@ -33,7 +33,7 @@
 #ifndef __EMSegmentationFilter_h
 #define __EMSegmentationFilter_h
 
-#include "BRAINSABCUtilities.h"
+#include "GeneratePurePlugMask.h"
 #include <map>
 #include <list>
 class AtlasDefinition;
@@ -113,11 +113,31 @@ public:
 
   typedef itk::Transform<double, 3, 3>  GenericTransformType;
 
-  typedef std::vector< FloatingPrecision >                      MeasurementVectorType;
+  typedef itk::Array< FloatingPrecision >                       MeasurementVectorType;
   typedef itk::Statistics::ListSample< MeasurementVectorType >  SampleType;
+
+  typedef itk::NearestNeighborInterpolateImageFunction< InputImageType, double > InputImageNNInterpolationType;
+  typedef itk::NearestNeighborInterpolateImageFunction< ByteImageType, double >  MaskNNInterpolationType;
+
+  typedef std::vector<typename InputImageNNInterpolationType::Pointer> InputImageInterpolatorVector;
+  typedef std::map<std::string, InputImageInterpolatorVector>          MapOfInputImageInterpolatorVectors;
 
   itkSetMacro(UseKNN, bool);
   itkGetMacro(UseKNN, bool);
+
+  itkSetMacro(UsePurePlugs, bool);
+  itkGetMacro(UsePurePlugs, bool);
+
+  itkSetMacro(PurePlugsThreshold, float);
+  itkGetMacro(PurePlugsThreshold, float);
+
+  void SetNumberOfSubSamplesInEachPlugArea(unsigned int nx, unsigned int ny, unsigned int nz)
+    {
+    m_NumberOfSubSamplesInEachPlugArea[0] = nx;
+    m_NumberOfSubSamplesInEachPlugArea[1] = ny;
+    m_NumberOfSubSamplesInEachPlugArea[2] = nz;
+    this->Modified();
+    }
 
   // Set/Get the maximum polynomial degree of the bias field estimate
   itkSetMacro(MaxBiasDegree, unsigned int);
@@ -260,10 +280,7 @@ protected:
                                        const ProbabilityImageVectorType &WarpedPriorsList,
                                        ByteImagePointer &NonAirRegion);
 
-  ByteImageVectorType ForceToOne(const unsigned int CurrentEMIteration,
-                                 // const MapOfInputImageVectors &intensityList,
-                                 ProbabilityImageVectorType &WarpedPriorsList,
-                                 typename ByteImageType::Pointer NonAirRegion);
+  ByteImageVectorType ForceToOne(ProbabilityImageVectorType &WarpedPriorsList);
 private:
 
   void WritePartitionTable(const unsigned int CurrentEMIteration) const;
@@ -291,9 +308,6 @@ private:
   unsigned int ComputePriorLookupTable(void);
 
   void InitializePosteriors(void);
-
-  typename TInputImage::Pointer
-  NormalizeInputIntensityImage(const typename TInputImage::Pointer inputImage);
 
   void
   kNNCore( SampleType * trainMatrix,
@@ -441,7 +455,12 @@ private:
 
   std::vector<RegionStats> m_ListOfClassStatistics;
 
-  bool         m_UseKNN;
+  bool              m_UseKNN;
+
+  bool              m_UsePurePlugs;
+  float             m_PurePlugsThreshold;
+  unsigned int      m_NumberOfSubSamplesInEachPlugArea[3];
+  ByteImagePointer  m_PurePlugsMask;
 
   bool         m_UpdateTransformation;
   unsigned int m_DebugLevel;

--- a/BRAINSABC/brainseg/GeneratePurePlugMask.cxx
+++ b/BRAINSABC/brainseg/GeneratePurePlugMask.cxx
@@ -1,0 +1,95 @@
+/*=========================================================================
+ *
+ *  Copyright SINAPSE: Scalable Informatics for Neuroscience, Processing and Software Engineering
+ *            The University of Iowa
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+/*
+ * Author: Ali Ghayoor
+ * at SINAPSE Lab,
+ * The University of Iowa 2015
+ */
+
+#include "GeneratePurePlugMask.h"
+#include "GeneratePurePlugMaskCLP.h"
+
+int main( int argc, char * argv[] )
+{
+  PARSE_ARGS;
+
+  typedef itk::Image<float, 3>                                                FloatImageType;
+  typedef FloatImageType::Pointer                                             FloatImagePointer;
+  typedef std::vector<FloatImagePointer>                                      InputImageList;
+  typedef itk::ImageFileReader<FloatImageType>                                LocalReaderType;
+  typedef itk::RescaleIntensityImageFilter< FloatImageType, FloatImageType >  RescaleFilterType;
+  typedef itk::Image<unsigned char, 3>                                        MaskImageType;
+
+  std::vector<std::string> inputFileNames;
+  if( inputImageModalities.size() > 1 )
+    {
+    inputFileNames = inputImageModalities;
+    }
+  else
+    {
+    std::cerr << "ERROR: At least two image modalities are needed to generate pure plug mask." << std::endl;
+    return EXIT_FAILURE;
+    }
+  const unsigned int numberOfImageModalities = inputFileNames.size(); // number of modality images
+
+  // Read the input modalities and set them in a vector of images
+  typedef LocalReaderType::Pointer             LocalReaderPointer;
+
+  InputImageList inputImageModalitiesList;
+  for( unsigned int i = 0; i < numberOfImageModalities; i++ )
+     {
+     std::cout << "Reading image: " << inputFileNames[i] << std::endl;
+
+     LocalReaderPointer imgreader = LocalReaderType::New();
+     imgreader->SetFileName( inputFileNames[i].c_str() );
+
+     try
+       {
+       imgreader->Update();
+       }
+     catch( ... )
+       {
+       std::cout << "ERROR:  Could not read image " << inputFileNames[i] << "." << std::endl;
+       return EXIT_FAILURE;
+       }
+
+     inputImageModalitiesList.push_back( imgreader->GetOutput() );
+     }
+
+  // define step size based on the number of sub-samples at each direction
+  MaskImageType::SizeType numberOfContinuousIndexSubSamples;
+  numberOfContinuousIndexSubSamples[0] = numberOfSubSamples[0];
+  numberOfContinuousIndexSubSamples[1] = numberOfSubSamples[1];
+  numberOfContinuousIndexSubSamples[2] = numberOfSubSamples[2];
+
+  MaskImageType::Pointer mask =
+    GeneratePurePlugMask<FloatImageType, MaskImageType>( inputImageModalitiesList,
+                                                        threshold,
+                                                        numberOfContinuousIndexSubSamples,
+                                                        false, verbose );
+
+  typedef itk::ImageFileWriter<MaskImageType> MaskWriterType;
+  MaskWriterType::Pointer writer = MaskWriterType::New();
+  writer->SetInput( mask );
+  writer->SetFileName( outputMaskFile );
+  writer->UseCompressionOn();
+  writer->Update();
+
+  return EXIT_SUCCESS;
+}

--- a/BRAINSABC/brainseg/GeneratePurePlugMask.h
+++ b/BRAINSABC/brainseg/GeneratePurePlugMask.h
@@ -1,0 +1,338 @@
+/*=========================================================================
+ *
+ *  Copyright SINAPSE: Scalable Informatics for Neuroscience, Processing and Software Engineering
+ *            The University of Iowa
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+/*
+ * Author: Ali Ghayoor
+ * at SINAPSE Lab,
+ * The University of Iowa 2015
+ */
+#ifndef __GeneratePurePlugMask_h
+#define __GeneratePurePlugMask_h
+
+#include "itkCastImageFilter.h"
+#include "itkCannyEdgeDetectionImageFilter.h"
+#include "BRAINSABCUtilities.h"
+#include "itkIntegrityMetricMembershipFunction.h"
+
+template <class InputImageType, class ByteImageType>
+typename ByteImageType::Pointer
+GeneratePurePlugMask(const std::vector<typename InputImageType::Pointer> & inputImages,
+                     const float threshold,
+                     const typename ByteImageType::SizeType & numberOfContinuousIndexSubSamples,
+                     bool areInputsNormalized,
+                     bool verbose = false) // verbose was only used for debugging purposes, should always be false.
+{
+  typedef typename itk::NearestNeighborInterpolateImageFunction<
+    InputImageType, double >                                               InputImageNNInterpolationType;
+  typedef std::vector<typename InputImageNNInterpolationType::Pointer>     InputImageInterpolatorVector;
+  typedef std::vector<typename InputImageType::Pointer>                    InputImageVector;
+  typedef itk::Array< double >                                             MeasurementVectorType;
+  typedef itk::Statistics::ListSample< MeasurementVectorType >             SampleType;
+  typedef itk::Statistics::IntegrityMetricMembershipFunction< SampleType > IntegrityMetricType;
+
+  typedef itk::Image< double, 3 >                                             RealImageType;
+  typedef itk::CastImageFilter< InputImageType, RealImageType >               CastToRealFilterType;
+  typedef itk::CastImageFilter< RealImageType, ByteImageType >                CastToByteFilterType;
+  typedef itk::CannyEdgeDetectionImageFilter< RealImageType, RealImageType >  CannyFilterType;
+  typedef typename itk::NearestNeighborInterpolateImageFunction<
+    ByteImageType, double >                                                   MaskNNInterpolationType;
+
+
+  muLogMacro(<< "\nGenerating pure plug mask..." << std::endl);
+  muLogMacro(<< "Threshold value is set to: " << threshold << std::endl);
+  muLogMacro(<< "Input number of subsamples per each direction in voxel space: "
+             << numberOfContinuousIndexSubSamples << std::endl);
+
+  itk::TimeProbe PurePlugsMaskTimer;
+  PurePlugsMaskTimer.Start();
+
+  const unsigned int numberOfImageModalities =
+    inputImages.size(); // number of modality images
+
+  InputImageVector                 normalizedInputModalImagesList( numberOfImageModalities );
+  InputImageInterpolatorVector     inputImageNNInterpolatorsVector( numberOfImageModalities );
+
+  typename ByteImageType::SpacingType maskSpacing;
+  maskSpacing.Fill(0);
+
+  typename ByteImageType::SpacingType minimumSpacing;
+  minimumSpacing.Fill(vcl_numeric_limits<double>::max());
+
+  size_t index = 0;
+  for( size_t i = 0; i < numberOfImageModalities; i++ )
+    {
+    // Generation of the pure plug mask needs the input images being normalized between 0 and 1.
+    if( !areInputsNormalized )
+      {
+      normalizedInputModalImagesList[i] = NormalizeInputIntensityImage<InputImageType>( inputImages[i] );
+      }
+    else
+      {
+      normalizedInputModalImagesList[i] = inputImages[i];
+      }
+    // create a vector of input image interpolators for evaluation of image values in physical space
+    typename InputImageNNInterpolationType::Pointer inputImageInterp =
+      InputImageNNInterpolationType::New();
+    inputImageInterp->SetInputImage( normalizedInputModalImagesList[i] );
+    inputImageNNInterpolatorsVector[i] = inputImageInterp;
+
+    // Pure plug mask should have the highest spacing (lowest resolution) at each direction
+    typename InputImageType::SpacingType currImageSpacing = normalizedInputModalImagesList[i]->GetSpacing();
+    for( size_t s = 0; s < 3; s++ )
+      {
+      if( currImageSpacing[s] > maskSpacing[s] )
+        {
+        maskSpacing[s] = currImageSpacing[s];
+        index = i;
+        }
+      if( currImageSpacing[s] < minimumSpacing[s] )
+        {
+        minimumSpacing[s] = currImageSpacing[s];
+        }
+      }
+    }
+
+  // if invalid values are passed as numberOfContinuousIndexSubSamples,
+  // we recompute that as the ratio between lowest resolution to highest resolution
+  bool recomputeNumberOfSubSamples = false;
+  for( size_t i = 0; i < 3; i++ )
+    {
+    if( numberOfContinuousIndexSubSamples[i] <= 0 )
+      {
+      recomputeNumberOfSubSamples = true;
+      }
+    }
+  typename ByteImageType::SizeType numberOfSubSamples;
+  if( recomputeNumberOfSubSamples )
+    {
+    numberOfSubSamples[0] = itk::Math::Round<itk::SizeValueType>( maskSpacing[0]/minimumSpacing[0] );
+    numberOfSubSamples[1] = itk::Math::Round<itk::SizeValueType>( maskSpacing[1]/minimumSpacing[1] );
+    numberOfSubSamples[2] = itk::Math::Round<itk::SizeValueType>( maskSpacing[2]/minimumSpacing[2] );
+    muLogMacro(<< "\nWARNING: Input number of subsamples in voxel space are invalid." << std::endl
+               << "Number of subsamples per each direction in voxel space are recomputed as: "
+               << numberOfSubSamples << std::endl);
+    }
+  else
+    {
+    numberOfSubSamples[0] = numberOfContinuousIndexSubSamples[0];
+    numberOfSubSamples[1] = numberOfContinuousIndexSubSamples[1];
+    numberOfSubSamples[2] = numberOfContinuousIndexSubSamples[2];
+    }
+
+  /*
+   * Create an edge mask from the finest resolution image.
+   * Edges should be excluded from purePlugsMask.
+   */
+  typename CastToRealFilterType::Pointer toReal = CastToRealFilterType::New();
+  toReal->SetInput( normalizedInputModalImagesList[0] );
+
+  typename CannyFilterType::Pointer cannyFilter = CannyFilterType::New();
+  cannyFilter->SetInput( toReal->GetOutput() );
+  cannyFilter->SetVariance( 2.0 );
+  cannyFilter->SetUpperThreshold( 0.05 );
+  cannyFilter->SetLowerThreshold( 0.02 );
+
+  typename CastToByteFilterType::Pointer toByte = CastToByteFilterType::New();
+  toByte->SetInput( cannyFilter->GetOutput() );
+  toByte->Update();
+
+  typename ByteImageType::Pointer edgeMask = toByte->GetOutput();
+  typename MaskNNInterpolationType::Pointer edgeMaskInterp = MaskNNInterpolationType::New();
+  edgeMaskInterp->SetInputImage( edgeMask );
+
+  // Write to disk for debug
+  typedef itk::ImageFileWriter<ByteImageType> EdgeMaskWriterType;
+  typename EdgeMaskWriterType::Pointer edgewriter = EdgeMaskWriterType::New();
+  edgewriter->SetInput( edgeMask );
+  edgewriter->SetFileName("DEBUG_Canny_Edge_Mask.nii.gz");
+  edgewriter->Update();
+  //
+
+  /*
+   * Create an all zero mask image
+   */
+  typename ByteImageType::Pointer mask = ByteImageType::New();
+  // Spacing is set as the largest spacing at each direction
+  mask->SetSpacing( maskSpacing );
+  // Origin and direction are set from the first modality image
+  mask->SetOrigin( normalizedInputModalImagesList[index]->GetOrigin() );
+  mask->SetDirection( normalizedInputModalImagesList[index]->GetDirection() );
+  // The FOV of mask is set as the FOV of the first modality image
+  typename ByteImageType::SizeType maskSize;
+  typename InputImageType::SizeType inputSize = normalizedInputModalImagesList[index]->GetLargestPossibleRegion().GetSize();
+  typename InputImageType::SpacingType inputSpacing = normalizedInputModalImagesList[index]->GetSpacing();
+  maskSize[0] = itk::Math::Ceil<itk::SizeValueType>( inputSize[0]*inputSpacing[0]/maskSpacing[0] );
+  maskSize[1] = itk::Math::Ceil<itk::SizeValueType>( inputSize[1]*inputSpacing[1]/maskSpacing[1] );
+  maskSize[2] = itk::Math::Ceil<itk::SizeValueType>( inputSize[2]*inputSpacing[2]/maskSpacing[2] );
+  // mask start index
+  typename ByteImageType::IndexType maskStart;
+  maskStart.Fill(0);
+  // Set mask region
+  typename ByteImageType::RegionType maskRegion(maskStart, maskSize);
+  mask->SetRegions( maskRegion );
+  mask->Allocate();
+  mask->FillBuffer(0);
+  ///////////////////////
+
+  IntegrityMetricType::Pointer integrityMetric = IntegrityMetricType::New();
+  integrityMetric->SetThreshold( threshold );
+
+  // define step size based on the number of sub-samples at each direction
+  typename ByteImageType::SpacingType stepSize;
+  stepSize[0] = maskSpacing[0]/numberOfSubSamples[0];
+  stepSize[1] = maskSpacing[1]/numberOfSubSamples[1];
+  stepSize[2] = maskSpacing[2]/numberOfSubSamples[2];
+
+  // Now iterate through the mask image
+  typedef typename itk::ImageRegionIteratorWithIndex< ByteImageType > MaskItType;
+  MaskItType maskIt( mask, mask->GetLargestPossibleRegion() );
+  maskIt.GoToBegin();
+
+  while( ! maskIt.IsAtEnd() )
+    {
+    typename ByteImageType::IndexType idx = maskIt.GetIndex();
+
+    if( verbose )
+      {
+      muLogMacro(<< "current index: " << idx << std::endl);
+      }
+
+    // A sample list is created for every index that is inside all input images buffers
+    SampleType::Pointer sample = SampleType::New();
+    sample->SetMeasurementVectorSize( numberOfImageModalities );
+
+    // flag that helps to break from loops if the current continous index is
+    // not inside the buffer of any input modality image
+    bool isInside = true;
+
+    // subsampling is performed in voxel space around each mask index.
+    // subsamples are taken as continues indices
+    for( double iss = idx[0]-(maskSpacing[0]/2)+(stepSize[0]/2); iss < idx[0]+(maskSpacing[0]/2); iss += stepSize[0] )
+      {
+      for( double jss = idx[1]-(maskSpacing[1]/2)+(stepSize[1]/2); jss < idx[1]+(maskSpacing[1]/2); jss += stepSize[1] )
+        {
+        for( double kss = idx[2]-(maskSpacing[2]/2)+(stepSize[2]/2); kss < idx[2]+(maskSpacing[2]/2); kss += stepSize[2] )
+          {
+          itk::ContinuousIndex<double,3> cidx;
+          cidx[0] = iss;
+          cidx[1] = jss;
+          cidx[2] = kss;
+
+          // All input modality images are aligned in physical space,
+          // so we need to transform each continuous index to physical point,
+          // so it represent the same location in all input images
+          typename ByteImageType::PointType currPoint;
+          mask->TransformContinuousIndexToPhysicalPoint(cidx, currPoint);
+
+          if( verbose )
+            {
+            muLogMacro(<< "current continous index: " << cidx << std::endl);
+            muLogMacro(<< "current physical point: " << currPoint << std::endl);
+            }
+
+          MeasurementVectorType mv( numberOfImageModalities );
+
+          for( unsigned int i = 0; i < numberOfImageModalities; i++ )
+            {
+            if( inputImageNNInterpolatorsVector[i]->IsInsideBuffer( currPoint ) && edgeMaskInterp->IsInsideBuffer( currPoint ) )
+              {
+              if( edgeMaskInterp->Evaluate(currPoint) ) // If the current point blongs to an edge, it cannot belong to a pure plug
+                {
+                isInside = false;
+                break;
+                }
+              else
+                {
+                mv[i] = inputImageNNInterpolatorsVector[i]->Evaluate( currPoint );
+                }
+              }
+            else
+              {
+              isInside = false;
+              break;
+              }
+            }
+
+          if( isInside )
+            {
+            if( verbose )
+              {
+              muLogMacro(<< "Is inside, measurement vector: " << mv << std::endl);
+              }
+            sample->PushBack( mv );
+            }
+          else
+            {
+            if( verbose )
+              {
+              muLogMacro(<< "Is not inside! so not pure!" << std::endl);
+              }
+            break;
+            }
+          } // end of nested loop 3
+        if( !isInside )
+          {
+          break;
+          }
+        } // end of nested loop 2
+      if( !isInside )
+        {
+        break;
+        }
+      } // end of nested loop 1
+
+    if( isInside )
+      {
+      if( verbose )
+        {
+        muLogMacro(<< "Integrity filter: " << std::endl);
+        integrityMetric->Print(std::cout);
+        }
+      if( integrityMetric->Evaluate( sample ) )
+        {
+        maskIt.Set(1);
+        if( verbose )
+          {
+          muLogMacro(<< "Is pure: True" << std::endl);
+          }
+        }
+      else
+        {
+        if( verbose )
+          {
+          muLogMacro(<< "Is pure: False" << std::endl);
+          }
+        }
+      }
+    if( verbose )
+      {
+      muLogMacro(<< "-----------" << std::endl);
+      }
+
+    ++maskIt;
+    } // end of while loop
+
+  PurePlugsMaskTimer.Stop();
+  itk::RealTimeClock::TimeStampType elapsedTime = PurePlugsMaskTimer.GetTotal();
+  muLogMacro(<< "Generating pure plugs mask took " << elapsedTime
+             << " " << PurePlugsMaskTimer.GetUnit() << "." << std::endl);
+
+  return mask;
+}
+
+#endif // __GeneratePurePlugMask_h

--- a/BRAINSABC/brainseg/GeneratePurePlugMask.xml
+++ b/BRAINSABC/brainseg/GeneratePurePlugMask.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<executable>
+  <category>Classification</category>
+  <title>Pure Plugs Mask</title>
+  <description>
+    This program gets several modality image files and returns a binary mask that defines the pure plugs.
+  </description>
+  <version>4.5.0</version>
+  <documentation-url> </documentation-url>
+  <license> </license>
+  <contributor>Ali Ghayoor</contributor>
+<acknowledgements>
+</acknowledgements>
+
+  <parameters>
+    <label>IO</label>
+    <description>Input/output parameters</description>
+
+    <string-vector>
+      <name>inputImageModalities</name>
+      <longflag>inputImageModalities</longflag>
+      <label>Input image file names</label>
+      <channel>input</channel>
+      <description>Input image files names (.nii.gz or .nrrd)</description>
+    </string-vector>
+
+    <float>
+      <name>threshold</name>
+      <longflag>threshold</longflag>
+      <label>Threshold Value</label>
+      <channel>input</channel>
+      <description>threshold value to define class membership.</description>
+      <default>0.2</default>
+    </float>
+
+    <integer-vector>
+      <name>numberOfSubSamples</name>
+      <longflag>numberOfSubSamples</longflag>
+      <label>Number of sub-samples at each direction</label>
+      <channel>input</channel>
+      <description>Number of continous index samples taken at each direction of lattice space for each plug volume.</description>
+      <default>0,0,0</default>
+    </integer-vector>
+
+    <boolean>
+      <name>verbose</name>
+      <flag>v</flag>
+      <longflag>verbose</longflag>
+      <label>verbose</label>
+      <default>false</default>
+      <description>Print out some debugging information.</description>
+    </boolean>
+
+    <image>
+      <name>outputMaskFile</name>
+      <longflag>outputMaskFile</longflag>
+      <label>Output binary mask file name</label>
+      <channel>output</channel>
+      <description>Ouput binary mask that includes the pure plugs (.nrrd)</description>
+      <default>./purePlugsBinaryMask.nrrd</default>
+    </image>
+  </parameters>
+
+</executable>

--- a/BRAINSABC/brainseg/LLSBiasCorrector.h
+++ b/BRAINSABC/brainseg/LLSBiasCorrector.h
@@ -83,7 +83,6 @@ public:
   typedef std::vector<InputImagePointer> InputImageVector;
   typedef std::map<std::string,InputImageVector> MapOfInputImageVectors;
 
-
   typedef itk::Image<unsigned char, itkGetStaticConstMacro(ImageDimension)> ByteImageType;
   typedef typename ByteImageType::Pointer                                   ByteImagePointer;
   typedef typename ByteImageType::IndexType                                 ByteImageIndexType;
@@ -105,6 +104,9 @@ public:
   typedef InternalImageType::PixelType  InternalImagePixelType;
   typedef InternalImageType::RegionType InternalImageRegionType;
   typedef InternalImageType::SizeType   InternalImageSizeType;
+
+  typedef itk::NearestNeighborInterpolateImageFunction< InputImageType, double > InputImageNNInterpolationType;
+  typedef itk::NearestNeighborInterpolateImageFunction< ByteImageType, double > MaskNNInterpolationType;
 
   typedef double ScalarType;
 

--- a/BRAINSABC/brainseg/StandardizeMaskIntensity.h
+++ b/BRAINSABC/brainseg/StandardizeMaskIntensity.h
@@ -24,6 +24,7 @@
 #include "itkIntensityWindowingImageFilter.h"
 #include "itkThresholdImageFilter.h"
 #include "itkNumericTraits.h"
+#include "BRAINSABCUtilities.h"
 
 #define MAX_IMAGE_OUTPUT_VALUE 4096
 
@@ -83,10 +84,18 @@ typename ImageType::Pointer StandardizeMaskIntensity(
     }
   else
     {
+    // resample input mask to the voxel lattice of the input image
+    // mask and input image are already at the same physical space
+    typename LabelImageType::Pointer resampledMask =
+      ResampleImageWithIdentityTransform<LabelImageType>( "NearestNeighbor",
+                                                         0,
+                                                         mask.GetPointer(),
+                                                         image.GetPointer() );
+
     typename itk::ThresholdImageFilter<LabelImageType>::Pointer thresholdFilter
       = itk::ThresholdImageFilter<LabelImageType>::New();
 
-    thresholdFilter->SetInput(mask);
+    thresholdFilter->SetInput(resampledMask);
     thresholdFilter->ThresholdAbove(1); // Values less than or equal to are set
                                         // to OutsideValue
     thresholdFilter->SetOutsideValue(maskInteriorLabel);

--- a/BRAINSABC/brainseg/itkIntegrityMetricMembershipFunction.h
+++ b/BRAINSABC/brainseg/itkIntegrityMetricMembershipFunction.h
@@ -1,0 +1,188 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+/*
+ * Author: Ali Ghayoor
+ * at SINAPSE Lab,
+ * The University of Iowa 2015
+ */
+
+#ifndef itkIntegrityMetricMembershipFunction_h
+#define itkIntegrityMetricMembershipFunction_h
+
+#include "itkVariableSizeMatrix.h"
+#include "itkMeasurementVectorTraits.h"
+#include "itkObject.h"
+#include "itkObjectFactory.h"
+
+namespace itk
+{
+namespace Statistics
+{
+/** \class IntegrityMetricMembershipFunction
+ * \brief IntegrityMetricMembershipFunction models class membership
+ * based on an Mahalanobis-weighted Euclidean distance.
+ *
+ * This class first calculates the Euclidean and the Mahalanobis distance
+ * for each sample measurement from the computed mean point.
+ * Then, Mahalanobis distances are scaled based on the maximum distance.
+ * Scaled Mahalanobis distances are then used to wieght the calculated
+ * Euclidean distances to create the output weighted distance vector.
+ *
+ * MahalanobisDistanceWeights = MahalanobisDistance/max(MahalanobisDistance)
+ * OutputWeighteDistanceVector = EuclideanDistance * MahalanobisDistanceWeights
+ *
+ * The ``Evaluate()'' method returns true if all members of the OutputWeighteDistanceVector
+ * are smaller than an input threshold value.
+ *
+ * \ingroup ITKStatistics
+ */
+
+template< typename TSample >
+class IntegrityMetricMembershipFunction:
+  public Object
+{
+public:
+  /** Standard class typedefs */
+  typedef IntegrityMetricMembershipFunction     Self;
+  typedef Object                                Superclass;
+  typedef SmartPointer< Self >                  Pointer;
+  typedef SmartPointer< const Self >            ConstPointer;
+
+  /** Strandard macros */
+  itkTypeMacro(IntegrityMetricMembershipFunction, Object);
+  itkNewMacro(Self);
+
+  typedef TSample                                                     SampleType;
+
+  /** Type of each measurement vector in sample */
+  typedef typename SampleType::MeasurementVectorType                  MeasurementVectorType;
+
+  /** Type of the length of each measurement vector */
+  typedef typename SampleType::MeasurementVectorSizeType              MeasurementVectorSizeType;
+
+  /** Type of measurement vector component value */
+  typedef typename SampleType::MeasurementType                        MeasurementType;
+
+  /** Type of a measurement vector, holding floating point values */
+  typedef typename NumericTraits< MeasurementVectorType >::RealType   MeasurementVectorRealType;
+
+  /** Type of a floating point measurement component value */
+  typedef typename NumericTraits< MeasurementType >::RealType         MeasurementRealType;
+
+  /** Type of the mean vector.  */
+  typedef MeasurementVectorRealType                    MeanVectorType;
+
+  /** Type of the covariance matrix */
+  typedef VariableSizeMatrix< MeasurementRealType >    CovarianceMatrixType;
+
+  /** Type of the output distance vector */
+  typedef vnl_vector<double>                           DistanceVectorType;
+
+  /** Set threshold */
+  itkSetMacro(Threshold, float);
+
+  /** Get the mean of the measurement samples. Mean is a vector type
+   * similar to the measurement type but with a real element type. */
+  itkGetConstReferenceMacro(Mean, MeanVectorType);
+
+  /** Get the covariance matrix of the measurement samples. Covariance
+   * matrix is a VariableSizeMatrix of real element type. */
+  itkGetConstReferenceMacro(Covariance, CovarianceMatrixType);
+
+  /**
+   * Evaluate the weighted distance of a measurement using the
+   * calculated Euclidean and Mahalanobis distances.
+   * Note mean and covariance are computed to derive Mahalanobis distance.
+   * This method returns true if all computed weighted distances are less
+   * than input threshold. */
+  bool Evaluate(const SampleType * measurementSample);
+
+  /** Get calculated weighted distance vector */
+  itkGetConstMacro(WeightedDistanceVector, DistanceVectorType);
+
+  /** Set the length of the measurement vector. If this membership
+   * function is templated over a vector type that can be resized,
+   * the new size is set. If the vector type has a fixed size and an
+   * attempt is made to change its size, an exception is
+   * thrown. */
+  virtual void SetMeasurementVectorSize(MeasurementVectorSizeType s)
+  {
+    // Test whether the vector type is resizable or not
+  MeasurementVectorType m;
+
+  if ( MeasurementVectorTraits::IsResizable(m) )
+    {
+    // then this is a resizable vector type
+    //
+    // if the new size is the same as the previou size, just return
+    if ( s == this->m_MeasurementVectorSize )
+      {
+      return;
+      }
+    else
+      {
+      this->m_MeasurementVectorSize = s;
+      this->Modified();
+      }
+    }
+  else
+    {
+    // If this is a non-resizable vector type
+    MeasurementVectorType     m3;
+    MeasurementVectorSizeType defaultLength =
+    NumericTraits<MeasurementVectorType>::GetLength(m3);
+    // and the new length is different from the default one, then throw an exception
+    if ( defaultLength != s )
+      {
+      itkExceptionMacro(
+        "Attempting to change the measurement vector size of a non-resizable vector type" );
+      }
+    }
+  }
+
+  /** Get the length of the measurement vector */
+  itkGetConstMacro(MeasurementVectorSize, MeasurementVectorSizeType);
+
+protected:
+  IntegrityMetricMembershipFunction();
+  virtual ~IntegrityMetricMembershipFunction(void) {}
+  void PrintSelf(std::ostream & os, Indent indent) const;
+
+  /** Set the mean used in the Mahalanobis distance.
+    * This method run sanity checks after mean is computed.  */
+  void SetMean(const MeanVectorType & mean);
+
+  /** Set the covariance matrix.
+    * This method run sanity checks after covariance is computed. */
+  void SetCovariance(const CovarianceMatrixType & cov);
+
+private:
+  MeasurementVectorSizeType   m_MeasurementVectorSize;
+  float                       m_Threshold;                // threshold value
+  MeanVectorType              m_Mean;                     // mean
+  CovarianceMatrixType        m_Covariance;               // covariance matrix
+  DistanceVectorType          m_WeightedDistanceVector;   // output weighted distance vector
+};
+} // end of namespace Statistics
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkIntegrityMetricMembershipFunction.hxx"
+#endif
+
+#endif

--- a/BRAINSABC/brainseg/itkIntegrityMetricMembershipFunction.hxx
+++ b/BRAINSABC/brainseg/itkIntegrityMetricMembershipFunction.hxx
@@ -1,0 +1,186 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkIntegrityMetricMembershipFunction_hxx
+#define itkIntegrityMetricMembershipFunction_hxx
+
+#include "itkIntegrityMetricMembershipFunction.h"
+
+#include "itkVector.h"
+#include "itkListSample.h"
+#include "itkCovarianceSampleFilter.h"
+#include "itkMahalanobisDistanceMetric.h"
+#include "itkEuclideanDistanceMetric.h"
+
+namespace itk
+{
+namespace Statistics
+{
+template< typename TSample >
+IntegrityMetricMembershipFunction< TSample >
+::IntegrityMetricMembershipFunction()
+{
+  m_MeasurementVectorSize = NumericTraits<MeasurementVectorType>::GetLength(                                                                          MeasurementVectorType() );
+
+  NumericTraits<MeanVectorType>::SetLength(m_Mean, this->GetMeasurementVectorSize());
+  m_Mean.Fill(0.0f);
+
+  m_Covariance.SetSize(this->GetMeasurementVectorSize(), this->GetMeasurementVectorSize());
+  m_Covariance.SetIdentity();
+
+  m_Threshold = 0.0;
+
+  m_WeightedDistanceVector.set_size(0);
+}
+
+template< typename TSample >
+void
+IntegrityMetricMembershipFunction< TSample >
+::SetMean(const MeanVectorType & mean)
+{
+  if( this->GetMeasurementVectorSize() )
+    {
+    MeasurementVectorTraits::Assert(mean,
+                                    this->GetMeasurementVectorSize(),
+                                    "IntegrityMetricMembershipFunction::SetMean(): Size of mean vector specified does not match the size of a measurement vector.");
+    }
+  else
+    {
+    // not already set, cache the size
+    this->SetMeasurementVectorSize( mean.Size() );
+    }
+
+  if( this->m_Mean != mean )
+    {
+    this->m_Mean = mean;
+    this->Modified();
+    }
+}
+
+template< typename TSample >
+void
+IntegrityMetricMembershipFunction< TSample >
+::SetCovariance(const CovarianceMatrixType & cov)
+{
+  // Sanity check
+  if( cov.GetVnlMatrix().rows() != cov.GetVnlMatrix().cols() )
+    {
+    itkExceptionMacro(<< "Covariance matrix must be square.");
+    }
+
+  if( this->GetMeasurementVectorSize() )
+    {
+    if( cov.GetVnlMatrix().rows() != this->GetMeasurementVectorSize() )
+      {
+      itkExceptionMacro(<< "Length of measurement vectors (" << this->GetMeasurementVectorSize()
+                        << ") must be the same as the size of the covariance matrix ("
+                        << cov.GetVnlMatrix().rows() << ").");
+      }
+    }
+  else
+    {
+    // not already set, cache the size
+    this->SetMeasurementVectorSize( cov.GetVnlMatrix().rows() );
+    }
+
+  if( this->m_Covariance != cov )
+    {
+    this->m_Covariance = cov;
+    this->Modified();
+    }
+}
+
+template< typename TSample >
+bool
+IntegrityMetricMembershipFunction< TSample >
+::Evaluate(const SampleType * measurementSample)
+{
+  if( measurementSample->Size() == 0 )
+    {
+    itkExceptionMacro(<< "There is no entry in input measurement sample.");
+    }
+
+  // If there is only one measurement sample per each plug area, that plug is pure!
+  if( measurementSample->Size() == 1 )
+    {
+    return true;
+    }
+
+  // compute mean and covariance
+  typedef itk::Statistics::CovarianceSampleFilter< SampleType > CovarianceAlgorithmType;
+  typename CovarianceAlgorithmType::Pointer covarianceAlgorithm = CovarianceAlgorithmType::New();
+  covarianceAlgorithm->SetInput( measurementSample );
+  covarianceAlgorithm->Update();
+
+  this->SetMean( covarianceAlgorithm->GetMean() );
+  this->SetCovariance( covarianceAlgorithm->GetCovarianceMatrix() );
+
+  // Compute Mahalanobis and Euclidean distances for each sample and put them in vectors
+  typedef itk::Statistics::EuclideanDistanceMetric< MeasurementVectorType >  EDMetricType;
+  typename EDMetricType::Pointer euclideanDist = EDMetricType::New();
+
+  typedef itk::Statistics::MahalanobisDistanceMetric< MeasurementVectorType >  MDMetricType;
+  typename MDMetricType::Pointer mahalanobisDist = MDMetricType::New();
+  mahalanobisDist->SetMeasurementVectorSize( this->GetMeasurementVectorSize() );
+  mahalanobisDist->SetCovariance( this->GetCovariance().GetVnlMatrix() );
+
+  vnl_vector<double> ed_vector( measurementSample->Size() ); // vector including euclidean distances for each sample
+  vnl_vector<double> md_vector( measurementSample->Size() ); // vector including mahalanobis distances for each sample
+  this->m_WeightedDistanceVector.clear();
+
+  unsigned int i = 0;
+  for( typename SampleType::ConstIterator s_iter = measurementSample->Begin();
+        s_iter != measurementSample->End(); ++s_iter)
+     {
+     ed_vector[i] = euclideanDist->Evaluate( this->GetMean(), s_iter.GetMeasurementVector() );
+     md_vector[i] = mahalanobisDist->Evaluate( this->GetMean(), s_iter.GetMeasurementVector() );
+     ++i;
+     }
+
+  // If points are so close to the mean, you can rest assure they belong to a pure plug.
+  // However, this ideal case mostly happen in background area!
+  if( ed_vector.max_value() < 1e-2 )
+    {
+    return true;
+    }
+
+  md_vector /= md_vector.max_value(); // Normalize mahalanobis distances to the maximum distance
+  this->m_WeightedDistanceVector = element_product(ed_vector, md_vector);
+
+  bool belongs = (this->m_WeightedDistanceVector.max_value() < this->m_Threshold);
+  return belongs;
+}
+
+template< typename TSample >
+void
+IntegrityMetricMembershipFunction< TSample >
+::PrintSelf(std::ostream & os, Indent indent) const
+{
+  Superclass::PrintSelf(os, indent);
+  os << indent << "Measurement vector size: " <<
+    this->m_MeasurementVectorSize << std::endl;
+  os << indent << "Mean: " << this->m_Mean << std::endl;
+  os << indent << "Covariance: " << std::endl;
+  os << this->m_Covariance.GetVnlMatrix();
+  os << indent << "Weighted distance matrix: " << std::endl;
+  os << this->m_WeightedDistanceVector << std::endl;
+}
+
+} // end namespace Statistics
+} // end of namespace itk
+
+#endif

--- a/BRAINSCommonLib/BRAINSComputeLabels.h
+++ b/BRAINSCommonLib/BRAINSComputeLabels.h
@@ -46,6 +46,8 @@ void ComputeLabels(
   TFloatingPrecision InclusionThreshold,  //No thresholding = 0.0F
   const size_t minLabelSizeAllowed) //Allow zero sized labels = 0
 {
+  std::cout << "\nComputing labels..." << std::endl;
+
   std::map<size_t,size_t> reverseLabelMap;
   for( size_t i=0; i < PriorLabelCodeVector.size(); ++i)
     {


### PR DESCRIPTION
This patch applies following changes to BRAINSABC:

1) Bias field correction and classification processes (EM and KNN)
are now run in physical space rather than voxel space.

2) A new feature is added to BRAINSABC that helps the program find the
voxels composed of partial volume effect, so only pure samples can be
used for classification and bias field correction.

An ITK membership filter is added to identify pure samples. This
filter evaluates a multimodal sample set at each plug area to check
whether all the picked samples within a plug area are affected by partial
volume issue or not based on a user defined threshold.

This threshold is a value between zero and one specified by a newly added
flag named "--purePlugsThreshold". The default value is zero that means
not using pure plugs for classification.
If you want to activate using pure plugs for EM computations and KNN
training, a value of 0.2 is suggested empirically.
The threshold value defines a Mahalanobis-weighted Euclidean distance
that is used as the metric in a ITK membership filter.

Size of a plug area is specified automatically as the lowest possible
resolution based on the voxel size of input multimodal scans.

The number of samples at each plug area is defined by a new BRAINSABC
flag named "--numberOfSubSamplesInEachPlugArea". The default value to
this flag is 0,0,0 that means number of picked samples will be decided
based on the ratio of finest to lowest resolution at each coordinate
direction.

Technically if you wish to run BRAINSABC using pure plugs feature, set a
value greater than zero (0.2 has shown promising results) to
"purePlugsThreshold".

----
If you want to generate a pure plug mask outside of BRAINSABC, use the
newly added program called "GeneratePurePlugMask".
Note that it is assumed that input multimodal scans to this program are
already aligned in physical space.

Usage:
$ bin/GeneratePurePlugMask \
  --inputImageModalities t1.nii.gz,t2.nii.gz,IDWI.nrrd \
  --threshold 0.2 \
  --numberOfSubSamples 2,2,2 \
  --outputMaskFile binary_pure_mask.nrrd

GeneratePurePlugMask.h is called to compute pure plugs, and this file
calls "itkIntegrityMetricMembershipFunction" filter to decide each plug
is pure or not.