### PR TITLE
ENH: register dcmtk codecs at startup

### DIFF
--- a/DWIConvert/DWIConvert.cxx
+++ b/DWIConvert/DWIConvert.cxx
@@ -74,6 +74,10 @@ DICOM Data Dictionary: http://medical.nema.org/Dicom/2011/11_06pu.pdf
 #include <BRAINSCommonLib.h>
 
 #include "dcmtk/oflog/helpers/loglog.h"
+#include "dcmtk/dcmimgle/dcmimage.h"
+#include "dcmtk/dcmjpeg/djdecode.h"
+#include "dcmtk/dcmjpls/djdecode.h"
+#include "dcmtk/dcmdata/dcrledrg.h"
 
 /** the DICOM datasets are read as 3D volumes, but they need to be
  *  written as 4D volumes for image types other than NRRD.
@@ -203,6 +207,13 @@ int main(int argc, char *argv[])
   const std::string version = commandLine.getVersion();
   BRAINSRegisterAlternateIO();
   dcmtk::log4cplus::helpers::LogLog::getLogLog()->setQuietMode(true);
+
+  // register DCMTK codecs, otherwise they will not be available when
+  // `itkDCMTKSeriesFileNames` is used to build a list of filenames,
+  // so reading series with JPEG transfer syntax will fail.
+  DJDecoderRegistration::registerCodecs();
+  DcmRLEDecoderRegistration::registerCodecs();
+
   // just need one instance to do double to string conversions
   itk::NumberToString<double> DoubleConvert;
 


### PR DESCRIPTION
Allows to convert DICOM series encoded with JPEG transfer syntax. ITK only registers these in one place (ITK::DCMTKImageIO), and that is too late for DWIConvert because it uses itkDCMTKSeriesFileNames to make a file list before directly (re-)reading the files.

Please see discussion: http://slicer-users.65878.n3.nabble.com/DWI-to-DTI-convertion-td4031356.html