### PR TITLE
Add link to Slicer docs in DWIConvert README

### DIFF
--- a/DWIConvert/README.md
+++ b/DWIConvert/README.md
@@ -1,3 +1,5 @@
+Please see [DWIConvert documentation](https://www.slicer.org/wiki/Documentation/Nightly/Modules/DWIConverter) on the Slicer wiki.
+
 This is a replacement project for the
 historical DicomToNrrd program.  There
 are many new features in this program, including
@@ -5,4 +7,3 @@ support for multiframe data, more compliance across
 a variety of scanner manufacturers, extensive testing,
 and support for both nifti and fsl formatting image
 conversions.
-


### PR DESCRIPTION
This is one of the top search results for `DWIConvert`, so probably useful to have a link.