### PR TITLE
WIP: partial change for improving registration.

### DIFF
--- a/AutoWorkup/utilities/misc.py
+++ b/AutoWorkup/utilities/misc.py
@@ -26,6 +26,22 @@ def CommonANTsRegistrationSettings(antsRegistrationNode,
     """
     ## TODO: Consider registration masking
 
+    if ( registrationTypeDescription == "FiveStageAntsRegistrationT1Only" ) or ( registrationTypeDescription == "FiveStageAntsRegistrationMultiModal" ):
+        local_num_stages=5 # Assumes BLI landmark initialization
+        antsRegistrationNode.inputs.transforms = ["Affine","Affine","SyN","SyN","SyN"]
+        if registrationTypeDescription == "FiveStageAntsRegistrationT1Only":
+            antsRegistrationNode.inputs.metric = ['MI','MI','CC','CC','CC']
+            antsRegistrationNode.inputs.metric_weight = [1.0,1.0,1.0,1.0,1.0]
+            antsRegistrationNode.inputs.sampling_strategy = ['Regular','Regular',None,None,None]
+            antsRegistrationNode.inputs.sampling_percentage = [.5,.5,1.0,1.0,1.0]
+            antsRegistrationNode.inputs.radius_or_number_of_bins = [32,32,4,4,4]
+        else:
+            antsRegistrationNode.inputs.metric = ['MI',['MI','MI'],'CC',['CC','CC'],['CC','CC']]
+            antsRegistrationNode.inputs.metric_weight = [1.0,[1.0,1.0],1.0,[1.0,1.0],[1.0,1.0]]
+            antsRegistrationNode.inputs.sampling_strategy = ['Regular',['Regular','Regular'],None,[None,None],[None,None]]
+            antsRegistrationNode.inputs.sampling_percentage = [0.5,[0.5,0.5],1.0,[1.0,1.0],[1.0,1.0]]
+            antsRegistrationNode.inputs.radius_or_number_of_bins = [32,[32,32],4,[4,4],[4,4]]
+
     if ( registrationTypeDescription == "SixStageAntsRegistrationT1Only" ) or ( registrationTypeDescription == "SixStageAntsRegistrationMultiModal" ):
         local_num_stages=6
         antsRegistrationNode.inputs.transforms = ["Rigid","Affine","Affine","SyN","SyN","SyN"]

--- a/AutoWorkup/workflows/baseline.py
+++ b/AutoWorkup/workflows/baseline.py
@@ -914,15 +914,12 @@ def generate_single_session_template_WF(projectid, subjectid, sessionid, onlyT1,
         #    print("T1 only processing in jointFusion")
         #else:
         #    print("Multimodal processing in jointFusion")
-        ###HACK, JointFusion is unstable with T2
-        ###HACK, JointFusion is unstable with T2
-        ###HACK, JointFusion is unstable with T2
-        ###HACK, JointFusion is unstable with T2
-        onlyT1 = True
         myLocalJointFusion = CreateJointFusionWorkflow("JointFusion", onlyT1, master_config)
         baw201.connect(myLocalTCWF,'outputspec.t1_average',myLocalJointFusion,'inputspec.subj_t1_image')
         baw201.connect(myLocalTCWF,'outputspec.t2_average',myLocalJointFusion,'inputspec.subj_t2_image')
-        baw201.connect(myLocalBrainStemWF, 'outputspec.ouputTissuelLabelFilename',myLocalJointFusion,'inputspec.subj_fixed_head_labels')
+        baw201.connect(myLocalTCWF, 'outputspec.outputHeadLabels',myLocalJointFusion,'inputspec.subj_fixed_head_labels')
+        #baw201.connect(myLocalBrainStemWF, 'outputspec.ouputTissuelLabelFilename',myLocalJointFusion,'inputspec.subj_fixed_head_labels')
+        #baw201.connect(myLocalBrainStemWF, 'outputspec.ouputTissuelLabelFilename',myLocalJointFusion,'inputspec.subj_fixed_head_labels')
 
         baw201.connect(BResample['template_leftHemisphere'],'outputVolume',myLocalJointFusion,'inputspec.subj_left_hemisphere')
         baw201.connect(myLocalLMIWF, 'outputspec.outputLandmarksInACPCAlignedSpace' ,myLocalJointFusion,'inputspec.subj_lmks')


### PR DESCRIPTION
@reginakim THIS IS NOT COMPLETE.  I started, but you can review and be inspired as you update and test tomorrow.

Registration changes:  We are passing in an affine TFM from BLI.   so we should not start with a rigid transform.

We were using brainmasks (because that was all that was available in the atlas space).  I updated the dictionary file to include volume_label_seg.nii.gz so that whole head can be used for registration. ideally it should probably be dilated by 2-3 voxels.   