### PR TITLE
BUG: template and longitudinal pipeline fix

### DIFF
--- a/AutoWorkup/template.py
+++ b/AutoWorkup/template.py
@@ -279,7 +279,8 @@ def _template_runner(argv, environment, experiment, pipeline_options, cluster):
             'template_nac_labels.nii.gz',
             'template_leftHemisphere.nii.gz',
             'template_rightHemisphere.nii.gz',
-            'template_ventricles.nii.gz'
+            'template_ventricles.nii.gz',
+            'template_headregion.nii.gz'
             ]
 
         baselineRequiredDG.inputs.field_template = {'t1_average':'*/%s/%s/TissueClassify/t1_average_BRAINSABC.nii.gz',

--- a/AutoWorkup/workflows/atlasNode.py
+++ b/AutoWorkup/workflows/atlasNode.py
@@ -96,7 +96,8 @@ def MakeAtlasNode(atlasDirectory, name, atlasParts):
             "template_WMPM2_labels.txt",
             "template_nac_labels.nii.gz",
             "template_nac_labels.txt",
-            "template_ventricles.nii.gz"
+            "template_ventricles.nii.gz",
+            "template_headregion.nii.gz"
         ])
     if 'W_ExtraSupport' in atlasParts:
         atlas_file_names.extend([
@@ -176,6 +177,7 @@ def CreateAtlasXMLAndCleanedDeformedAverages(t1_image, deformed_list, AtlasTempl
         'AVG_l_thalamus_ProbabilityMap.nii.gz': 'IGNORED',
         'AVG_l_globus_ProbabilityMap.nii.gz': 'IGNORED',
         'AVG_template_ventricles.nii.gz': 'IGNORED',
+        'AVG_template_headregion.nii.gz': 'IGNORED',
         'AVG_r_thalamus_ProbabilityMap.nii.gz': 'IGNORED',
         'AVG_l_putamen_ProbabilityMap.nii.gz': 'IGNORED',
         'AVG_rho.nii.gz': 'IGNORED',
@@ -243,6 +245,7 @@ def CreateAtlasXMLAndCleanedDeformedAverages(t1_image, deformed_list, AtlasTempl
         'AVG_l_thalamus_ProbabilityMap.nii.gz',
         'AVG_l_globus_ProbabilityMap.nii.gz',
         'AVG_template_ventricles.nii.gz',
+        'AVG_template_headregion.nii.gz',
         'AVG_r_thalamus_ProbabilityMap.nii.gz',
         'AVG_l_putamen_ProbabilityMap.nii.gz',
         'AVG_rho.nii.gz',

--- a/AutoWorkup/workflows/baseline.py
+++ b/AutoWorkup/workflows/baseline.py
@@ -478,7 +478,7 @@ def generate_single_session_template_WF(projectid, subjectid, sessionid, onlyT1,
                                              'template_ventricles': '%s/Atlas/AVG_template_ventricles.nii.gz',
                                              'template_t1_denoised_gaussian': '%s/Atlas/AVG_T1.nii.gz',
                                              'template_landmarks_50Lmks_fcsv': '%s/Atlas/AVG_LMKS.fcsv',
-                                             'template_headregion': '%s/Atlas/AVG_template_headregion'
+                                             'template_headregion': '%s/Atlas/AVG_template_headregion.nii.gz'
         }
         template_DG.inputs.template_args = {'outAtlasXMLFullPath': [['subject', 'subject']],
                                             'hncma_atlas': [['subject']],
@@ -503,7 +503,7 @@ def generate_single_session_template_WF(projectid, subjectid, sessionid, onlyT1,
             ('template_rightHemisphere', 'template_rightHemisphere'),
             ('template_WMPM2_labels', 'template_WMPM2_labels'),
             ('template_nac_labels', 'template_nac_labels'),
-            ('template_ventricles', 'template_ventricles'),
+            ('template_ventricles', 'template_ventricles')
             ]
                         )]
         )
@@ -511,7 +511,7 @@ def generate_single_session_template_WF(projectid, subjectid, sessionid, onlyT1,
         baw201.connect([(template_DG, inputsSpec,
                          [('template_t1_denoised_gaussian', 'template_t1_denoised_gaussian'),
                           ('template_landmarks_50Lmks_fcsv', 'atlasLandmarkFilename'),
-                          ('template_headregion', 'template_headregion'),
+                          ('template_headregion', 'template_headregion')
                          ]),
         ])
 
@@ -845,7 +845,8 @@ def generate_single_session_template_WF(projectid, subjectid, sessionid, onlyT1,
         AtlasBinaryMapsToResample = [
             'template_rightHemisphere',
             'template_leftHemisphere',
-            'template_ventricles']
+            'template_ventricles',
+            'template_headregion']
 
         for atlasImage in AtlasBinaryMapsToResample:
             BResample[atlasImage] = pe.Node(interface=BRAINSResample(), name="BRAINSResample_" + atlasImage)


### PR DESCRIPTION
This patch fixes the pipeline for the longitudinal stage. 
Simply adding the template_headregion to the DataGrabber. To run the template/longitudinal process, it requires re-run the previous baseline stage. The processing would not take long though. It just have to grab the headregion, and bring it to the subject space. 