### PR TITLE
Proposed (DWIConvert, BRAINSDWICleanup) module XML update

### DIFF
--- a/BRAINSDWICleanup/BRAINSDWICleanup.xml
+++ b/BRAINSDWICleanup/BRAINSDWICleanup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
-  <category>Diffusion.Diffusion Weighted Images</category>
+  <category>Diffusion.Utilities</category>
   <title>BRAINSDWICleanup</title>
 
   <description>Remove bad gradients/volumes from DWI NRRD file.</description>

--- a/DWIConvert/DWIConvert.xml
+++ b/DWIConvert/DWIConvert.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
-  <category>Diffusion.Diffusion Data Conversion</category>
-  <title>DWIConverter</title>
-  <description><![CDATA[Converts diffusion weighted MR images in dicom series into Nrrd format for analysis in Slicer. This program has been tested on only a limited subset of DTI dicom formats available from Siemens, GE, and Phillips scanners. Work in progress to support dicom multi-frame data. The program parses dicom header to extract necessary information about measurement frame, diffusion weighting directions, b-values, etc, and write out a nrrd image. For non-diffusion weighted dicom images, it loads in an entire dicom series and writes out a single dicom volume in a .nhdr/.raw pair.]]></description>
+  <category>Diffusion.Import and Export</category>
+  <title>Diffusion-weighted DICOM Import (DWIConvert)</title>
+  <description><![CDATA[Converts diffusion weighted MR images in DICOM series into NRRD format for analysis in Slicer. This program has been tested on only a limited subset of DTI DICOM formats available from Siemens, GE, and Philips scanners. Work in progress to support DICOM multi-frame data. The program parses DICOM header to extract necessary information about measurement frame, diffusion weighting directions, b-values, etc, and write out a NRRD image. For non-diffusion weighted DICOM images, it loads in an entire DICOM series and writes out a single dicom volume in a .nhdr/.raw pair.]]></description>
   <version>4.7.1</version>
   <documentation-url>http://wiki.slicer.org/slicerWiki/index.php/Documentation/4.5/Modules/DWIConverter</documentation-url>
   <license>Apache License Version 2.0</license>


### PR DESCRIPTION
We're working on organizing/cleaning-up the DMRI-related module categories and names in Slicer, the current module ordering and names in the GUI was difficult to follow. cc @ljod

before:
![image](https://cloud.githubusercontent.com/assets/327706/17447577/29f366da-5b1d-11e6-80da-69ecc90a10bc.png)

after:
![image](https://cloud.githubusercontent.com/assets/327706/17447609/6349ff52-5b1d-11e6-9712-a1738f5f599a.png)

