### PR TITLE
Fix implementation of the centerOfROI initializer

### DIFF
--- a/BRAINSFit/BRAINSFit.cxx
+++ b/BRAINSFit/BRAINSFit.cxx
@@ -288,6 +288,8 @@ int main(int argc, char *argv[])
     }
 
   // Need to ensure that the order of transforms is from smallest to largest.
+  if(localInitializeTransformMode == "Off")
+  {
   try
     {
     itk::ValidateTransformRankOrdering(localTransformType);
@@ -298,6 +300,7 @@ int main(int argc, char *argv[])
     std::cout << err << std::endl;
     throw;
     }
+  }
 
   // Extracting a timeIndex cube from the fixed image goes here....
   // Also MedianFilter


### PR DESCRIPTION
This fix implements the initializer the way it was introduced into BRAINSFit back in the ITKv3 days. See comment for details. 

This commit also adds the capability to save the initializer transform when no registration phases are specified.

cc: @che85