### PR TITLE
ENH: BCD user selected landmark option

### DIFF
--- a/AutoWorkup/singleSession.py
+++ b/AutoWorkup/singleSession.py
@@ -84,12 +84,16 @@ def _create_singleSession(dataDict, master_config, interpMode, pipeline_name):
             doDenoise = False
         else:
             doDenoise = True
+    useEMSP=False
+    if dataDict['EMSP'] > 0:
+        useEMSP =True
     sessionWorkflow = generate_single_session_template_WF(project, subject, session, onlyT1, master_config,
                                                           phase=master_config['workflow_phase'],
                                                           interpMode=interpMode,
                                                           pipeline_name=pipeline_name,
                                                           doDenoise=doDenoise,
-                                                          badT2=dataDict['BadT2'])
+                                                          badT2=dataDict['BadT2'],
+                                                          useEMSP=useEMSP)
     sessionWorkflow.base_dir = master_config['cachedir']
 
     sessionWorkflow_inputsspec = sessionWorkflow.get_node('inputspec')
@@ -97,6 +101,7 @@ def _create_singleSession(dataDict, master_config, interpMode, pipeline_name):
     sessionWorkflow_inputsspec.inputs.T2s = dataDict['T2s']
     sessionWorkflow_inputsspec.inputs.PDs = dataDict['PDs']
     sessionWorkflow_inputsspec.inputs.FLs = dataDict['FLs']
+    sessionWorkflow_inputsspec.inputs.EMSP = dataDict['EMSP'][0]
     sessionWorkflow_inputsspec.inputs.OTHERs = dataDict['OTHERs']
     return sessionWorkflow
 
@@ -149,6 +154,7 @@ def createAndRun(sessions, environment, experiment, pipeline, cluster, useSentin
                 _dict['BadT2'] = True
             _dict['PDs'] = database.getFilenamesByScantype(session, ['PD-15', 'PD-30'])
             _dict['FLs'] = database.getFilenamesByScantype(session, ['FL-15', 'FL-30'])
+            _dict['EMSP'] = database.getFilenamesByScantype(session, ['EMSP'])
             _dict['OTHERs'] = database.getFilenamesByScantype(session, ['OTHER-15', 'OTHER-30'])
             sentinal_file_basedir = os.path.join(
                 master_config['resultdir'],

--- a/AutoWorkup/workflows/baseline.py
+++ b/AutoWorkup/workflows/baseline.py
@@ -238,7 +238,7 @@ def image_autounwrap(wrapped_inputfn, unwrapped_outputbasefn):
 
 
 def generate_single_session_template_WF(projectid, subjectid, sessionid, onlyT1, master_config, phase, interpMode,
-                                        pipeline_name, doDenoise=True, badT2 = False):
+                                        pipeline_name, doDenoise=True, badT2 = False, useEMSP=False):
     """
     Run autoworkup on a single sessionid
 
@@ -272,6 +272,7 @@ def generate_single_session_template_WF(projectid, subjectid, sessionid, onlyT1,
     inputsSpec = pe.Node(interface=IdentityInterface(fields=['atlasLandmarkFilename', 'atlasWeightFilename',
                                                              'LLSModel', 'inputTemplateModel', 'template_t1_denoised_gaussian',
                                                              'atlasDefinition', 'T1s', 'T2s', 'PDs', 'FLs', 'OTHERs',
+                                                             'EMSP',
                                                              'hncma_atlas',
                                                              'template_rightHemisphere',
                                                              'template_leftHemisphere',
@@ -550,7 +551,7 @@ def generate_single_session_template_WF(projectid, subjectid, sessionid, onlyT1,
         DoReverseMapping = False  # Set to true for debugging outputs
         if 'auxlmk' in master_config['components']:
             DoReverseMapping = True
-        myLocalLMIWF = CreateLandmarkInitializeWorkflow("LandmarkInitialize", master_config, interpMode, PostACPCAlignToAtlas, DoReverseMapping, False)
+        myLocalLMIWF = CreateLandmarkInitializeWorkflow("LandmarkInitialize", master_config, interpMode, PostACPCAlignToAtlas, DoReverseMapping, useEMSP, Debug=False)
 
         baw201.connect([(makePreprocessingOutList, myLocalLMIWF,
                          [(('T1s', get_list_element, 0), 'inputspec.inputVolume' )]),
@@ -559,7 +560,8 @@ def generate_single_session_template_WF(projectid, subjectid, sessionid, onlyT1,
                           ('atlasWeightFilename', 'inputspec.atlasWeightFilename'),
                           ('LLSModel', 'inputspec.LLSModel'),
                           ('inputTemplateModel', 'inputspec.inputTemplateModel'),
-                          ('template_t1_denoised_gaussian', 'inputspec.atlasVolume')]),
+                          ('template_t1_denoised_gaussian', 'inputspec.atlasVolume'),
+                          ('EMSP','inputspec.EMSP')]),
                         (myLocalLMIWF, outputsSpec,
                          [('outputspec.outputResampledCroppedVolume', 'BCD_ACPC_T1_CROPPED'),
                           ('outputspec.outputLandmarksInACPCAlignedSpace',


### PR DESCRIPTION
Instead of blacklist, if a landmark file
(EMSP, *.fcsv format) is given, the pipeline
will force the BCD to read the given landmark
file first.

The EMSP landmark file can be given with the
other T1/T2 as a csv file.
EX)

"project","0000","01","{'T1-15':['t1.nii.gz'],'EMSP':['01_EMSP.fcsv']}"