### PR TITLE
ENH: Throw IO Exception when reading/writing invalid landmarks file

### DIFF
--- a/BRAINSCommonLib/Slicer3LandmarkIO.cxx
+++ b/BRAINSCommonLib/Slicer3LandmarkIO.cxx
@@ -24,6 +24,7 @@
 
 #include "Slicer3LandmarkIO.h"
 #include "itkNumberToString.h"
+#include "itkImageFileReaderException.h"
 
 LandmarkWeightMapType ReadLandmarkWeights( const std::string & weightFilename )
 {
@@ -32,7 +33,7 @@ LandmarkWeightMapType ReadLandmarkWeights( const std::string & weightFilename )
   if( !weightFileStream.is_open() )
     {
     std::cerr << "Fail to open weight file " << std::endl;
-    exit(EXIT_FAILURE);
+    throw itk::ImageFileReaderException(__FILE__, __LINE__, "Couldn't open landmark weight file for reading", ITK_LOCATION);
     }
 
   std::string           line;
@@ -97,7 +98,7 @@ WriteITKtoSlicer3Lmk( const std::string & landmarksFilename,
     std::cerr << "Error: Can't write Slicer3 landmark file "
               << fullPathLandmarksFileName << std::endl;
     std::cerr.flush();
-    return;
+    throw itk::ImageFileReaderException(__FILE__, __LINE__, "Couldn't open landmarks file for writing", ITK_LOCATION);
     }
   myfile << lmksStream.str();
   myfile.close();
@@ -114,7 +115,8 @@ ReadSlicer3toITKLmk( const std::string & landmarksFilename )
     {
     std::cerr << "Error: Failed to load landmarks file!" << std::endl;
     std::cerr.flush();
-    return landmarks; // return empty landmarks
+    throw itk::ImageFileReaderException(__FILE__, __LINE__, "Couldn't open landmarks file for reading", ITK_LOCATION);
+    // do not return empty landmarks
     }
   std::string line;
   while( getline( myfile, line ) )

--- a/BRAINSCommonLib/TestSuite/CMakeLists.txt
+++ b/BRAINSCommonLib/TestSuite/CMakeLists.txt
@@ -14,11 +14,20 @@ add_executable(DWIMetaDataDictionaryValidatorTests DWIMetaDataDictionaryValidato
 target_link_libraries(DWIMetaDataDictionaryValidatorTests BRAINSCommonLib)
 set_target_properties(DWIMetaDataDictionaryValidatorTests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testbin)
 
+add_executable(Slicer3LandmarkIOExceptionTest Slicer3LandmarkIOTest.cxx)
+target_link_libraries(Slicer3LandmarkIOExceptionTest BRAINSCommonLib)
+set_target_properties(Slicer3LandmarkIOExceptionTest PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testbin)
 StandardBRAINSBuildMacro(NAME FindCenterOfBrain TARGET_LIBRARIES BRAINSCommonLib)
 
 ExternalData_add_test(FindCenterOfBrainFetchData
   NAME PrettyPrintTableTest
   COMMAND ${LAUNCH_EXE} $<TARGET_FILE:PrettyPrintTableTest>
+  ## No arguments
+  )
+
+ExternalData_add_test(FindCenterOfBrainFetchData
+  NAME Slicer3LandmarkIOExceptionTest
+  COMMAND ${LAUNCH_EXE} $<TARGET_FILE:Slicer3LandmarkIOExceptionTest>
   ## No arguments
   )
 

--- a/BRAINSCommonLib/TestSuite/Slicer3LandmarkIOTest.cxx
+++ b/BRAINSCommonLib/TestSuite/Slicer3LandmarkIOTest.cxx
@@ -1,0 +1,65 @@
+/*=========================================================================
+ *
+ *  Copyright SINAPSE: Scalable Informatics for Neuroscience, Processing and Software Engineering
+ *            The University of Iowa
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "Slicer3LandmarkIO.h"
+
+
+int main()
+{
+  bool testPassedStatus = true;
+
+  // read in bogus landmarks file
+  try
+    {
+    std::cout << "Attempting to read in non-exitsant landmarks file" <<std::endl;
+    //hopefully there is no landmarks file with this path in your system.
+    LandmarksMapType bogusLandmarks = ReadSlicer3toITKLmk("/this/file/does/not/exist.fcsv");
+
+    // An exception should be thrown, and this code should never be reached
+    std::cout << "!!Error: Succesfully read non-existant file ?!?!?! :(" <<std::endl;
+    testPassedStatus &= false;
+    }
+  catch (itk::ExceptionObject &exception)
+    {
+    // We want to succesfully catch this exception
+    std::cout << "Successfully caught exception for landmark file reading." << std::endl;
+    std::cout << "Exception was:";
+    exception.Print(std::cout);
+    testPassedStatus &= true;
+    }
+  try
+    {
+    std::cout << "Attempting to read in non-exitsant landmark weight file" <<std::endl;
+    //hopefully there is no landmarks file with this path in your system.
+    LandmarkWeightMapType bogusLandmarksWeights = ReadLandmarkWeights("/this/file/does/not/exist/either.fcsv");
+
+    // An exception should be thrown, and this code should never be reached
+    std::cout << "!!Error: Succesfully read non-existant file ?!?!?! :(" <<std::endl;
+    testPassedStatus &= false;
+    }
+  catch (itk::ExceptionObject &exception)
+    {
+    // We want to succesfully catch this exception
+    std::cout << "Successfully caught exception for landmark weights file reading." << std::endl;
+    std::cout << "Exception was:";
+    exception.Print(std::cout);
+    testPassedStatus &= true;
+    }
+
+  return testPassedStatus ? EXIT_SUCCESS: EXIT_FAILURE;
+}


### PR DESCRIPTION
The functions provided by Slicer3LandmarkIO allow landmark files to be written
and read.
Previously, if an invalid filename for a landmarks file was supplied, an error
message was printed, and if reading, an empty set of landmarks was returned.
This could cause problems, as it would be difficult to know if the landmarks
file was empty, or if an invalid filename was supplied. By throwing an exception
a program calling the function can halt progress if necessary. This will also
make debugging much easier.