### PR TITLE
COMP: BRAINSDemonWarpTemplates: Fix unknown SpatialObjectType error.

### DIFF
--- a/BRAINSDemonWarp/BRAINSDemonWarpTemplates.h
+++ b/BRAINSDemonWarp/BRAINSDemonWarpTemplates.h
@@ -39,6 +39,7 @@
 #include "itkArray.h"
 
 #include "BRAINSCommonLib.h"
+#include "BRAINSTypes.h"
 
 #include "BRAINSDemonWarpCommonLibWin32Header.h"
 #include "GenericTransformImage.h"


### PR DESCRIPTION
Fixes #285

This commit fixes a regression introduced in e808fbe (ENH: Remove
shadowed typedefs). It addresses errors like these ones:

In file included from /path/to/BRAINSTools/BRAINSDemonWarp/BRAINSDemonWarpTemplates_Vdouble.cxx:19:0:
/path/to/BRAINSTools/BRAINSDemonWarp/BRAINSDemonWarpTemplates.h: In function ‘void ThirionFunction(const BRAINSDemonWarpAppParameters&)’:
/path/to/BRAINSTools/BRAINSDemonWarp/BRAINSDemonWarpTemplates.h:312:55: error: ‘SpatialObjectType’ does not name a type
         actualfilter->SetFixedImageMask( dynamic_cast<SpatialObjectType *>( fixedMask.GetPointer() ) );
                                                       ^
/path/to/BRAINSTools/BRAINSDemonWarp/BRAINSDemonWarpTemplates.h:312:73: error: expected ‘>’ before ‘*’ token
         actualfilter->SetFixedImageMask( dynamic_cast<SpatialObjectType *>( fixedMask.GetPointer() ) );
                                                                         ^