### PR TITLE
BUG: defined an orderedmap class for BABC

### DIFF
--- a/BRAINSABC/brainseg/AtlasRegistrationMethod.h
+++ b/BRAINSABC/brainseg/AtlasRegistrationMethod.h
@@ -185,13 +185,13 @@ public:
   typedef itk::Array<unsigned char> FlagArrayType;
 
   typedef std::vector<std::string> StringVector;
-  typedef std::map<std::string,StringVector > MapOfStringVectors;
+  typedef orderedmap<std::string,StringVector > MapOfStringVectors;
 
   typedef std::vector<InternalImagePointer> FloatImageVector;
-  typedef std::map<std::string, FloatImageVector> MapOfFloatImageVectors;
+  typedef orderedmap<std::string, FloatImageVector> MapOfFloatImageVectors;
 
   typedef std::vector<GenericTransformType::Pointer> TransformList;
-  typedef std::map<std::string,TransformList>        MapOfTransformLists;
+  typedef orderedmap<std::string,TransformList>        MapOfTransformLists;
 
   void SetSuffix(std::string suffix);
 

--- a/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
+++ b/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
@@ -145,7 +145,7 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
   muLogMacro(<< "Register Intra subject images" << std::endl);
 
   int i = 0;
-  for(MapOfFloatImageVectors::iterator mapOfModalImageListsIt = this->m_IntraSubjectOriginalImageList.begin();
+  for(auto mapOfModalImageListsIt = this->m_IntraSubjectOriginalImageList.begin();
       mapOfModalImageListsIt != this->m_IntraSubjectOriginalImageList.end();
       ++mapOfModalImageListsIt)
     {

--- a/BRAINSABC/brainseg/BRAINSABC.cxx
+++ b/BRAINSABC/brainseg/BRAINSABC.cxx
@@ -425,7 +425,7 @@ int main(int argc, char * *argv)
   currentRow++;
   for( unsigned int pwi = 0; pwi < PriorNames.size(); pwi++ )
     {
-    std::map<std::string, AtlasDefinition::BoundsType> temp_range_List;
+    orderedmap<std::string, AtlasDefinition::BoundsType> temp_range_List;
     for( unsigned int tt = 0; tt < input_VolumeTypes.size(); tt++ )
       {
       AtlasDefTable.add(currentRow + tt * 2 + 0, 0, std::string(input_VolumeTypes[tt]) + std::string(" Lower") );
@@ -562,7 +562,7 @@ int main(int argc, char * *argv)
     for( AtlasRegType::StringVector::const_iterator imIt = typeIt->second.begin();
          imIt != typeIt->second.end(); ++imIt,++i )
       {
-      muLogMacro(<< "Reading image " << ": " << (*imIt) << "...\n");
+      muLogMacro(<< "\n***Reading image " << ": " << (*imIt) << "...\n");
 
       LocalReaderPointer imgreader = LocalReaderType::New();
       imgreader->SetFileName( (*imIt).c_str() );
@@ -659,7 +659,7 @@ int main(int argc, char * *argv)
       mapIt != templateVolumes.end(); ++mapIt)
     {
     const std::string curAtlasName = FindPathFromAtlasXML(*(mapIt->second.begin()),atlasDefinitionPath);
-    muLogMacro(<< "Reading atlas image " << mapIt->first << ": " << curAtlasName << "...\n");
+    muLogMacro(<< "\n***Reading atlas image " << mapIt->first << ": " << curAtlasName << "...\n");
     LocalReaderPointer imgreader = LocalReaderType::New();
     imgreader->SetFileName(curAtlasName.c_str());
     try
@@ -1077,7 +1077,7 @@ int main(int argc, char * *argv)
     SegFilterType::RangeDBType myRanges;
     for(auto & PriorName : PriorNames)
       {
-      std::map<std::string, AtlasDefinition::BoundsType> temp_range_List;
+      orderedmap<std::string, AtlasDefinition::BoundsType> temp_range_List;
       for(auto & input_VolumeType : input_VolumeTypes)
         {
         temp_range_List[input_VolumeType] = atlasDefinitionParser.GetBounds(PriorName, input_VolumeType);

--- a/BRAINSABC/brainseg/BRAINSABCUtilities.h
+++ b/BRAINSABC/brainseg/BRAINSABCUtilities.h
@@ -56,6 +56,61 @@ typedef unsigned int LOOPITERTYPE;
 { }
 #endif
 
+/** A utility class for holding ordered maps */
+
+/**
+ * Make ordered map by choosing less than operator based on order of inputs
+ * This comparitor function will order the maps based on a first in
+ * priority. Elements that are not already in the list of keys
+ * are added at the end.  Elements that show up in the list first are considered
+ * less than elements that show up in the list second.
+ **/
+class firstInOrderingOfStrings
+{
+public:
+  firstInOrderingOfStrings() { }
+  bool operator() (const std::string& lhs, const std::string& rhs) const
+  {
+  for(auto &elem : m_firstInOrdering)
+    {
+    if(elem == lhs && (lhs != rhs ))
+      {
+      return true;
+      }
+    else if(elem == rhs)
+      {
+      return false;
+      }
+    }
+  /* New elements go at the end */
+  if( lhs == rhs )
+    {
+    this->m_firstInOrdering.push_back(lhs);
+    return false;
+    }
+  else
+    {
+    this->m_firstInOrdering.push_back(rhs);
+    this->m_firstInOrdering.push_back(lhs);
+    return false;
+    }
+  }
+private:
+  /* This needs to be mutable. The function signature needs to be
+   * const, but this internal list needs to be mutable for the case
+   * of new elements being added*/
+  mutable std::list<std::string> m_firstInOrdering;
+};
+
+template<class Key, class T>
+class orderedmap: public std::map<Key, T, firstInOrderingOfStrings>
+{
+public:
+  orderedmap():std::map<Key, T, firstInOrderingOfStrings>()
+  {};
+  using std::map<Key, T, firstInOrderingOfStrings>::operator[];
+};
+
 typedef double                          FloatingPrecision;
 typedef itk::Image<unsigned char, 3>    ByteImageType;
 typedef itk::Image<float, 3>            FloatImageType;
@@ -64,14 +119,14 @@ typedef itk::Image<signed short int, 3> ShortImageType;
 
 typedef itk::Image<float, 3> CorrectIntensityImageType;
 
-typedef std::map<std::string,std::string> ImageByTypeMap;
+typedef orderedmap<std::string,std::string> ImageByTypeMap;
 
-typedef std::vector<FloatImagePointerType>      FloatImageVector;
-typedef std::map<std::string, FloatImageVector> MapOfFloatImageVectors;
+typedef std::vector<FloatImagePointerType>        FloatImageVector;
+typedef orderedmap<std::string, FloatImageVector> MapOfFloatImageVectors;
 
 typedef itk::Transform<double, 3, 3>               GenericTransformType;
 typedef std::vector<GenericTransformType::Pointer> TransformList;
-typedef std::map<std::string,TransformList>        MapOfTransformLists;
+typedef orderedmap<std::string,TransformList>      MapOfTransformLists;
 
 /** A utiliy class for holding statistical information
  * for all image channels for a given tissue class type
@@ -81,7 +136,7 @@ class RegionStats
 public:
   typedef vnl_matrix<FloatingPrecision>         MatrixType;
   typedef vnl_matrix_inverse<FloatingPrecision> MatrixInverseType;
-  typedef std::map<std::string,double>          MeanMapType;
+  typedef orderedmap<std::string,double>        MeanMapType;
   RegionStats() : m_Means(), m_Covariance(), m_Weighting(0.0)
   {
   }

--- a/BRAINSABC/brainseg/ComputeDistributions.h
+++ b/BRAINSABC/brainseg/ComputeDistributions.h
@@ -31,7 +31,7 @@ typedef itk::CompensatedSummation<double> CompensatedSummationType;
 template <class TInputImage, class TProbabilityImage, class MatrixType>
 void
 CombinedComputeDistributions( const std::vector<typename ByteImageType::Pointer> & SubjectCandidateRegions,
-                              const std::map<std::string,std::vector<typename TInputImage::Pointer> >
+                              const orderedmap<std::string,std::vector<typename TInputImage::Pointer> >
                               &InputImageMap,
                               const std::vector<typename TProbabilityImage::Pointer> & PosteriorsList,
                               std::vector<RegionStats> & ListOfClassStatistics, //
@@ -48,7 +48,7 @@ CombinedComputeDistributions( const std::vector<typename ByteImageType::Pointer>
                               )
 {
   typedef std::vector<typename TInputImage::Pointer> InputImageVector;
-  typedef std::map<std::string,InputImageVector> MapOfInputImageVectors;
+  typedef orderedmap<std::string,InputImageVector>   MapOfInputImageVectors;
 
   typedef itk::NearestNeighborInterpolateImageFunction< TInputImage, double > InputImageNNInterpolationType;
 
@@ -214,7 +214,7 @@ CombinedComputeDistributions( const std::vector<typename ByteImageType::Pointer>
                         //
                         // this will end up as a vnl_matrix for assignment to
                         // the Class Statistics object after this is computed.
-                        std::map<std::string, std::map<std::string, double> > TypeCovariance;
+                        orderedmap<std::string, orderedmap<std::string, double> > TypeCovariance;
                         // initialize -- no easy way since it is a map of maps
                         for (typename MapOfInputImageVectors::const_iterator mapIt = InputImageMap.begin();
                              mapIt != InputImageMap.end(); ++mapIt) {

--- a/BRAINSABC/brainseg/EMSegmentationFilter.h
+++ b/BRAINSABC/brainseg/EMSegmentationFilter.h
@@ -60,7 +60,7 @@ public:
 
   typedef double CoordinateRepType;
 
-  typedef typename std::map<std::string,  std::map<std::string, AtlasDefinition::BoundsType> > RangeDBType;
+  typedef orderedmap<std::string,  orderedmap<std::string, AtlasDefinition::BoundsType> > RangeDBType;
   // Image types
   typedef TInputImage                       InputImageType;
   typedef typename TInputImage::Pointer     InputImagePointer;
@@ -74,7 +74,7 @@ public:
   typedef std::vector<InputImagePixelType> BackgroundValueVector;
 
   typedef std::vector<InputImagePointer> InputImageVector;
-  typedef std::map<std::string, InputImageVector> MapOfInputImageVectors;
+  typedef orderedmap<std::string, InputImageVector> MapOfInputImageVectors;
 
   typedef typename ByteImageType::Pointer    ByteImagePointer;
   typedef typename ByteImageType::IndexType  ByteImageIndexType;
@@ -120,7 +120,7 @@ public:
   typedef itk::NearestNeighborInterpolateImageFunction< ByteImageType, double >  MaskNNInterpolationType;
 
   typedef std::vector<typename InputImageNNInterpolationType::Pointer> InputImageInterpolatorVector;
-  typedef std::map<std::string, InputImageInterpolatorVector>          MapOfInputImageInterpolatorVectors;
+  typedef orderedmap<std::string, InputImageInterpolatorVector>        MapOfInputImageInterpolatorVectors;
 
   itkSetMacro(UseKNN, bool);
   itkGetMacro(UseKNN, bool);

--- a/BRAINSABC/brainseg/LLSBiasCorrector.h
+++ b/BRAINSABC/brainseg/LLSBiasCorrector.h
@@ -81,7 +81,7 @@ public:
   typedef typename TInputImage::SpacingType InputImageSpacingType;
 
   typedef std::vector<InputImagePointer> InputImageVector;
-  typedef std::map<std::string,InputImageVector> MapOfInputImageVectors;
+  typedef orderedmap<std::string,InputImageVector> MapOfInputImageVectors;
 
   typedef itk::Image<unsigned char, itkGetStaticConstMacro(ImageDimension)> ByteImageType;
   typedef typename ByteImageType::Pointer                                   ByteImagePointer;


### PR DESCRIPTION
When BABC is run using multimodal scans, it is important that they are
saved in a map based on a proper order i.e. T1 type always comes first,
then T2, PD, Flair, and Others.
The current implementation was using a std::map container for holding
the input types, so they were ordered alphabetically and PD was
considered as the first (main) input modality.