### PR TITLE
COMP: fix Slicer issue 4041, invalid packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(POLICY CMP0017)
 endif()
 foreach(p
   CMP0054 # CMake 3.1 Only interpret ``if()`` arguments as variables or keywords when unquoted.
-  CMP0042 # ``MACOSX_RPATH`` is enabled by default.
+  # CMP0042 # ``MACOSX_RPATH`` is enabled by default. NOTE: as of 20160719, this is disabled in Slicer
   CMP0025 # AppleClang vs. regular Clang
   CMP0063 # Honor visibility properties for all target types
   )


### PR DESCRIPTION
The BRAINS CMAKE_OSX_RPATH default no longer matched the Slicer default [1].

Due to this setting, the RPATH for BRAINS libraries was not being
detected and replaced correctly by the Slicer fixup_bundle procedure.

Specifically, as far as I can tell, having a pre-set `@rpath` in the
installed libraries caused the fixup_bundle procedure to copy the
(fixed) libraries into the `Slicer-4.5` base directory, rather than
fixing in-place the libraries in `Slicer-4.5/cli-modules`. This caused
two copies of the libraries to be included in the distribution bundle
[2], one of which was un-patched. This un-patched version is referred
to by all *other* libraries, causing dlopen failures. The end result
is that BRAINS could not be used in shared-library mode on Mac [3].

See:
  [1] https://github.com/Slicer/ITK/commit/8ac0d6013b76238f9d84de906c14b493addf8ac8
  [2] http://www.na-mic.org/Bug/view.php?id=4041
  [3] http://massmail.spl.harvard.edu/public-archives/slicer-users/2016/010782.html