### PR TITLE
BUG: Adds null check to string assignment in BRAINSMeasureSurface.cxx

### DIFF
--- a/BRAINSSurfaceTools/BRAINSSurfaceGeneration/BRAINSMeasureSurface.cxx
+++ b/BRAINSSurfaceTools/BRAINSSurfaceGeneration/BRAINSMeasureSurface.cxx
@@ -255,7 +255,11 @@ int main( int argc, char * *argv )
     }
 
   std::string measurementTime = itksys::SystemTools::GetCurrentDateTime("%Y-%m-%d_%H:%M.%S");
-  std::string user = itksys::SystemTools::GetEnv("USER");
+  std::string user = "User";
+  if( itksys::SystemTools::GetEnv("USER") ) //Null check
+    {
+    user = itksys::SystemTools::GetEnv("USER");
+    }
 
   if( writeCsvFile )
     {


### PR DESCRIPTION
On some systems, the USER environment variable is unset and checking it
returns null. This was causing a test failure when BRAINSMeasureSurface
tried to initialize a string to the value of a non-existant variable.