### PR TITLE
COMP: Force CMAKE_CONFIGURATION_TYPES only when using multi-config ge…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ else()
   project(${LOCAL_PROJECT_NAME} C CXX)
 endif()
 
-if(NOT DEFINED CMAKE_CONFIGURATION_TYPES)
+if(DEFINED CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_CONFIGURATION_TYPES "Release;Debug" CACHE STRING "" FORCE) # setting only two configuration types
 endif()
 


### PR DESCRIPTION
…nerator

This commit fixes a regression first introduced in 831eab6 (ENH: Allow
selecting C++11 from CMAKE_CXX_STANDARD) and incorrectly fixed
in 8987b5d (BUG: Do not dereference a variable when checking for existance.)

CMAKE_CONFIGURATION_TYPES variable is now forced to a value only
if it has been defined by CMake. This ensures that project (e.g Slicer)
directly adding BRAINSTools source tree can still rely on the
assumption CMAKE_CONFIGURATION_TYPES is set only when multi-configuration
generator are used.