### PR TITLE
ENH: Updates compareTwoCVSFiels.py.in to work with python3

### DIFF
--- a/GTRACT/Cmdline/TestSuite/compareTwoCSVFiles.py.in
+++ b/GTRACT/Cmdline/TestSuite/compareTwoCSVFiles.py.in
@@ -30,28 +30,28 @@ def main(argv):
   try:
     opts, args = getopt.getopt(argv,"hr:i:",["csvReferenceFile=","csvInputFile="])
   except getopt.GetoptError:
-    print 'compareTwoCSVFiles.py -r <csvReferenceFile> -i <csvInputFile>'
+    print ('compareTwoCSVFiles.py -r <csvReferenceFile> -i <csvInputFile>')
     sys.exit(2)
   for opt, arg in opts:
     if opt == '-h':
-      print 'compareTwoCSVFiles.py -r <csvReferenceFile> -i <csvInputFile>'
+      print ('compareTwoCSVFiles.py -r <csvReferenceFile> -i <csvInputFile>')
       sys.exit()
     elif opt in ("-r", "--csvReferenceFile"):
       referenceFile = arg
     elif opt in ("-i", "--csvInputFile"):
       inputFile = arg
 
-  print 'Reference csv file: ', referenceFile
-  print 'Input csv file: ', inputFile
+  print ('Reference csv file: ', referenceFile)
+  print ('Input csv file: ', inputFile)
 
   refDataList = csv_file_reader(referenceFile)
   inputDataList = csv_file_reader(inputFile)
 
   if refDataList != inputDataList:
-    print 'Input csv files do not match!!!'
+    print ('Input csv files do not match!!!')
     sys.exit(1)
   else:
-    print 'Input csv files are the same!'
+    print ('Input csv files are the same!')
 
 if __name__ == "__main__":
   main(sys.argv[1:])


### PR DESCRIPTION
The print function uses slightly different syntax in python3 than
python2. The print statements in this file have been updated to
work with both versions.

This was causing some test failures on systems where the python executable was python3