### PR TITLE
ENH: throw (overridable) error when attempting lossy NIFTI conversion.

### DIFF
--- a/DWIConvert/DWIConvert.cxx
+++ b/DWIConvert/DWIConvert.cxx
@@ -212,13 +212,13 @@ int main(int argc, char *argv[])
   if( conversionMode == "FSLToNrrd" )
     {
     return FSLToNrrd(inputVolume, outputVolume,fslNIFTIFile,
-                     inputBValues, inputBVectors,transpose);
+                     inputBValues, inputBVectors, transpose, allowLossyConversion);
     }
   // make FSL file set from a NRRD file.
   if( conversionMode == "NrrdToFSL" )
     {
     return NrrdToFSL(inputVolume, outputVolume,
-                     outputBValues, outputBVectors);
+                     outputBValues, outputBVectors, allowLossyConversion);
     }
 
   bool nrrdFormat(true);

--- a/DWIConvert/DWIConvert.xml
+++ b/DWIConvert/DWIConvert.xml
@@ -162,5 +162,12 @@
       <default>true</default>
       <description><![CDATA[FSL input BVectors are expected to be encoded in the input file as one vector per line. If it is not the case, use this option to transpose the file as it is read]]></description>
     </boolean>
+    <boolean>
+      <name>allowLossyConversion</name>
+      <longflag>allowLossyConversion</longflag>
+      <label>Allow lossy image conversion</label>
+      <default>false</default>
+      <description><![CDATA[The only supported output type is 'short'. Conversion from images of a different type may cause data loss due to rounding or truncation. Use with caution!"]]></description>
+    </boolean>
   </parameters>
 </executable>

--- a/DWIConvert/FSLToNrrd.cxx
+++ b/DWIConvert/FSLToNrrd.cxx
@@ -40,7 +40,8 @@ FSLToNrrd(const std::string & inputVolume,
           const std::string & fslNIFTIFile,
           const std::string & inputBValues,
           const std::string & inputBVectors,
-          bool transpose
+          bool transpose,
+          bool allowLossyConversion
          )
 {
   if( (CheckArg<std::string>("Input Volume", inputVolume, "") == EXIT_FAILURE &&
@@ -56,13 +57,13 @@ FSLToNrrd(const std::string & inputVolume,
   std::string inputVolumeNameTemplate = inputVolume;
   if(fslNIFTIFile.size() > 0)
     {
-    if( ReadVolume<Volume4DType>(inputVol, fslNIFTIFile) != EXIT_SUCCESS )
+    if( ReadVolume<Volume4DType>(inputVol, fslNIFTIFile, allowLossyConversion) != EXIT_SUCCESS )
       {
       return EXIT_FAILURE;
       }
     inputVolumeNameTemplate = fslNIFTIFile;
     }
-  else if( inputVolume.size() == 0 || ReadVolume<Volume4DType>(inputVol, inputVolume) != EXIT_SUCCESS )
+  else if( inputVolume.size() == 0 || ReadVolume<Volume4DType>(inputVol, inputVolume, allowLossyConversion) != EXIT_SUCCESS )
     {
     return EXIT_FAILURE;
     }

--- a/DWIConvert/NrrdToFSL.cxx
+++ b/DWIConvert/NrrdToFSL.cxx
@@ -88,7 +88,8 @@ StripNIfTIName(const std::string &niftiName)
 int NrrdToFSL(const std::string & inputVolume,
               const std::string & outputVolume,
               const std::string & outputBValues,
-              const std::string & outputBVectors)
+              const std::string & outputBVectors,
+              bool allowLossyConversion)
 {
   if( CheckArg<std::string>("Input Volume", inputVolume, "") == EXIT_FAILURE ||
       CheckArg<std::string>("Output Volume", outputVolume, "") == EXIT_FAILURE)
@@ -115,7 +116,7 @@ int NrrdToFSL(const std::string & inputVolume,
     }
 
   VectorVolumeType::Pointer inputVol;
-  if( ReadVolume<VectorVolumeType>( inputVol, inputVolume ) != EXIT_SUCCESS )
+  if( ReadVolume<VectorVolumeType>( inputVol, inputVolume, allowLossyConversion ) != EXIT_SUCCESS )
     {
     return EXIT_FAILURE;
     }


### PR DESCRIPTION
Partially addresses #261.

```
Test project /Users/inorton/work/git/BRAINSTools-build
      Start  1: PrettyPrintTableTest
1/68 Test  #1: PrettyPrintTableTest .......................................   Passed    0.07 sec
...
68/68 Test #68: DWIConvertSiemensTrio_Syngo2004A_2Test .....................   Passed   13.71 sec

100% tests passed, 0 tests failed out of 68
```