### PR TITLE
ENH: Added GenerateEdgeMapImage for super resolution

### DIFF
--- a/BRAINSSuperResolution/BRAINSSuperResolutionCommonLib.h.in
+++ b/BRAINSSuperResolution/BRAINSSuperResolutionCommonLib.h.in
@@ -1,0 +1,13 @@
+/*
+ * Here is where system computed values get stored.
+ * These values should only change when the target compile platform changes.
+ */
+
+#if defined(WIN32) && !defined(BRAINSSUPERRESOLUTIONCOMMONLIB_STATIC)
+#pragma warning ( disable : 4275 )
+#endif
+
+#cmakedefine BUILD_SHARED_LIBS
+#ifndef BUILD_SHARED_LIBS
+#define BRAINSSUPERRESOLUTIONCOMMONLIB_STATIC
+#endif

--- a/BRAINSSuperResolution/CMakeLists.txt
+++ b/BRAINSSuperResolution/CMakeLists.txt
@@ -1,0 +1,46 @@
+
+##- project(BRAINSSuperResolution)
+
+#-----------------------------------------------------------------------------
+# Dependencies.
+#
+
+#
+# ITK
+#
+
+FindITKUtil(BRAINSSuperResolution_ITK
+  ITKImageFilterBase
+  ITKImageFunction
+  ITKImageGrid
+  ITKImageGradient
+  ITKImageIntensity
+  ITKImageSources
+  ITKImageStatistics
+  ITKThresholding
+  ITKTransform
+  ITKImageCompare
+  ITKTestKernel
+)
+
+#-----------------------------------------------------------------------------
+# Output directories.
+#
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/BRAINSSuperResolutionCommonLib.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/BRAINSSuperResolutionCommonLib.h
+  )
+
+set(ALL_PROGS_LIST
+  GenerateEdgeMapImage
+  #BRAINSSuperResolution
+  )
+foreach(prog ${ALL_PROGS_LIST})
+  StandardBRAINSBuildMacro(NAME ${prog} TARGET_LIBRARIES BRAINSCommonLib )
+endforeach()
+
+### Add the Testing Subdirectory.
+#if(BUILD_TESTING AND NOT BRAINSTools_DISABLE_TESTING)
+#  add_subdirectory(TestSuite)
+#endif()

--- a/BRAINSSuperResolution/GenerateEdgeMapImage.cxx
+++ b/BRAINSSuperResolution/GenerateEdgeMapImage.cxx
@@ -1,0 +1,164 @@
+/*=========================================================================
+ *
+ *  Copyright SINAPSE: Scalable Informatics for Neuroscience, Processing and Software Engineering
+ *            The University of Iowa
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+/*
+ * \author: Ali Ghayoor
+ * at SINAPSE Lab,
+ * The University of Iowa 2016
+ */
+
+#include <iostream>
+#include <itkImageFileReader.h>
+#include <itkImageFileWriter.h>
+#include <itkDivideImageFilter.h>
+
+#include "GenerateMaxGradientImage.h"
+
+#include "GenerateEdgeMapImageCLP.h"
+#include <BRAINSCommonLib.h>
+
+int main( int argc, char * argv[] )
+{
+  PARSE_ARGS;
+
+  const unsigned int Dim = 3;
+
+  typedef itk::Image<float, Dim>                  FloatImageType;
+  typedef FloatImageType::Pointer                 FloatImagePointer;
+  typedef std::vector<FloatImagePointer>          InputImageList;
+  typedef itk::ImageFileReader<FloatImageType>    ImageReaderType;
+  typedef itk::Image<unsigned char, Dim>          CharImageType;
+  typedef itk::ImageFileReader<CharImageType>     MaskReaderType;
+
+  if( outputEdgeMap.compare( "" ) == 0 &&
+      outputMaximumGradientImage.compare( "" ) == 0 )
+    {
+    std::cerr << "ERROR: No output image is specified!" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  std::vector<std::string> inputMRFileNames;
+  if( inputMRVolumes.size() > 0 )
+    {
+    inputMRFileNames = inputMRVolumes;
+    }
+  else
+    {
+    std::cerr << "ERROR: At least one MR image modality is needed "
+              << "to generate the maximum gradient image and edgemap image."
+              << std::endl;
+    return EXIT_FAILURE;
+    }
+  const unsigned int numberOfMRImages = inputMRFileNames.size(); // number of modality images
+
+  // Read the input MR modalities and set them in a vector of images
+  typedef ImageReaderType::Pointer             LocalReaderPointer;
+
+  InputImageList inputMRImageModalitiesList;
+  for( unsigned int i = 0; i < numberOfMRImages; i++ )
+    {
+    std::cout << "Reading image: " << inputMRFileNames[i] << std::endl;
+    LocalReaderPointer imgreader = ImageReaderType::New();
+    imgreader->SetFileName( inputMRFileNames[i].c_str() );
+    try
+      {
+      imgreader->Update();
+      }
+    catch( ... )
+      {
+      std::cerr << "ERROR:  Could not read image " << inputMRFileNames[i] << "." << std::endl;
+      return EXIT_FAILURE;
+      }
+    inputMRImageModalitiesList.push_back( imgreader->GetOutput() );
+    }
+
+  CharImageType::Pointer mask;
+  if( inputMask.compare( "" ) != 0 )
+    {
+    MaskReaderType::Pointer maskreader = MaskReaderType::New();
+    maskreader->SetFileName( inputMask );
+    try
+      {
+      maskreader->Update();
+      }
+    catch( ... )
+      {
+      std::cerr << "ERROR:  Could not read mask " << inputMask << "." << std::endl;
+      return EXIT_FAILURE;
+      }
+    mask = maskreader->GetOutput();
+    }
+
+  // Create maximum gradient image using the input structural MR images.
+  CharImageType::Pointer MGI = GenerateMaxGradientImage<
+    FloatImageType,CharImageType,CharImageType>(inputMRImageModalitiesList,
+                                                lowerPercentileMatching,
+                                                upperPercentileMatching,
+                                                minimumOutputRange,
+                                                maximumOutputRange,
+                                                mask);
+
+  if( outputMaximumGradientImage.compare( "" ) != 0 )
+    {
+    typedef itk::ImageFileWriter<CharImageType> WriterType;
+    WriterType::Pointer writer = WriterType::New();
+    writer->UseCompressionOn();
+    writer->SetFileName( outputMaximumGradientImage );
+    writer->SetInput( MGI );
+    try
+      {
+      writer->Update();
+      }
+    catch( itk::ExceptionObject & exp )
+      {
+      std::cerr << "ExceptionObject with writer" << std::endl;
+      std::cerr << exp << std::endl;
+      return EXIT_FAILURE;
+      }
+    }
+
+  // EdgeMap is created as the inverse of Maximum Gradient Image
+  typedef itk::DivideImageFilter <FloatImageType, CharImageType, FloatImageType> DivideImageFilterType;
+
+  DivideImageFilterType::Pointer divideImageFilter = DivideImageFilterType::New ();
+  divideImageFilter->SetInput1( 1.0 );
+  divideImageFilter->SetInput2( MGI );
+  divideImageFilter->Update();
+  FloatImageType::Pointer edgeMap = divideImageFilter->GetOutput();
+
+  if( outputEdgeMap.compare( "" ) != 0 )
+    {
+    typedef itk::ImageFileWriter<FloatImageType> WriterType;
+    WriterType::Pointer writer = WriterType::New();
+    writer->UseCompressionOn();
+    writer->SetFileName( outputEdgeMap );
+    writer->SetInput( edgeMap );
+    try
+      {
+      writer->Update();
+      }
+    catch( itk::ExceptionObject & exp )
+      {
+      std::cerr << "ExceptionObject with writer" << std::endl;
+      std::cerr << exp << std::endl;
+      return EXIT_FAILURE;
+      }
+    }
+
+  return EXIT_SUCCESS;
+}

--- a/BRAINSSuperResolution/GenerateEdgeMapImage.xml
+++ b/BRAINSSuperResolution/GenerateEdgeMapImage.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<executable>
+  <category>SuperResolution</category>
+  <title>GenerateEdgeMapImage</title>
+  <description>Inverse of Maximum Gradient Image</description>
+  <version>4.7.0</version>
+  <documentation-url></documentation-url>
+  <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt</license>
+  <contributor>Ali Ghayoor</contributor>
+  <acknowledgements></acknowledgements>
+  <parameters>
+    <image multiple="true">
+      <name>inputMRVolumes</name>
+      <longflag>inputMRVolumes</longflag>
+      <label>Input structural MR volumes to create the maximum edgemap</label>
+      <channel>input</channel>
+      <description>Input image files names</description>
+    </image>
+    <image>
+      <name>inputMask</name>
+      <longflag>inputMask</longflag>
+      <description>Input mask file name. If set, image histogram percentiles will be calculated within the mask</description>
+      <channel>input</channel>
+    </image>
+    <image fileExtensions=".nii.gz,.nrrd">
+      <name>outputMaximumGradientImage</name>
+      <longflag>outputMaximumGradientImage</longflag>
+      <description>output gradient image file name</description>
+      <channel>output</channel>
+    </image>
+    <image fileExtensions=".nii.gz,.nrrd">
+      <name>outputEdgeMap</name>
+      <longflag>outputEdgeMap</longflag>
+      <description>output edgemap file name</description>
+      <channel>output</channel>
+    </image>
+    <double>
+      <name>lowerPercentileMatching</name>
+      <longflag>lowerPercentileMatching</longflag>
+      <label>Lower percentile</label>
+      <description>Map lower quantile and below to minOutputRange. It should be a value between zero and one.</description>
+      <default>0.5</default>
+    </double>
+    <double>
+      <name>upperPercentileMatching</name>
+      <longflag>upperPercentileMatching</longflag>
+      <label>Upper percentile</label>
+      <description>Map upper quantile and above to maxOutputRange. It should be a value between zero and one.</description>
+      <default>0.95</default>
+    </double>
+    <integer>
+      <name>minimumOutputRange</name>
+      <longflag>minimumOutputRange</longflag>
+      <label>Minimum Output Range</label>
+      <description>Map lower quantile and below to minimum output range. It should be an epsilon number greater than zero. Default is 1.</description>
+      <default>1</default>
+    </integer>
+    <integer>
+      <name>maximumOutputRange</name>
+      <longflag>maximumOutputRange</longflag>
+      <label>Maximum Output Range</label>
+      <description>Map upper quantile and above to maximum output range. Default is 255 that is the maximum range of unsigned char.</description>
+      <default>255</default>
+    </integer>
+    <integer>
+      <name>numberOfThreads</name>
+      <longflag deprecatedalias="debugNumberOfThreads" >numberOfThreads</longflag>
+      <label>Number Of Threads</label>
+      <description>Explicitly specify the maximum number of threads to use.</description>
+      <default>-1</default>
+    </integer>
+  </parameters>
+</executable>

--- a/BRAINSSuperResolution/GenerateMaxGradientImage.h
+++ b/BRAINSSuperResolution/GenerateMaxGradientImage.h
@@ -1,0 +1,220 @@
+/*=========================================================================
+ *
+ *  Copyright SINAPSE: Scalable Informatics for Neuroscience, Processing and Software Engineering
+ *            The University of Iowa
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+/*
+ * Author: Ali Ghayoor
+ * at SINAPSE Lab,
+ * The University of Iowa 2016
+ */
+
+#ifndef __GenerateMaxGradientImage_h
+#define __GenerateMaxGradientImage_h
+
+#include "itkGradientMagnitudeImageFilter.h"
+#include "itkLabelStatisticsImageFilter.h"
+#include "itkMinimumMaximumImageCalculator.h"
+#include "itkIntensityWindowingImageFilter.h"
+#include "itkMaximumImageFilter.h"
+#include "itkTimeProbe.h"
+#include <vector>
+
+// Class to print the proper exception message
+class EmptyVectorException
+{
+public:
+  EmptyVectorException(const char* pStr = "The list of input images was empty.  Nothing to find maximum!") :
+    pMessage(pStr)
+    {
+    }
+
+  const char * what() const
+  {
+  return pMessage;
+  }
+
+private:
+  const char * pMessage;
+};
+
+// Auxiliary function to find the maximum of the rescaled gradient image list
+template <typename TImage>
+typename TImage::Pointer
+MaxOfImageList(const std::vector<typename TImage::Pointer> & inputImageList) // inputImageList = rescaledGradientImageList
+{
+  typedef itk::MaximumImageFilter<TImage, TImage, TImage>   MaximumFilterType;
+
+  if( inputImageList.empty() )
+    {
+    // No images, something went wrong.
+    throw EmptyVectorException();
+    }
+  if( inputImageList.size() == 1 )
+    {
+    // Only one image, no need to find maximum image.
+    return inputImageList[0];
+    }
+
+  // Initialize the maximum image with the first image in the list
+  typename TImage::Pointer maxImage = inputImageList[0];
+
+  for(unsigned int i = 1; i < inputImageList.size(); ++i)
+     {
+     typename MaximumFilterType::Pointer myMax = MaximumFilterType::New();
+     myMax->SetInput1( maxImage );
+     myMax->SetInput2( inputImageList[i] );
+     try
+       {
+       myMax->Update();
+       }
+     catch( itk::ExceptionObject & exp )
+       {
+       std::cerr << "ExceptionObject with Iterator" << std::endl;
+       std::cerr << exp << std::endl;
+       }
+     maxImage = myMax->GetOutput();
+     }
+
+  return maxImage;
+}
+
+/*
+ * Main function to generate the maximum gradient image.
+ * Weak edges (whose gradients are less than %50 quantile) are set to minOutputRange (1).
+ * Strong edges (whose gradients are more than %95 quantile) are set to maxOutputRange(255).
+ *
+ *** NOTE ***
+ * All input images and the input mask must be in the same voxel space
+ ************
+ */
+template <class InputImageType, class OutputImageType, class MaskImageType>
+typename OutputImageType::Pointer
+GenerateMaxGradientImage(const std::vector<typename InputImageType::Pointer> & inputImages,
+                         const float LowerPercentileMatching, // Map lower quantile and below to minOutputRange
+                         const float UpperPercentileMatching, // Map upper quantile and above to maxOutputRange
+                         const unsigned int minOutputRange,   // epsilon
+                         const unsigned int maxOutputRange,
+                         typename MaskImageType::Pointer mask = NULL)
+{
+  std::cout << "Generating maximum gradient image..." << std::endl;
+  std::cout << "[LowerQuantile UpperQuantile] = [" << LowerPercentileMatching << " " << UpperPercentileMatching << "]" << std::endl;
+  std::cout << "[minOutputRange maxOutputRange] [" << minOutputRange << " " << maxOutputRange << "]" << std::endl;
+
+  typedef itk::GradientMagnitudeImageFilter<InputImageType, InputImageType>   GradientFilterType;
+  typedef itk::MinimumMaximumImageCalculator<InputImageType>                  MinMaxCalculatorType;
+  typedef itk::LabelStatisticsImageFilter<InputImageType, MaskImageType>      LabelStatisticsImageFilter;
+  typedef typename itk::IntensityWindowingImageFilter<InputImageType,
+                                                      OutputImageType>        WindowRescalerType;
+  typedef std::vector<typename OutputImageType::Pointer>                      RescaledImageGradientVectorType;
+
+  itk::TimeProbe MaxGradientImageTimer;
+  MaxGradientImageTimer.Start();
+
+  const unsigned int numberOfImageModalities =
+    inputImages.size(); // number of modality images
+
+  // list of rescaled gradient magnitude images
+  RescaledImageGradientVectorType rescaledGradientImageList( numberOfImageModalities );
+
+  const typename MaskImageType::PixelType maskInteriorLabel = 1;
+  typename MaskImageType::Pointer internalMask;
+  if( mask.IsNull() )
+    {
+    internalMask = MaskImageType::New();
+    internalMask->CopyInformation( inputImages[0] );
+    internalMask->SetRegions( inputImages[0]->GetLargestPossibleRegion() );
+    internalMask->Allocate();
+    internalMask->FillBuffer( maskInteriorLabel );
+    }
+  else
+    {
+    internalMask = mask;
+    }
+
+  for( size_t i = 0; i < numberOfImageModalities; i++ )
+     {
+     typename GradientFilterType::Pointer gradientFilter = GradientFilterType::New();
+     gradientFilter->SetInput( inputImages[i] );
+     gradientFilter->Update();
+
+     typename MinMaxCalculatorType::Pointer myMinMax = MinMaxCalculatorType::New();
+     myMinMax->SetImage( gradientFilter->GetOutput() );
+     myMinMax->Compute();
+     typename InputImageType::PixelType imgMin = myMinMax->GetMinimum();
+     typename InputImageType::PixelType imgMax = myMinMax->GetMaximum();
+
+     int numBins = vnl_math_rnd(imgMax - imgMin + 1);
+     if( numBins < 256 )
+       {
+       numBins = 256;
+       }
+
+     typename LabelStatisticsImageFilter::Pointer maskedStatistics = LabelStatisticsImageFilter::New();
+     maskedStatistics->SetInput( gradientFilter->GetOutput() );
+     maskedStatistics->SetLabelInput( internalMask );
+     maskedStatistics->UseHistogramsOn();
+     maskedStatistics->SetHistogramParameters(numBins, imgMin, imgMax);
+     maskedStatistics->Update();
+     typename LabelStatisticsImageFilter::HistogramType::Pointer hist =
+       maskedStatistics->GetHistogram( maskInteriorLabel );
+     if( hist.IsNull() )
+       {
+       itkGenericExceptionMacro("histogram had no value for label "
+                                << maskInteriorLabel);
+       }
+
+     /*
+     // maximum is defined such that (Max - Epsilon)/2 = Q(%85)
+     unsigned int maxOutputRange = 2 * hist->Quantile(0, 0.85F) + minOutputRange;
+     if( maxOutputRange > 255 )
+       {
+       maxOutputRange = 255;
+       }
+     */
+
+     typename WindowRescalerType::Pointer intensityMapper = WindowRescalerType::New();
+     intensityMapper->SetInput( maskedStatistics->GetOutput() );
+     intensityMapper->SetOutputMinimum( minOutputRange );
+     intensityMapper->SetOutputMaximum( maxOutputRange );
+     intensityMapper->SetWindowMinimum( hist->Quantile(0, LowerPercentileMatching) );
+     intensityMapper->SetWindowMaximum( hist->Quantile(0, UpperPercentileMatching) );
+     intensityMapper->Update();
+
+     rescaledGradientImageList[i] = intensityMapper->GetOutput();
+     }
+
+  typename OutputImageType::Pointer maxGradientImage = MaxOfImageList<OutputImageType>(rescaledGradientImageList);
+/*
+  // Another rescaling was needed if we were computing summed gradient image.
+  typedef itk::IntensityWindowingImageFilter<OutputImageType,
+                                             OutputImageType>           RescaleFilterType;
+  typename RescaleFilterType::Pointer outputRescaler = RescaleFilterType::New();
+  outputRescaler->SetOutputMinimum(0);
+  outputRescaler->SetOutputMaximum(255);
+  outputRescaler->SetInput( maxGradientImage );
+  outputRescaler->Update();
+*/
+  MaxGradientImageTimer.Stop();
+  itk::RealTimeClock::TimeStampType elapsedTime = MaxGradientImageTimer.GetTotal();
+  std::cout << "Generating maximum gradient image took " << elapsedTime
+            << " " << MaxGradientImageTimer.GetUnit() << "." << std::endl;
+
+  //return outputRescaler->GetOutput();
+  return maxGradientImage;
+}
+
+#endif // __GenerateMaxGradientImage_h

--- a/BRAINSTools.cmake
+++ b/BRAINSTools.cmake
@@ -203,6 +203,7 @@ set(brains_modulenames
   AutoWorkup
   BRAINSDWICleanup
   ReferenceAtlas
+  BRAINSSuperResolution
   )
 
 if(USE_DebugImageViewer)

--- a/Common.cmake
+++ b/Common.cmake
@@ -94,6 +94,7 @@ bt_option(USE_ConvertBetweenFileFormats      "Build ConvertBetweenFileFormats"  
 bt_option(USE_BRAINSDWICleanup               "Build BRAINSDWICleanup"               ON)
 bt_option(USE_BRAINSCreateLabelMapFromProbabilityMaps "Build BRAINSCreateLabelMapFromProbabilityMaps" OFF)
 bt_option(USE_BRAINSSnapShotWriter           "Build BRAINSSnapShotWriter"           ON)
+bt_option(USE_BRAINSSuperResolution          "Build BRAINSSuperResolution"          OFF)
 
 if(CMAKE_CXX_STANDARD LESS 11)
   bt_option(USE_BRAINSABC                      "Build BRAINSABC"                      OFF)


### PR DESCRIPTION
A new directory called "BRAINSSuperResolution" is added to the
BRAINSTools. This directory can be the home of an under-developing tool
for super resolution reconstruction of 3D volumes that is applicable to
4D DWI images.

First step of super resolution reconstruction through a weighted TV
approach is creating an edgemap from available high resolution
modalities.

A new program called "GenerateEdgeMapImage" is added.
Usage:

GenerateEdgeMapImage  \
--inputMRVolumes {list of input MR volumes in higher spatial resolution}
--lowerPercentileMatching 0.50 \
--upperPercentileMatching 0.95
--maximumOutputRange 255 \
--minimumOutputRange 1 \
--inputMask {If set, image histogram percentiles will be calculated
  within the mask} \
--outputEdgeMap EdgeMap.nrrd \
--outputMaximumGradientImage MaximumGradientImage.nrrd