### PR TITLE
Support itk scalar image DWIConvert Version

### DIFF
--- a/BRAINSCommonLib/DWIMetaDataDictionaryValidator.cxx
+++ b/BRAINSCommonLib/DWIMetaDataDictionaryValidator.cxx
@@ -64,7 +64,8 @@ DWIMetaDataDictionaryValidator::RotationMatrixType DWIMetaDataDictionaryValidato
 {
   RotationMatrixType myRM;
   std::vector<std::vector<double> > retval;
-  itk::ExposeMetaData<std::vector<std::vector<double> > >(m_dict, "NRRD_measurement frame", retval);
+  //itk::ExposeMetaData<std::vector<std::vector<double> > >(m_dict, "NRRD_measurement frame", retval);
+  itk::ExposeMetaData<std::vector<std::vector<double> > >(m_dict, "measurement frame", retval);
   if (retval.size() != 0)
     {
       for (size_t r = 0; r < myRM.RowDimensions; ++r)

--- a/BRAINSCommonLib/DWIMetaDataDictionaryValidator.cxx
+++ b/BRAINSCommonLib/DWIMetaDataDictionaryValidator.cxx
@@ -64,8 +64,7 @@ DWIMetaDataDictionaryValidator::RotationMatrixType DWIMetaDataDictionaryValidato
 {
   RotationMatrixType myRM;
   std::vector<std::vector<double> > retval;
-  //itk::ExposeMetaData<std::vector<std::vector<double> > >(m_dict, "NRRD_measurement frame", retval);
-  itk::ExposeMetaData<std::vector<std::vector<double> > >(m_dict, "measurement frame", retval);
+  itk::ExposeMetaData<std::vector<std::vector<double> > >(m_dict, "NRRD_measurement frame", retval);
   if (retval.size() != 0)
     {
       for (size_t r = 0; r < myRM.RowDimensions; ++r)

--- a/DWIConvert/Convert4DImageTo3DSeries.cxx
+++ b/DWIConvert/Convert4DImageTo3DSeries.cxx
@@ -40,11 +40,11 @@ int main( int argc, char * argv[] )
   const std::string outputPrefix( argv[2] );
 
   typedef float                               PixelValueType;
-  typedef itk::Image<PixelValueType, 4>       Volume4DType;
-  typedef itk::Image<PixelValueType, 3>       Volume3DType;
+  typedef itk::Image<PixelValueType, 4>       ScalarImage4DType;
+  typedef itk::Image<PixelValueType, 3>       ScalarImage3DType;
 
   std::cout << "- Read image: " << input4Dimage << std::endl;
-  typedef itk::ImageFileReader<Volume4DType> Image4DReaderType;
+  typedef itk::ImageFileReader<ScalarImage4DType> Image4DReaderType;
   Image4DReaderType::Pointer image4DReader = Image4DReaderType::New();
   image4DReader->SetFileName( input4Dimage );
   try
@@ -56,27 +56,27 @@ int main( int argc, char * argv[] )
     std::cerr << "Exception thrown while reading the image" << std::endl;
     std::cerr << excp << std::endl;
     }
-  Volume4DType::Pointer inputVol = image4DReader->GetOutput();
+  ScalarImage4DType::Pointer inputVol = image4DReader->GetOutput();
 
   // "inputVol" is read as a 4D image. Here we extract each 3D component and write that to disk
   //
-  Volume4DType::SizeType inputSize =
+  ScalarImage4DType::SizeType inputSize =
     inputVol->GetLargestPossibleRegion().GetSize();
 
-  Volume4DType::IndexType inputIndex =
+  ScalarImage4DType::IndexType inputIndex =
     inputVol->GetLargestPossibleRegion().GetIndex();
 
   const unsigned int volumeCount = inputSize[3];
 
-  typedef itk::ExtractImageFilter< Volume4DType, Volume3DType > ExtractFilterType;
+  typedef itk::ExtractImageFilter< ScalarImage4DType, ScalarImage3DType > ExtractFilterType;
 
   for( size_t componentNumber = 0; componentNumber < volumeCount; ++componentNumber )
     {
-    Volume4DType::SizeType extractSize = inputSize;
+    ScalarImage4DType::SizeType extractSize = inputSize;
     extractSize[3] = 0;
-    Volume4DType::IndexType extractIndex = inputIndex;
+    ScalarImage4DType::IndexType extractIndex = inputIndex;
     extractIndex[3] = componentNumber;
-    Volume4DType::RegionType extractRegion(extractIndex, extractSize);
+    ScalarImage4DType::RegionType extractRegion(extractIndex, extractSize);
 
     ExtractFilterType::Pointer extracter = ExtractFilterType::New();
     extracter->SetExtractionRegion( extractRegion );
@@ -91,7 +91,7 @@ int main( int argc, char * argv[] )
 
     std::cout << "- Write image: " << fn << std::endl;
 
-    typedef itk::ImageFileWriter<Volume3DType> Image3DWriterType;
+    typedef itk::ImageFileWriter<ScalarImage3DType> Image3DWriterType;
     Image3DWriterType::Pointer image3DWriter = Image3DWriterType::New();
     image3DWriter->SetFileName( fn );
     image3DWriter->SetInput( extracter->GetOutput() );

--- a/DWIConvert/DWIConvertLib.cxx
+++ b/DWIConvert/DWIConvertLib.cxx
@@ -178,11 +178,12 @@ int DWIConvert::write(const std::string& outputVolume)
   if( "FSL" == getOutputFileType())
   {
 
-    //VectorVolumeType::PointType origin3D = m_converter->GetDiffusionVolume()->GetOrigin();
+    //Vector3DType::PointType origin3D = m_converter->GetDiffusionVolume()->GetOrigin();
     Volume4DType::Pointer img4D = m_converter->OrientForFSLConventions();
     //Volume4DType::PointType origin4D = img4D->GetOrigin();
     // write the image */
-    m_converter->WriteFSLFormattedFileSet(outputVolumeHeaderName, m_outputBValues, m_outputBVectors, img4D);
+    //m_converter->WriteFSLFormattedFileSet(outputVolumeHeaderName, m_outputBValues, m_outputBVectors, img4D);
+    m_converter->WriteFSLFormattedFileSet(outputVolumeHeaderName, m_outputBValues, m_outputBVectors);
   }
   else if ("Nrrd" == getOutputFileType())
   {

--- a/DWIConvert/DWIConvertLib.cxx
+++ b/DWIConvert/DWIConvertLib.cxx
@@ -178,12 +178,14 @@ int DWIConvert::write(const std::string& outputVolume)
   if( "FSL" == getOutputFileType())
   {
 
-    //VectorImage3DType::PointType origin3D = m_converter->GetDiffusionVolume()->GetOrigin();
     ScalarImage4DType::Pointer img4D = m_converter->OrientForFSLConventions();
-    //ScalarImage4DType::PointType origin4D = img4D->GetOrigin();
-    // write the image */
+
+    // write the scalar image 4D format*/
     //m_converter->WriteFSLFormattedFileSet(outputVolumeHeaderName, m_outputBValues, m_outputBVectors, img4D);
-    m_converter->WriteFSLFormattedFileSet(outputVolumeHeaderName, m_outputBValues, m_outputBVectors);
+
+    //write the vectorImage 3D format
+    VectorImage3DType::Pointer vectorImage3D = convertScalarImage4DToVectorImage3D(img4D);
+    m_converter->WriteFSLFormattedFileSet(outputVolumeHeaderName, m_outputBValues, m_outputBVectors, vectorImage3D);
   }
   else if ("Nrrd" == getOutputFileType())
   {

--- a/DWIConvert/DWIConvertLib.cxx
+++ b/DWIConvert/DWIConvertLib.cxx
@@ -290,12 +290,15 @@ DWIConverter * DWIConvert::CreateDicomConverter(
 void DWIConvert::setInputFileType(const std::string& inputVolume, const std::string& inputDicomDirectory){
   m_inputVolume = inputVolume;
   m_inputDicomDirectory = inputDicomDirectory;
-  if ("" == m_inputDicomDirectory){
+  if ("" == m_inputDicomDirectory && "" != m_inputVolume){
     std::string inputExt = findFilenameExt(m_inputVolume);
     if (".nii" == inputExt) m_inputFileType = "FSL";
-    if (".nrrd" == inputExt || ".nhdr" == inputExt) m_inputFileType = "Nrrd";
+    else if (".nrrd" == inputExt || ".nhdr" == inputExt) m_inputFileType = "Nrrd";
+    else {
+      std::cerr <<"Error: file type of inputVoume is not supported currently"<<std::endl;
+    }
   }
-  else if ("" == m_inputVolume)
+  else if ("" != m_inputDicomDirectory)
   {
     m_inputFileType = "Dicom";
   }
@@ -340,8 +343,13 @@ std::string DWIConvert::getConversionMode()
 
 //{ ".nii", ".nii.gz", ".nhdr", ".nrrd"}
 std::string DWIConvert::findFilenameExt(const std::string filename){
+    std::string subStr = "";
     std::string::size_type pos = filename.rfind(".");
-    std::string subStr = filename.substr(pos);
+    if (std::string::npos == pos){
+        std::cerr<<"Error: incorrect filename to seek extention name. "<< std::endl;
+        return subStr;
+    }
+    subStr = filename.substr(pos);
     if (".gz" == subStr){
         subStr = filename.substr(pos-4,4);
     }

--- a/DWIConvert/DWIConvertLib.cxx
+++ b/DWIConvert/DWIConvertLib.cxx
@@ -9,7 +9,7 @@
 #include "dcmtk/dcmjpeg/djdecode.h"
 #include "dcmtk/dcmjpls/djdecode.h"
 #include "dcmtk/dcmdata/dcrledrg.h"
-
+#include "itksys/SystemTools.hxx"
 
 
 DWIConvert::DWIConvert()
@@ -284,16 +284,14 @@ DWIConverter * DWIConvert::CreateDicomConverter(
   return converter;
 }
 
-//one of ["DicomToNrrd", "DicomToFSL", "NrrdToFSL", "FSLToNrrd", "NrrdToNrrd", "FSLToFSL"]
-//if return "", invalidate input parameters.
-
+//currently supported file types: { ".nii", ".nii.gz", ".nhdr", ".nrrd"}
 void DWIConvert::setInputFileType(const std::string& inputVolume, const std::string& inputDicomDirectory){
   m_inputVolume = inputVolume;
   m_inputDicomDirectory = inputDicomDirectory;
   if ("" == m_inputDicomDirectory && "" != m_inputVolume){
-    std::string inputExt = findFilenameExt(m_inputVolume);
-    if (".nii" == inputExt) m_inputFileType = "FSL";
-    else if (".nrrd" == inputExt || ".nhdr" == inputExt) m_inputFileType = "Nrrd";
+    std::string inputExt = itksys::SystemTools::GetFilenameExtension(m_inputVolume);
+    if ( std::string::npos != inputExt.rfind(".nii")) m_inputFileType = "FSL";
+    else if (std::string::npos != inputExt.rfind(".nrrd") || std::string::npos != inputExt.rfind(".nhdr")) m_inputFileType = "Nrrd";
     else {
       std::cerr <<"Error: file type of inputVoume is not supported currently"<<std::endl;
     }
@@ -309,9 +307,9 @@ void DWIConvert::setInputFileType(const std::string& inputVolume, const std::str
 
 void DWIConvert::setOutputFileType(const std::string& outputVolume){
   m_outputVolume = outputVolume;
-  std::string outputExt = findFilenameExt(m_outputVolume);
-  if (".nii" == outputExt) m_outputFileType = "FSL";
-  else if (".nrrd" == outputExt || ".nhdr" == outputExt) m_outputFileType = "Nrrd";
+  std::string outputExt = itksys::SystemTools::GetFilenameExtension(m_outputVolume);
+  if (std::string::npos != outputExt.rfind(".nii")) m_outputFileType = "FSL";
+  else if (std::string::npos != outputExt.rfind(".nrrd")|| std::string::npos != outputExt.rfind(".nhdr")) m_outputFileType = "Nrrd";
   else{
     std::cerr <<"Error: the output file type is not supported currently"<<std::endl;
   }
@@ -325,35 +323,6 @@ std::string DWIConvert::getInputFileType()
 std::string DWIConvert::getOutputFileType()
 {
   return m_outputFileType;
-}
-
-/*
-void DWIConvert::setConversionMode(const std::string conversionMode){
-    //["DicomToNrrd", "DicomToFSL", "NrrdToFSL", "FSLToNrrd","NrrdToNrrd", "FSLToFSL"]
-    m_conversionMode =  conversionMode;
-}
-
-std::string DWIConvert::getConversionMode()
-{
-  if ("" == m_conversionMode) setConversionMode();
-  return m_conversionMode;
-}
-
- */
-
-//{ ".nii", ".nii.gz", ".nhdr", ".nrrd"}
-std::string DWIConvert::findFilenameExt(const std::string filename){
-    std::string subStr = "";
-    std::string::size_type pos = filename.rfind(".");
-    if (std::string::npos == pos){
-        std::cerr<<"Error: incorrect filename to seek extention name. "<< std::endl;
-        return subStr;
-    }
-    subStr = filename.substr(pos);
-    if (".gz" == subStr){
-        subStr = filename.substr(pos-4,4);
-    }
-    return subStr;
 }
 
 const std::string &DWIConvert::getInputVolume() const {

--- a/DWIConvert/DWIConvertLib.cxx
+++ b/DWIConvert/DWIConvertLib.cxx
@@ -181,11 +181,11 @@ int DWIConvert::write(const std::string& outputVolume)
     ScalarImage4DType::Pointer img4D = m_converter->OrientForFSLConventions();
 
     // write the scalar image 4D format*/
-    //m_converter->WriteFSLFormattedFileSet(outputVolumeHeaderName, m_outputBValues, m_outputBVectors, img4D);
+    m_converter->WriteFSLFormattedFileSet(outputVolumeHeaderName, m_outputBValues, m_outputBVectors, img4D);
 
     //write the vectorImage 3D format
-    VectorImage3DType::Pointer vectorImage3D = convertScalarImage4DToVectorImage3D(img4D);
-    m_converter->WriteFSLFormattedFileSet(outputVolumeHeaderName, m_outputBValues, m_outputBVectors, vectorImage3D);
+    //VectorImage3DType::Pointer vectorImage3D = convertScalarImage4DToVectorImage3D(img4D);
+    //m_converter->WriteFSLFormattedFileSet(outputVolumeHeaderName, m_outputBValues, m_outputBVectors, vectorImage3D);
   }
   else if ("Nrrd" == getOutputFileType())
   {

--- a/DWIConvert/DWIConvertLib.cxx
+++ b/DWIConvert/DWIConvertLib.cxx
@@ -178,9 +178,9 @@ int DWIConvert::write(const std::string& outputVolume)
   if( "FSL" == getOutputFileType())
   {
 
-    //Vector3DType::PointType origin3D = m_converter->GetDiffusionVolume()->GetOrigin();
-    Volume4DType::Pointer img4D = m_converter->OrientForFSLConventions();
-    //Volume4DType::PointType origin4D = img4D->GetOrigin();
+    //VectorImage3DType::PointType origin3D = m_converter->GetDiffusionVolume()->GetOrigin();
+    ScalarImage4DType::Pointer img4D = m_converter->OrientForFSLConventions();
+    //ScalarImage4DType::PointType origin4D = img4D->GetOrigin();
     // write the image */
     //m_converter->WriteFSLFormattedFileSet(outputVolumeHeaderName, m_outputBValues, m_outputBVectors, img4D);
     m_converter->WriteFSLFormattedFileSet(outputVolumeHeaderName, m_outputBValues, m_outputBVectors);

--- a/DWIConvert/DWIConvertLib.cxx
+++ b/DWIConvert/DWIConvertLib.cxx
@@ -178,7 +178,9 @@ int DWIConvert::write(const std::string& outputVolume)
   if( "FSL" == getOutputFileType())
   {
 
+    //VectorVolumeType::PointType origin3D = m_converter->GetDiffusionVolume()->GetOrigin();
     Volume4DType::Pointer img4D = m_converter->OrientForFSLConventions();
+    //Volume4DType::PointType origin4D = img4D->GetOrigin();
     // write the image */
     m_converter->WriteFSLFormattedFileSet(outputVolumeHeaderName, m_outputBValues, m_outputBVectors, img4D);
   }

--- a/DWIConvert/DWIConvertLib.h
+++ b/DWIConvert/DWIConvertLib.h
@@ -92,7 +92,6 @@ private:
 
     std::string getInputFileType();
     std::string getOutputFileType();
-    std::string findFilenameExt(const std::string filename);
 
     DWIConverter *CreateDicomConverter(
             const std::string inputDicomDirectory,

--- a/DWIConvert/DWIConvertUtils.cxx
+++ b/DWIConvert/DWIConvertUtils.cxx
@@ -318,8 +318,8 @@ Volume4DType::Pointer Convert3DVectorVolumeTo4DVolume(VectorVolumeType::Pointer 
 VectorVolumeType::Pointer Convert4DVolumeTo3DVectorVolume(Volume4DType::Pointer inputVol)
 {
   typedef itk::Image<unsigned short,3> Volume3DType; //Used for a single 3D volume component
-// convert from image series to vector voxels
-  Volume4DType::SpacingType inputSpacing = inputVol->GetSpacing();
+  // convert from image series to vector voxels
+  //Volume4DType::SpacingType inputSpacing = inputVol->GetSpacing();
   Volume4DType::SizeType inputSize = inputVol->GetLargestPossibleRegion().GetSize();
   Volume4DType::IndexType inputIndex = inputVol->GetLargestPossibleRegion().GetIndex();
 ////////

--- a/DWIConvert/DWIConvertUtils.cxx
+++ b/DWIConvert/DWIConvertUtils.cxx
@@ -248,19 +248,19 @@ ReadBVecs(DWIMetaDataDictionaryValidator::GradientTableType & bVecs, unsigned in
   return EXIT_SUCCESS;
 }
 
-static Volume4DType::Pointer CreateEmpty4DVolume(Vector3DType::Pointer & inputVol)
+static ScalarImage4DType::Pointer CreateEmpty4DVolume(VectorImage3DType::Pointer & inputVol)
 {
-  Vector3DType::SizeType inputSize =
+  VectorImage3DType::SizeType inputSize =
           inputVol->GetLargestPossibleRegion().GetSize();
-  Vector3DType::SpacingType inputSpacing = inputVol->GetSpacing();
-  Vector3DType::PointType inputOrigin = inputVol->GetOrigin();
-  Vector3DType::DirectionType inputDirection = inputVol->GetDirection();
+  VectorImage3DType::SpacingType inputSpacing = inputVol->GetSpacing();
+  VectorImage3DType::PointType inputOrigin = inputVol->GetOrigin();
+  VectorImage3DType::DirectionType inputDirection = inputVol->GetDirection();
 
-  Volume4DType::Pointer FourDVolume = Volume4DType::New();
-  Volume4DType::SizeType volSize;
-  Volume4DType::SpacingType volSpacing;
-  Volume4DType::PointType volOrigin;
-  Volume4DType::DirectionType volDirection;
+  ScalarImage4DType::Pointer FourDVolume = ScalarImage4DType::New();
+  ScalarImage4DType::SizeType volSize;
+  ScalarImage4DType::SpacingType volSpacing;
+  ScalarImage4DType::PointType volOrigin;
+  ScalarImage4DType::DirectionType volDirection;
 
   for( unsigned int i = 0; i < 3; ++i )
   {
@@ -288,24 +288,24 @@ static Volume4DType::Pointer CreateEmpty4DVolume(Vector3DType::Pointer & inputVo
   return FourDVolume;
 }
 
-Volume4DType::Pointer Convert3DVectorVolumeTo4DVolume(Vector3DType::Pointer inputVol)
+ScalarImage4DType::Pointer Convert3DVectorVolumeTo4DVolume(VectorImage3DType::Pointer inputVol)
 {
-  Volume4DType::Pointer FourDVolume = CreateEmpty4DVolume(inputVol);
-  const Vector3DType::SizeType inputSize( inputVol->GetLargestPossibleRegion().GetSize() );
-  const Volume4DType::IndexType::IndexValueType vecLength = inputVol->GetNumberOfComponentsPerPixel();
+  ScalarImage4DType::Pointer FourDVolume = CreateEmpty4DVolume(inputVol);
+  const VectorImage3DType::SizeType inputSize( inputVol->GetLargestPossibleRegion().GetSize() );
+  const ScalarImage4DType::IndexType::IndexValueType vecLength = inputVol->GetNumberOfComponentsPerPixel();
 
-  Vector3DType::IndexType vecIndex;
-  Volume4DType::IndexType volIndex;
+  VectorImage3DType::IndexType vecIndex;
+  ScalarImage4DType::IndexType volIndex;
 // convert from vector image to 4D volume image
   for( volIndex[3] = 0; volIndex[3] < vecLength; ++volIndex[3] )
   {
-    for( volIndex[2] = 0; volIndex[2] < Volume4DType::IndexType::IndexValueType( inputSize[2] ); ++volIndex[2] )
+    for( volIndex[2] = 0; volIndex[2] < ScalarImage4DType::IndexType::IndexValueType( inputSize[2] ); ++volIndex[2] )
     {
       vecIndex[2] = volIndex[2];
-      for( volIndex[1] = 0; volIndex[1] < Volume4DType::IndexType::IndexValueType( inputSize[1] ); ++volIndex[1] )
+      for( volIndex[1] = 0; volIndex[1] < ScalarImage4DType::IndexType::IndexValueType( inputSize[1] ); ++volIndex[1] )
       {
         vecIndex[1] = volIndex[1];
-        for( volIndex[0] = 0; volIndex[0] < Volume4DType::IndexType::IndexValueType( inputSize[0] ); ++volIndex[0] )
+        for( volIndex[0] = 0; volIndex[0] < ScalarImage4DType::IndexType::IndexValueType( inputSize[0] ); ++volIndex[0] )
         {
           vecIndex[0] = volIndex[0];
           FourDVolume->SetPixel(volIndex, inputVol->GetPixel(vecIndex)[volIndex[3]]);
@@ -317,28 +317,28 @@ Volume4DType::Pointer Convert3DVectorVolumeTo4DVolume(Vector3DType::Pointer inpu
   return FourDVolume;
 }
 
-Vector3DType::Pointer Convert4DVolumeTo3DVectorVolume(Volume4DType::Pointer inputVol)
+VectorImage3DType::Pointer Convert4DVolumeTo3DVectorVolume(ScalarImage4DType::Pointer inputVol)
 {
-  typedef itk::Image<unsigned short,3> Volume3DType; //Used for a single 3D volume component
+  typedef itk::Image<unsigned short,3> ScalarImage3DType; //Used for a single 3D volume component
   // convert from image series to vector voxels
-  //Volume4DType::SpacingType inputSpacing = inputVol->GetSpacing();
-  Volume4DType::SizeType inputSize = inputVol->GetLargestPossibleRegion().GetSize();
-  Volume4DType::IndexType inputIndex = inputVol->GetLargestPossibleRegion().GetIndex();
+  //ScalarImage4DType::SpacingType inputSpacing = inputVol->GetSpacing();
+  ScalarImage4DType::SizeType inputSize = inputVol->GetLargestPossibleRegion().GetSize();
+  ScalarImage4DType::IndexType inputIndex = inputVol->GetLargestPossibleRegion().GetIndex();
 ////////
-// "inputVol" is read as a 4D image. Here we convert that to a Vector3DType:
+// "inputVol" is read as a 4D image. Here we convert that to a VectorImage3DType:
 //
-  typedef itk::ExtractImageFilter< Volume4DType, Volume3DType > ExtractFilterType;
+  typedef itk::ExtractImageFilter< ScalarImage4DType, ScalarImage3DType > ExtractFilterType;
 
-  typedef itk::ComposeImageFilter<Volume3DType, Vector3DType> ComposeImageFilterType;
+  typedef itk::ComposeImageFilter<ScalarImage3DType, VectorImage3DType> ComposeImageFilterType;
   ComposeImageFilterType::Pointer composer= ComposeImageFilterType::New();
 
   for( size_t componentNumber = 0; componentNumber < inputSize[3]; ++componentNumber )
   {
-    Volume4DType::SizeType extractSize = inputSize;
+    ScalarImage4DType::SizeType extractSize = inputSize;
     extractSize[3] = 0;
-    Volume4DType::IndexType extractIndex = inputIndex;
+    ScalarImage4DType::IndexType extractIndex = inputIndex;
     extractIndex[3] = componentNumber;
-    Volume4DType::RegionType extractRegion(extractIndex, extractSize);
+    ScalarImage4DType::RegionType extractRegion(extractIndex, extractSize);
 
     ExtractFilterType::Pointer extracter = ExtractFilterType::New();
     extracter->SetExtractionRegion( extractRegion );
@@ -349,7 +349,7 @@ Vector3DType::Pointer Convert4DVolumeTo3DVectorVolume(Volume4DType::Pointer inpu
     composer->SetInput(componentNumber,extracter->GetOutput());
   }
   composer->Update();
-  Vector3DType::Pointer nrrdVolume = composer->GetOutput();
+  VectorImage3DType::Pointer nrrdVolume = composer->GetOutput();
   nrrdVolume->SetMetaDataDictionary( inputVol->GetMetaDataDictionary());
   return nrrdVolume;
 }

--- a/DWIConvert/DWIConvertUtils.cxx
+++ b/DWIConvert/DWIConvertUtils.cxx
@@ -248,13 +248,13 @@ ReadBVecs(DWIMetaDataDictionaryValidator::GradientTableType & bVecs, unsigned in
   return EXIT_SUCCESS;
 }
 
-static Volume4DType::Pointer CreateEmpty4DVolume(VectorVolumeType::Pointer & inputVol)
+static Volume4DType::Pointer CreateEmpty4DVolume(Vector3DType::Pointer & inputVol)
 {
-  VectorVolumeType::SizeType inputSize =
+  Vector3DType::SizeType inputSize =
           inputVol->GetLargestPossibleRegion().GetSize();
-  VectorVolumeType::SpacingType inputSpacing = inputVol->GetSpacing();
-  VectorVolumeType::PointType inputOrigin = inputVol->GetOrigin();
-  VectorVolumeType::DirectionType inputDirection = inputVol->GetDirection();
+  Vector3DType::SpacingType inputSpacing = inputVol->GetSpacing();
+  Vector3DType::PointType inputOrigin = inputVol->GetOrigin();
+  Vector3DType::DirectionType inputDirection = inputVol->GetDirection();
 
   Volume4DType::Pointer FourDVolume = Volume4DType::New();
   Volume4DType::SizeType volSize;
@@ -288,13 +288,13 @@ static Volume4DType::Pointer CreateEmpty4DVolume(VectorVolumeType::Pointer & inp
   return FourDVolume;
 }
 
-Volume4DType::Pointer Convert3DVectorVolumeTo4DVolume(VectorVolumeType::Pointer inputVol)
+Volume4DType::Pointer Convert3DVectorVolumeTo4DVolume(Vector3DType::Pointer inputVol)
 {
   Volume4DType::Pointer FourDVolume = CreateEmpty4DVolume(inputVol);
-  const VectorVolumeType::SizeType inputSize( inputVol->GetLargestPossibleRegion().GetSize() );
+  const Vector3DType::SizeType inputSize( inputVol->GetLargestPossibleRegion().GetSize() );
   const Volume4DType::IndexType::IndexValueType vecLength = inputVol->GetNumberOfComponentsPerPixel();
 
-  VectorVolumeType::IndexType vecIndex;
+  Vector3DType::IndexType vecIndex;
   Volume4DType::IndexType volIndex;
 // convert from vector image to 4D volume image
   for( volIndex[3] = 0; volIndex[3] < vecLength; ++volIndex[3] )
@@ -317,7 +317,7 @@ Volume4DType::Pointer Convert3DVectorVolumeTo4DVolume(VectorVolumeType::Pointer 
   return FourDVolume;
 }
 
-VectorVolumeType::Pointer Convert4DVolumeTo3DVectorVolume(Volume4DType::Pointer inputVol)
+Vector3DType::Pointer Convert4DVolumeTo3DVectorVolume(Volume4DType::Pointer inputVol)
 {
   typedef itk::Image<unsigned short,3> Volume3DType; //Used for a single 3D volume component
   // convert from image series to vector voxels
@@ -325,11 +325,11 @@ VectorVolumeType::Pointer Convert4DVolumeTo3DVectorVolume(Volume4DType::Pointer 
   Volume4DType::SizeType inputSize = inputVol->GetLargestPossibleRegion().GetSize();
   Volume4DType::IndexType inputIndex = inputVol->GetLargestPossibleRegion().GetIndex();
 ////////
-// "inputVol" is read as a 4D image. Here we convert that to a VectorImageType:
+// "inputVol" is read as a 4D image. Here we convert that to a Vector3DType:
 //
   typedef itk::ExtractImageFilter< Volume4DType, Volume3DType > ExtractFilterType;
 
-  typedef itk::ComposeImageFilter<Volume3DType, VectorVolumeType> ComposeImageFilterType;
+  typedef itk::ComposeImageFilter<Volume3DType, Vector3DType> ComposeImageFilterType;
   ComposeImageFilterType::Pointer composer= ComposeImageFilterType::New();
 
   for( size_t componentNumber = 0; componentNumber < inputSize[3]; ++componentNumber )
@@ -349,7 +349,7 @@ VectorVolumeType::Pointer Convert4DVolumeTo3DVectorVolume(Volume4DType::Pointer 
     composer->SetInput(componentNumber,extracter->GetOutput());
   }
   composer->Update();
-  VectorVolumeType::Pointer nrrdVolume = composer->GetOutput();
+  Vector3DType::Pointer nrrdVolume = composer->GetOutput();
   nrrdVolume->SetMetaDataDictionary( inputVol->GetMetaDataDictionary());
   return nrrdVolume;
 }

--- a/DWIConvert/DWIConvertUtils.cxx
+++ b/DWIConvert/DWIConvertUtils.cxx
@@ -288,7 +288,7 @@ static ScalarImage4DType::Pointer CreateEmpty4DVolume(VectorImage3DType::Pointer
   return FourDVolume;
 }
 
-ScalarImage4DType::Pointer Convert3DVectorVolumeTo4DVolume(VectorImage3DType::Pointer inputVol)
+ScalarImage4DType::Pointer convertVectorImage3DToScalarImage4D(VectorImage3DType::Pointer inputVol)
 {
   ScalarImage4DType::Pointer FourDVolume = CreateEmpty4DVolume(inputVol);
   const VectorImage3DType::SizeType inputSize( inputVol->GetLargestPossibleRegion().GetSize() );
@@ -317,7 +317,7 @@ ScalarImage4DType::Pointer Convert3DVectorVolumeTo4DVolume(VectorImage3DType::Po
   return FourDVolume;
 }
 
-VectorImage3DType::Pointer Convert4DVolumeTo3DVectorVolume(ScalarImage4DType::Pointer inputVol)
+VectorImage3DType::Pointer convertScalarImage4DToVectorImage3D(ScalarImage4DType::Pointer inputVol)
 {
   typedef itk::Image<unsigned short,3> ScalarImage3DType; //Used for a single 3D volume component
   // convert from image series to vector voxels

--- a/DWIConvert/DWIConvertUtils.cxx
+++ b/DWIConvert/DWIConvertUtils.cxx
@@ -297,6 +297,12 @@ ScalarImage4DType::Pointer convertVectorImage3DToScalarImage4D(VectorImage3DType
   VectorImage3DType::IndexType vecIndex;
   ScalarImage4DType::IndexType volIndex;
 // convert from vector image to 4D volume image
+
+
+
+
+
+
   for( volIndex[3] = 0; volIndex[3] < vecLength; ++volIndex[3] )
   {
     for( volIndex[2] = 0; volIndex[2] < ScalarImage4DType::IndexType::IndexValueType( inputSize[2] ); ++volIndex[2] )
@@ -317,16 +323,12 @@ ScalarImage4DType::Pointer convertVectorImage3DToScalarImage4D(VectorImage3DType
   return FourDVolume;
 }
 
+//"inputVol" is read as a 4D image. Here we convert that to a VectorImage3DType:
 VectorImage3DType::Pointer convertScalarImage4DToVectorImage3D(ScalarImage4DType::Pointer inputVol)
 {
-  typedef itk::Image<unsigned short,3> ScalarImage3DType; //Used for a single 3D volume component
-  // convert from image series to vector voxels
-  //ScalarImage4DType::SpacingType inputSpacing = inputVol->GetSpacing();
   ScalarImage4DType::SizeType inputSize = inputVol->GetLargestPossibleRegion().GetSize();
   ScalarImage4DType::IndexType inputIndex = inputVol->GetLargestPossibleRegion().GetIndex();
-////////
-// "inputVol" is read as a 4D image. Here we convert that to a VectorImage3DType:
-//
+
   typedef itk::ExtractImageFilter< ScalarImage4DType, ScalarImage3DType > ExtractFilterType;
 
   typedef itk::ComposeImageFilter<ScalarImage3DType, VectorImage3DType> ComposeImageFilterType;

--- a/DWIConvert/DWIConvertUtils.cxx
+++ b/DWIConvert/DWIConvertUtils.cxx
@@ -284,6 +284,7 @@ static Volume4DType::Pointer CreateEmpty4DVolume(VectorVolumeType::Pointer & inp
   FourDVolume->SetSpacing(volSpacing);
   FourDVolume->SetDirection(volDirection);
   FourDVolume->Allocate();
+  FourDVolume->SetMetaDataDictionary( inputVol->GetMetaDataDictionary());
   return FourDVolume;
 }
 
@@ -312,6 +313,7 @@ Volume4DType::Pointer Convert3DVectorVolumeTo4DVolume(VectorVolumeType::Pointer 
       }
     }
   }
+  FourDVolume->SetMetaDataDictionary( inputVol->GetMetaDataDictionary());
   return FourDVolume;
 }
 
@@ -348,5 +350,6 @@ VectorVolumeType::Pointer Convert4DVolumeTo3DVectorVolume(Volume4DType::Pointer 
   }
   composer->Update();
   VectorVolumeType::Pointer nrrdVolume = composer->GetOutput();
+  nrrdVolume->SetMetaDataDictionary( inputVol->GetMetaDataDictionary());
   return nrrdVolume;
 }

--- a/DWIConvert/DWIConvertUtils.h
+++ b/DWIConvert/DWIConvertUtils.h
@@ -46,6 +46,15 @@ typedef short                          PixelValueType;
  */
 typedef itk::Image<PixelValueType, 4>       Volume4DType;
 
+/* Volume3DType:
+     *
+     * The internal format is an unwrapped 3D scalar image that is x,y,slices
+   * where slices is all the slices in both 3D and 4d directions.
+   * If each volume is 3DSlices, and their are NumGradients, then
+   * the last direction of the unwrapped direction is (3DSlices*NumGradients).
+   */
+typedef itk::Image<PixelValueType, 3>       Volume3DType;
+
 typedef itk::VectorImage<PixelValueType, 3> Vector3DType;
 typedef itk::Matrix<double, 3, 3>           RotationMatrixType;
 

--- a/DWIConvert/DWIConvertUtils.h
+++ b/DWIConvert/DWIConvertUtils.h
@@ -44,9 +44,10 @@ typedef short                          PixelValueType;
 /*
  * The Volume4DType is a scalar image with diemensions cols,rows,3Dslices,NumGradients
  */
-typedef itk::Image<PixelValueType, 4>  Volume4DType;
+typedef itk::Image<PixelValueType, 4>       Volume4DType;
 
 typedef itk::VectorImage<PixelValueType, 3> VectorVolumeType;
+typedef itk::Matrix<double, 3, 3>           RotationMatrixType;
 
 template <typename TArg>
 int
@@ -166,6 +167,12 @@ extern int NrrdToFSL(const std::string & inputVolume,
 
 VectorVolumeType::Pointer Convert4DVolumeTo3DVectorVolume(Volume4DType::Pointer inputVol);
 Volume4DType::Pointer Convert3DVectorVolumeTo4DVolume(VectorVolumeType::Pointer inputVol);
+
+//template<typename ImageType>
+//RotationMatrixType GetSpacingMatrix(typename ImageType::Pointer im);
+
+template<typename ImageType>
+RotationMatrixType GetNRRDSpaceDirection(typename ImageType::Pointer im);
 
 #include "DWIConvertUtils.hxx"
 

--- a/DWIConvert/DWIConvertUtils.h
+++ b/DWIConvert/DWIConvertUtils.h
@@ -46,6 +46,8 @@ typedef short                          PixelValueType;
  */
 typedef itk::Image<PixelValueType, 4>  Volume4DType;
 
+typedef itk::VectorImage<PixelValueType, 3> VectorVolumeType;
+
 template <typename TArg>
 int
 CheckArg(const char *argName, const TArg & argVal, const TArg & emptyVal);
@@ -162,6 +164,8 @@ extern int NrrdToFSL(const std::string & inputVolume,
                          const std::string & outputBVectors,
                          bool allowLossyConversion);
 
+VectorVolumeType::Pointer Convert4DVolumeTo3DVectorVolume(Volume4DType::Pointer inputVol);
+Volume4DType::Pointer Convert3DVectorVolumeTo4DVolume(VectorVolumeType::Pointer inputVol);
 
 #include "DWIConvertUtils.hxx"
 

--- a/DWIConvert/DWIConvertUtils.h
+++ b/DWIConvert/DWIConvertUtils.h
@@ -174,8 +174,8 @@ extern int NrrdToFSL(const std::string & inputVolume,
                          const std::string & outputBVectors,
                          bool allowLossyConversion);
 
-VectorImage3DType::Pointer Convert4DVolumeTo3DVectorVolume(ScalarImage4DType::Pointer inputVol);
-ScalarImage4DType::Pointer Convert3DVectorVolumeTo4DVolume(VectorImage3DType::Pointer inputVol);
+VectorImage3DType::Pointer convertScalarImage4DToVectorImage3D(ScalarImage4DType::Pointer inputVol);
+ScalarImage4DType::Pointer convertVectorImage3DToScalarImage4D(VectorImage3DType::Pointer inputVol);
 
 //template<typename ImageType>
 //RotationMatrixType GetSpacingMatrix(typename ImageType::Pointer im);

--- a/DWIConvert/DWIConvertUtils.h
+++ b/DWIConvert/DWIConvertUtils.h
@@ -42,20 +42,20 @@
 
 typedef short                          PixelValueType;
 /*
- * The Volume4DType is a scalar image with diemensions cols,rows,3Dslices,NumGradients
+ * The ScalarImage4DType is a scalar image with diemensions cols,rows,3Dslices,NumGradients
  */
-typedef itk::Image<PixelValueType, 4>       Volume4DType;
+typedef itk::Image<PixelValueType, 4>       ScalarImage4DType;
 
-/* Volume3DType:
+/* ScalarImage3DType:
      *
      * The internal format is an unwrapped 3D scalar image that is x,y,slices
    * where slices is all the slices in both 3D and 4d directions.
    * If each volume is 3DSlices, and their are NumGradients, then
    * the last direction of the unwrapped direction is (3DSlices*NumGradients).
    */
-typedef itk::Image<PixelValueType, 3>       Volume3DType;
+typedef itk::Image<PixelValueType, 3>       ScalarImage3DType;
 
-typedef itk::VectorImage<PixelValueType, 3> Vector3DType;
+typedef itk::VectorImage<PixelValueType, 3> VectorImage3DType;
 typedef itk::Matrix<double, 3, 3>           RotationMatrixType;
 
 template <typename TArg>
@@ -174,8 +174,8 @@ extern int NrrdToFSL(const std::string & inputVolume,
                          const std::string & outputBVectors,
                          bool allowLossyConversion);
 
-Vector3DType::Pointer Convert4DVolumeTo3DVectorVolume(Volume4DType::Pointer inputVol);
-Volume4DType::Pointer Convert3DVectorVolumeTo4DVolume(Vector3DType::Pointer inputVol);
+VectorImage3DType::Pointer Convert4DVolumeTo3DVectorVolume(ScalarImage4DType::Pointer inputVol);
+ScalarImage4DType::Pointer Convert3DVectorVolumeTo4DVolume(VectorImage3DType::Pointer inputVol);
 
 //template<typename ImageType>
 //RotationMatrixType GetSpacingMatrix(typename ImageType::Pointer im);

--- a/DWIConvert/DWIConvertUtils.h
+++ b/DWIConvert/DWIConvertUtils.h
@@ -46,7 +46,7 @@ typedef short                          PixelValueType;
  */
 typedef itk::Image<PixelValueType, 4>       Volume4DType;
 
-typedef itk::VectorImage<PixelValueType, 3> VectorVolumeType;
+typedef itk::VectorImage<PixelValueType, 3> Vector3DType;
 typedef itk::Matrix<double, 3, 3>           RotationMatrixType;
 
 template <typename TArg>
@@ -165,8 +165,8 @@ extern int NrrdToFSL(const std::string & inputVolume,
                          const std::string & outputBVectors,
                          bool allowLossyConversion);
 
-VectorVolumeType::Pointer Convert4DVolumeTo3DVectorVolume(Volume4DType::Pointer inputVol);
-Volume4DType::Pointer Convert3DVectorVolumeTo4DVolume(VectorVolumeType::Pointer inputVol);
+Vector3DType::Pointer Convert4DVolumeTo3DVectorVolume(Volume4DType::Pointer inputVol);
+Volume4DType::Pointer Convert3DVectorVolumeTo4DVolume(Vector3DType::Pointer inputVol);
 
 //template<typename ImageType>
 //RotationMatrixType GetSpacingMatrix(typename ImageType::Pointer im);

--- a/DWIConvert/DWIConvertUtils.hxx
+++ b/DWIConvert/DWIConvertUtils.hxx
@@ -369,5 +369,28 @@ void PrintVec(const std::vector<TVal> & vec)
   }
   std::cerr << "]" << std::endl;
 }
+/*
+template<typename ImageType>
+RotationMatrixType GetSpacingMatrix(typename ImageType::Pointer im)
+{
+  RotationMatrixType SpacingMatrix;
+  SpacingMatrix.Fill(0.0);
+  SpacingMatrix[0][0] = im->GetSpacing()[0];
+  SpacingMatrix[1][1] = im->GetSpacing()[1];
+  SpacingMatrix[2][2] = im->GetSpacing()[2];
+  return SpacingMatrix;
+}
+*/
+
+template<typename ImageType>
+RotationMatrixType GetNRRDSpaceDirection(typename ImageType::Pointer im)
+{
+  RotationMatrixType SpacingMatrix;
+  SpacingMatrix.Fill(0.0);
+  SpacingMatrix[0][0] = im->GetSpacing()[0];
+  SpacingMatrix[1][1] = im->GetSpacing()[1];
+  SpacingMatrix[2][2] = im->GetSpacing()[2];
+  return  im->GetDirection() * SpacingMatrix;
+}
 
 #endif //DWIConvertUtils

--- a/DWIConvert/DWIConvertUtils.hxx
+++ b/DWIConvert/DWIConvertUtils.hxx
@@ -50,7 +50,7 @@ ReadScalarVolume( typename TImage::Pointer & img, const std::string & fname, boo
   }
   catch( itk::ExceptionObject & excp )
   {
-    std::cerr << "Exception thrown while reading "
+    std::cerr << "Exception thrown while reading"
               << fname << std::endl;
     std::cerr << excp << std::endl;
     return EXIT_FAILURE;
@@ -123,7 +123,7 @@ ReadVectorVolume( typename TImage::Pointer & img, const std::string & fname, boo
   }
   catch( itk::ExceptionObject & excp )
   {
-    std::cerr << "Exception thrown while reading "
+    std::cerr << "*******Exception thrown while reading *************"
               << fname << std::endl;
     std::cerr << excp << std::endl;
     return EXIT_FAILURE;

--- a/DWIConvert/DWIConverter.cxx
+++ b/DWIConvert/DWIConverter.cxx
@@ -112,14 +112,12 @@ Volume4DType::Pointer DWIConverter::OrientForFSLConventions( const bool toFSL)
    */
   //
   // FSL wants the second and third dimensions flipped with regards to LPS orientation
-  // FSL wants the second and third dimeinsions flipped with regards to LPS orientation
   myFlipper->SetFlipAxes(arrayAxisFlip);
   myFlipper->FlipAboutOriginOff();  //Flip the image and direction cosignes
   // this is similar to a transform of [1 0 0; 0 -1 0; 0 0 -1]
   myFlipper->Update();
   Volume4DType::Pointer temp = myFlipper->GetOutput();
   temp->SetMetaDataDictionary( image4D->GetMetaDataDictionary());
-  this->m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume(temp);
   return temp;
 }
 

--- a/DWIConvert/DWIConverter.cxx
+++ b/DWIConvert/DWIConverter.cxx
@@ -409,8 +409,11 @@ void DWIConverter::ManualWriteNRRDFile(
   header << std::endl;;
   if (nrrdSingleFileFormat) {
     unsigned long nVoxels = this->GetDiffusionVolume()->GetBufferedRegion().GetNumberOfPixels();
+    //header.write(reinterpret_cast<char*>(this->GetDiffusionVolume()->GetBufferPointer()),
+    //             nVoxels*sizeof(short));
+    int nVolume = m_Vector3DVolume->GetVectorLength();
     header.write(reinterpret_cast<char*>(this->GetDiffusionVolume()->GetBufferPointer()),
-                 nVoxels*sizeof(short));
+                 nVoxels*sizeof(short)*nVolume);
   }
   else {
     // if we're writing out NRRD, and the split header/data NRRD

--- a/DWIConvert/DWIConverter.cxx
+++ b/DWIConvert/DWIConverter.cxx
@@ -356,7 +356,7 @@ void DWIConverter::ManualWriteNRRDFile(
   header << "encoding: raw" << std::endl;
   header << "space units: \"mm\" \"mm\" \"mm\"" << std::endl;
 
-  const VectorImage3DType::PointType ImageOrigin = this->GetOrigin();
+  const ScalarImage3DType::PointType ImageOrigin = this->GetOrigin();
   header << "space origin: "
          << "(" << DoubleConvert(ImageOrigin[0])
          << "," << DoubleConvert(ImageOrigin[1])

--- a/DWIConvert/DWIConverter.h
+++ b/DWIConvert/DWIConverter.h
@@ -72,8 +72,9 @@ public:
   /* The internal default format for DWIConverter is an itk::VectorImage<PixelValueType,3> */
   typedef std::vector< std::string > FileNamesContainer;
 
-  typedef VectorVolumeType::SpacingType            SpacingType;
 
+  typedef Vector3DType::SpacingType            SpacingType;
+  //typedef itk::ImageFileReader<Volume3DUnwrappedType>   SingleFileReaderType;
   typedef itk::Vector<double, 3>                        PointType;
 
   typedef std::map<std::string,std::string> CommonDicomFieldMapType;
@@ -116,12 +117,12 @@ public:
  void SetBValues( const std::vector<double> & inBValues );
  double GetMaxBValue() const;
 
- VectorVolumeType::Pointer GetDiffusionVolume() const ;
+ Vector3DType::Pointer GetDiffusionVolume() const ;
 
  SpacingType GetSpacing() const;
 
- VectorVolumeType::PointType GetOrigin() const;
- void SetOrigin(VectorVolumeType::PointType origin);
+ Vector3DType::PointType GetOrigin() const;
+ void SetOrigin(Vector3DType::PointType origin);
 
  RotationMatrixType   GetLPSDirCos() const;
 
@@ -165,6 +166,9 @@ public:
   void WriteFSLFormattedFileSet(const std::string& outputVolumeHeaderName,
                              const std::string outputBValues, const std::string outputBVectors, Volume4DType::Pointer img4D) const;
 
+  void WriteFSLFormattedFileSet(const std::string& outputVolumeHeaderName,
+                                                const std::string outputBValues, const std::string outputBVectors) const;
+
 
   /**
    * @brief Choose if we are going to allow for lossy conversion by typecasting
@@ -196,7 +200,7 @@ protected:
 
 
   //the default data model for all of DWIConvert
-  VectorVolumeType::Pointer   m_Vector3DVolume;
+  Vector3DType::Pointer   m_Vector3DVolume;
 
   /** measurement from for gradients if different than patient
    *  reference frame.

--- a/DWIConvert/DWIConverter.h
+++ b/DWIConvert/DWIConverter.h
@@ -117,12 +117,12 @@ public:
  void SetBValues( const std::vector<double> & inBValues );
  double GetMaxBValue() const;
 
- VectorImage3DType::Pointer GetDiffusionVolume() const ;
+    ScalarImage3DType::Pointer GetDiffusionVolume() const ;
 
  SpacingType GetSpacing() const;
 
- VectorImage3DType::PointType GetOrigin() const;
- void SetOrigin(VectorImage3DType::PointType origin);
+    ScalarImage3DType::PointType GetOrigin() const;
+ void SetOrigin(ScalarImage3DType::PointType origin);
 
  RotationMatrixType   GetLPSDirCos() const;
 
@@ -184,6 +184,10 @@ protected:
   double ComputeMaxBvalue(const std::vector<double> &bValues) const;
   size_t has_valid_nifti_extension( std::string outputVolumeHeaderName ) const;
 
+  ScalarImage4DType::Pointer ThreeDUnwrappedToFourDImage(ScalarImage3DType::Pointer img) const;
+
+  ScalarImage3DType::Pointer FourDToThreeDUnwrappedImage(ScalarImage4DType::Pointer img4D) const;
+
   /** add vendor-specific flags; */
   virtual void AddFlagsToDictionary() = 0;
 
@@ -200,7 +204,27 @@ protected:
 
 
   //the default data model for all of DWIConvert
-  VectorImage3DType::Pointer   m_vectorImage3D;
+  //VectorImage3DType::Pointer   m_vectorImage3D;
+
+  /* ScalarImage3DType:
+   *
+   * The internal format is an unwrapped 3D scalar image that is x,y,slices
+   * where slices is all the slices in both 3D and 4d directions.
+   * If each volume is 3DSlices, and their are NumGradients, then
+   * the last direction of the unwrapped direction is (3DSlices*NumGradients).
+   */
+  ScalarImage3DType::Pointer m_scalarImage3D; //Unwrapped
+
+    // this is always "left-posterior-superior" in all cases that we currently support
+    const std::string           m_NRRDSpaceDefinition;
+    /** dimensions */
+    unsigned int        m_SlicesPerVolume;
+    /** number of total slices */
+    unsigned int        m_NSlice;
+    /** number of gradient volumes */
+    unsigned int        m_NVolume;
+    unsigned int GetSlicesPerVolume() const;
+    unsigned int GetNVolume() const;
 
   /** measurement from for gradients if different than patient
    *  reference frame.
@@ -213,8 +237,7 @@ protected:
   // A map of common dicom fields to be propagated to image
   std::map<std::string,std::string> m_CommonDicomFieldsMap;
 
-// this is always "left-posterior-superior" in all cases that we currently support
-    const std::string           m_NRRDSpaceDefinition;
+
 
 };
 

--- a/DWIConvert/DWIConverter.h
+++ b/DWIConvert/DWIConverter.h
@@ -74,7 +74,7 @@ public:
 
 
   typedef Vector3DType::SpacingType            SpacingType;
-  //typedef itk::ImageFileReader<Volume3DUnwrappedType>   SingleFileReaderType;
+
   typedef itk::Vector<double, 3>                        PointType;
 
   typedef std::map<std::string,std::string> CommonDicomFieldMapType;

--- a/DWIConvert/DWIConverter.h
+++ b/DWIConvert/DWIConverter.h
@@ -69,21 +69,12 @@
 class DWIConverter
 {
 public:
+  /* The internal default format for DWIConverter is an itk::VectorImage<PixelValueType,3> */
+  typedef std::vector< std::string > FileNamesContainer;
 
-  /* The internal format is an unwrapped 3D scalar image that is x,y,slices
-   * where slices is all the slices in both 3D and 4d directions.
-   * If each volume is 3DSlices, and their are NumGradients, then
-   * the last direction of the unwrapped direction is (3DSlices*NumGradients).
-   */
-  typedef itk::Image<PixelValueType, 3>  Volume3DUnwrappedType;
-
-  typedef Volume3DUnwrappedType::SpacingType            SpacingType;
-  typedef itk::ImageSeriesReader<Volume3DUnwrappedType> ReaderType;
-  typedef ReaderType::FileNamesContainer                FileNamesContainer;
-  typedef itk::VectorImage<PixelValueType, 3> VectorVolumeType;
+  typedef VectorVolumeType::SpacingType            SpacingType;
 
 
-  typedef itk::ImageFileReader<Volume3DUnwrappedType>   SingleFileReaderType;
   typedef itk::Matrix<double, 3, 3>                     RotationMatrixType;
   typedef itk::Vector<double, 3>                        PointType;
 
@@ -127,12 +118,12 @@ public:
  void SetBValues( const std::vector<double> & inBValues );
  double GetMaxBValue() const;
 
- Volume3DUnwrappedType::Pointer GetDiffusionVolume() const ;
+ VectorVolumeType::Pointer GetDiffusionVolume() const ;
 
  SpacingType GetSpacing() const;
 
- Volume3DUnwrappedType::PointType GetOrigin() const;
- void SetOrigin(DWIConverter::Volume3DUnwrappedType::PointType origin);
+ VectorVolumeType::PointType GetOrigin() const;
+ void SetOrigin(VectorVolumeType::PointType origin);
 
  RotationMatrixType   GetLPSDirCos() const;
 
@@ -140,16 +131,16 @@ public:
 
  RotationMatrixType GetNRRDSpaceDirection() const;
 
- unsigned int GetSlicesPerVolume() const;
- unsigned int GetNVolume() const;
+
  std::string GetNRRDSpaceDefinition() const;
 
  unsigned short GetRows() const;
 
  unsigned short GetCols() const;
+ unsigned short GetSlices() const;
 
 
-  /**
+    /**
    * @brief Force overwriting the gradient directions by inserting values read from specified file
    * @param gradientVectorFile The file with gradients specified for overwriting
    */
@@ -171,9 +162,7 @@ public:
   void ManualWriteNRRDFile(
             const std::string& outputVolumeHeaderName,
             const std::string commentstring) const;
-  Volume4DType::Pointer ThreeDToFourDImage(Volume3DUnwrappedType::Pointer img) const;
 
-  Volume3DUnwrappedType::Pointer FourDToThreeDImage(Volume4DType::Pointer img4D) const;
 
 /** the DICOM datasets are read as 3D volumes, but they need to be
  *  written as 4D volumes for image types other than NRRD.
@@ -189,8 +178,7 @@ public:
    */
   void SetAllowLossyConversion(const bool newValue);
 
-  //add by Hui Xie
-  Volume3DUnwrappedType::Pointer getVolumePointer();
+
 
 
 protected:
@@ -211,22 +199,9 @@ protected:
   itk::NumberToString<double> m_DoubleConvert;
   bool       m_FSLFileFormatHorizontalBy3Rows; // Format of FSL files on disk
 
-  unsigned int        m_SlicesPerVolume;
-  /** number of total slices */
-  unsigned int        m_NSlice;
-  /** number of gradient volumes */
-  unsigned int        m_NVolume;
-    /* The following variables make up the primary data model for diffusion weighted images
-     * in the most generic sense.  These variables all need to be manipulated together in
-     * order to maintain a consistent data model.
-     */
-    /** the image read from the DICOM dataset */
- Volume3DUnwrappedType::Pointer m_Volume;
 
-
-  // this is always "left-posterior-superior" in all cases that we currently support
-  const std::string           m_NRRDSpaceDefinition;
-
+  //the default data model for all of DWIConvert
+  VectorVolumeType::Pointer   m_Vector3DVolume;
 
   /** measurement from for gradients if different than patient
    *  reference frame.
@@ -238,6 +213,9 @@ protected:
   DWIMetaDataDictionaryValidator::GradientTableType  m_DiffusionVectors;
   // A map of common dicom fields to be propagated to image
   std::map<std::string,std::string> m_CommonDicomFieldsMap;
+
+// this is always "left-posterior-superior" in all cases that we currently support
+    const std::string           m_NRRDSpaceDefinition;
 
 };
 

--- a/DWIConvert/DWIConverter.h
+++ b/DWIConvert/DWIConverter.h
@@ -167,7 +167,7 @@ public:
                              const std::string outputBValues, const std::string outputBVectors, ScalarImage4DType::Pointer img4D) const;
 
   void WriteFSLFormattedFileSet(const std::string& outputVolumeHeaderName,
-                                                const std::string outputBValues, const std::string outputBVectors) const;
+                                                const std::string outputBValues, const std::string outputBVectors, VectorImage3DType::Pointer vectorImage3D) const;
 
 
   /**
@@ -200,7 +200,7 @@ protected:
 
 
   //the default data model for all of DWIConvert
-  VectorImage3DType::Pointer   m_Vector3DVolume;
+  VectorImage3DType::Pointer   m_vectorImage3D;
 
   /** measurement from for gradients if different than patient
    *  reference frame.

--- a/DWIConvert/DWIConverter.h
+++ b/DWIConvert/DWIConverter.h
@@ -74,8 +74,6 @@ public:
 
   typedef VectorVolumeType::SpacingType            SpacingType;
 
-
-  typedef itk::Matrix<double, 3, 3>                     RotationMatrixType;
   typedef itk::Vector<double, 3>                        PointType;
 
   typedef std::map<std::string,std::string> CommonDicomFieldMapType;
@@ -84,7 +82,7 @@ public:
 
   virtual void LoadFromDisk() = 0 ;
 
-  RotationMatrixType GetSpacingMatrix() const;
+
 
   /** extract dwi data -- vendor specific so must happen in subclass
    *  implementing this method.
@@ -128,9 +126,6 @@ public:
  RotationMatrixType   GetLPSDirCos() const;
 
  RotationMatrixType GetMeasurementFrame() const;
-
- RotationMatrixType GetNRRDSpaceDirection() const;
-
 
  std::string GetNRRDSpaceDefinition() const;
 

--- a/DWIConvert/DWIConverter.h
+++ b/DWIConvert/DWIConverter.h
@@ -72,7 +72,7 @@ public:
   /* The internal default format for DWIConverter is an itk::VectorImage<PixelValueType,3> */
   typedef std::vector< std::string > FileNamesContainer;
 
-  typedef VectorImage3DType::SpacingType            SpacingType;
+  typedef ScalarImage3DType::SpacingType            SpacingType;
 
   typedef itk::Vector<double, 3>                        PointType;
 

--- a/DWIConvert/DWIConverter.h
+++ b/DWIConvert/DWIConverter.h
@@ -73,7 +73,7 @@ public:
   typedef std::vector< std::string > FileNamesContainer;
 
 
-  typedef Vector3DType::SpacingType            SpacingType;
+  typedef VectorImage3DType::SpacingType            SpacingType;
 
   typedef itk::Vector<double, 3>                        PointType;
 
@@ -111,18 +111,18 @@ public:
   *         FSL [1 0 0; 0 -1 0; 0 0 1]    Dicom [1 0 0; 0 1 0; 0 0 1]
   * @return Returns a 4D image pointer properly formatted
   */
- Volume4DType::Pointer OrientForFSLConventions (const bool toFSL=true );
+ ScalarImage4DType::Pointer OrientForFSLConventions (const bool toFSL=true );
 
  const std::vector<double> &GetBValues() const;
  void SetBValues( const std::vector<double> & inBValues );
  double GetMaxBValue() const;
 
- Vector3DType::Pointer GetDiffusionVolume() const ;
+ VectorImage3DType::Pointer GetDiffusionVolume() const ;
 
  SpacingType GetSpacing() const;
 
- Vector3DType::PointType GetOrigin() const;
- void SetOrigin(Vector3DType::PointType origin);
+ VectorImage3DType::PointType GetOrigin() const;
+ void SetOrigin(VectorImage3DType::PointType origin);
 
  RotationMatrixType   GetLPSDirCos() const;
 
@@ -164,7 +164,7 @@ public:
  *  written as 4D volumes for image types other than NRRD.
  */
   void WriteFSLFormattedFileSet(const std::string& outputVolumeHeaderName,
-                             const std::string outputBValues, const std::string outputBVectors, Volume4DType::Pointer img4D) const;
+                             const std::string outputBValues, const std::string outputBVectors, ScalarImage4DType::Pointer img4D) const;
 
   void WriteFSLFormattedFileSet(const std::string& outputVolumeHeaderName,
                                                 const std::string outputBValues, const std::string outputBVectors) const;
@@ -200,7 +200,7 @@ protected:
 
 
   //the default data model for all of DWIConvert
-  Vector3DType::Pointer   m_Vector3DVolume;
+  VectorImage3DType::Pointer   m_Vector3DVolume;
 
   /** measurement from for gradients if different than patient
    *  reference frame.

--- a/DWIConvert/DWIDICOMConverterBase.cxx
+++ b/DWIConvert/DWIDICOMConverterBase.cxx
@@ -376,7 +376,7 @@ void DWIDICOMConverterBase::DetermineSliceOrderIS()
   image1Origin[0] -= image0Origin[0];
   image1Origin[1] -= image0Origin[1];
   image1Origin[2] -= image0Origin[2];
-  const RotationMatrixType & NRRDSpaceDirection = this->GetNRRDSpaceDirection();
+  const RotationMatrixType & NRRDSpaceDirection = GetNRRDSpaceDirection<Volume3DUnwrappedType>(this->m_3DUnwrappedVolume);
   double x1 = image1Origin[0] * (NRRDSpaceDirection[0][2])
               + image1Origin[1] * (NRRDSpaceDirection[1][2])
               + image1Origin[2] * (NRRDSpaceDirection[2][2]);

--- a/DWIConvert/DWIDICOMConverterBase.cxx
+++ b/DWIConvert/DWIDICOMConverterBase.cxx
@@ -61,8 +61,8 @@ void DWIDICOMConverterBase::LoadDicomDirectory()
   }
   else
   {
-    itk::ImageFileReader<Volume3DUnwrappedType>::Pointer reader =
-            itk::ImageFileReader<Volume3DUnwrappedType>::New();
+    itk::ImageFileReader<Volume3DType>::Pointer reader =
+            itk::ImageFileReader<Volume3DType>::New();
     reader->SetImageIO( dcmtkIO );
     reader->SetFileName( this->m_InputFileNames[0] );
     m_NSlice = this->m_InputFileNames.size();
@@ -83,7 +83,7 @@ void DWIDICOMConverterBase::LoadDicomDirectory()
     // origin
     double origin[3];
     m_Headers[0]->GetOrigin(origin);
-    Volume3DUnwrappedType::PointType imOrigin;
+    Volume3DType::PointType imOrigin;
     imOrigin[0] = origin[0];
     imOrigin[1] = origin[1];
     imOrigin[2] = origin[2];
@@ -165,7 +165,7 @@ void DWIDICOMConverterBase::LoadDicomDirectory()
   }
 
   {
-    Volume3DUnwrappedType::DirectionType LPSDirCos;
+    Volume3DType::DirectionType LPSDirCos;
     LPSDirCos.SetIdentity();
 
     // check ImageOrientationPatient and figure out slice direction in
@@ -293,7 +293,7 @@ void DWIDICOMConverterBase::SetDirectionsFromSliceOrder()
   else
   {
     std::cout << "Slice order is SI" << std::endl;
-    Volume3DUnwrappedType::DirectionType LPSDirCos = this->m_3DUnwrappedVolume->GetDirection();
+    Volume3DType::DirectionType LPSDirCos = this->m_3DUnwrappedVolume->GetDirection();
     LPSDirCos[0][2] *= -1;
     LPSDirCos[1][2] *= -1;
     LPSDirCos[2][2] *= -1;
@@ -313,19 +313,19 @@ void DWIDICOMConverterBase::DeInterleaveVolume()
 {
   size_t NVolumes = this->m_NSlice / this->m_SlicesPerVolume;
 
-  Volume3DUnwrappedType::RegionType R = this->m_3DUnwrappedVolume->GetLargestPossibleRegion();
+  Volume3DType::RegionType R = this->m_3DUnwrappedVolume->GetLargestPossibleRegion();
 
   R.SetSize(2, 1);
-  std::vector<Volume3DUnwrappedType::PixelType> v(this->m_NSlice);
-  std::vector<Volume3DUnwrappedType::PixelType> w(this->m_NSlice);
+  std::vector<Volume3DType::PixelType> v(this->m_NSlice);
+  std::vector<Volume3DType::PixelType> w(this->m_NSlice);
 
-  itk::ImageRegionIteratorWithIndex<Volume3DUnwrappedType> I(this->m_3DUnwrappedVolume, R );
+  itk::ImageRegionIteratorWithIndex<Volume3DType> I(this->m_3DUnwrappedVolume, R );
   // permute the slices by extracting the 1D array of voxels for
   // a particular {x,y} position, then re-ordering the voxels such
   // that all the voxels for a particular volume are adjacent
   for( I.GoToBegin(); !I.IsAtEnd(); ++I )
   {
-    Volume3DUnwrappedType::IndexType idx = I.GetIndex();
+    Volume3DType::IndexType idx = I.GetIndex();
     // extract all values in one "column"
     for( unsigned int k = 0; k < this->m_NSlice; ++k )
     {
@@ -376,7 +376,7 @@ void DWIDICOMConverterBase::DetermineSliceOrderIS()
   image1Origin[0] -= image0Origin[0];
   image1Origin[1] -= image0Origin[1];
   image1Origin[2] -= image0Origin[2];
-  const RotationMatrixType & NRRDSpaceDirection = GetNRRDSpaceDirection<Volume3DUnwrappedType>(this->m_3DUnwrappedVolume);
+  const RotationMatrixType & NRRDSpaceDirection = GetNRRDSpaceDirection<Volume3DType>(this->m_3DUnwrappedVolume);
   double x1 = image1Origin[0] * (NRRDSpaceDirection[0][2])
               + image1Origin[1] * (NRRDSpaceDirection[1][2])
               + image1Origin[2] * (NRRDSpaceDirection[2][2]);
@@ -387,14 +387,14 @@ void DWIDICOMConverterBase::DetermineSliceOrderIS()
 }
 
 
-Volume4DType::Pointer DWIDICOMConverterBase::ThreeDUnwrappedToFourDImage(Volume3DUnwrappedType::Pointer img) const
+Volume4DType::Pointer DWIDICOMConverterBase::ThreeDUnwrappedToFourDImage(Volume3DType::Pointer img) const
 {
   const int nVolumes = this->GetNVolume();
 
-  Volume3DUnwrappedType::SizeType size3D(img->GetLargestPossibleRegion().GetSize());
-  Volume3DUnwrappedType::DirectionType direction3D(img->GetDirection());
-  Volume3DUnwrappedType::SpacingType spacing3D(img->GetSpacing());
-  Volume3DUnwrappedType::PointType origin3D(img->GetOrigin());
+  Volume3DType::SizeType size3D(img->GetLargestPossibleRegion().GetSize());
+  Volume3DType::DirectionType direction3D(img->GetDirection());
+  Volume3DType::SpacingType spacing3D(img->GetSpacing());
+  Volume3DType::PointType origin3D(img->GetOrigin());
 
   Volume4DType::RegionType region4D;
   {
@@ -456,22 +456,22 @@ Volume4DType::Pointer DWIDICOMConverterBase::ThreeDUnwrappedToFourDImage(Volume3
 }
 
 
-DWIDICOMConverterBase::Volume3DUnwrappedType::Pointer DWIDICOMConverterBase::FourDToThreeDUnwrappedImage(Volume4DType::Pointer img4D) const
+Volume3DType::Pointer DWIDICOMConverterBase::FourDToThreeDUnwrappedImage(Volume4DType::Pointer img4D) const
 {
   Volume4DType::SizeType      size4D(img4D->GetLargestPossibleRegion().GetSize() );
   Volume4DType::DirectionType direction4D(img4D->GetDirection() );
   Volume4DType::SpacingType   spacing4D(img4D->GetSpacing() );
   Volume4DType::PointType     origin4D(img4D->GetOrigin() );
 
-  Volume3DUnwrappedType::RegionType region3D;
+  Volume3DType::RegionType region3D;
   {
-    Volume3DUnwrappedType::SizeType size3D;
+    Volume3DType::SizeType size3D;
     size3D[0] = size4D[0];
     size3D[1] = size4D[1];
     const int nVolumes = img4D->GetLargestPossibleRegion().GetSize()[3];
     size3D[2] = size4D[2] * nVolumes;
 
-    Volume3DUnwrappedType::IndexType index3D;
+    Volume3DType::IndexType index3D;
     index3D.Fill(0);
     region3D.SetIndex(index3D);
     region3D.SetSize(size3D);
@@ -485,11 +485,11 @@ DWIDICOMConverterBase::Volume3DUnwrappedType::Pointer DWIDICOMConverterBase::Fou
               << size3D[2] % nVolumes << std::endl);
     }
   }
-  Volume3DUnwrappedType::DirectionType direction3D;
+  Volume3DType::DirectionType direction3D;
   direction3D.SetIdentity();
-  Volume3DUnwrappedType::SpacingType   spacing3D;
+  Volume3DType::SpacingType   spacing3D;
   spacing3D.Fill(1.0);
-  Volume3DUnwrappedType::PointType     origin3D;
+  Volume3DType::PointType     origin3D;
   origin3D.Fill(0.0);
   for( unsigned i = 0; i < 3; ++i )
   {
@@ -501,7 +501,7 @@ DWIDICOMConverterBase::Volume3DUnwrappedType::Pointer DWIDICOMConverterBase::Fou
     origin3D[i] = origin4D[i];
   }
 
-  Volume3DUnwrappedType::Pointer img = Volume3DUnwrappedType::New();
+  Volume3DType::Pointer img = Volume3DType::New();
   img->SetRegions(region3D);
   img->SetDirection(direction3D);
   img->SetSpacing(spacing3D);

--- a/DWIConvert/DWIDICOMConverterBase.cxx
+++ b/DWIConvert/DWIDICOMConverterBase.cxx
@@ -61,8 +61,8 @@ void DWIDICOMConverterBase::LoadDicomDirectory()
   }
   else
   {
-    itk::ImageFileReader<Volume3DType>::Pointer reader =
-            itk::ImageFileReader<Volume3DType>::New();
+    itk::ImageFileReader<ScalarImage3DType>::Pointer reader =
+            itk::ImageFileReader<ScalarImage3DType>::New();
     reader->SetImageIO( dcmtkIO );
     reader->SetFileName( this->m_InputFileNames[0] );
     m_NSlice = this->m_InputFileNames.size();
@@ -83,7 +83,7 @@ void DWIDICOMConverterBase::LoadDicomDirectory()
     // origin
     double origin[3];
     m_Headers[0]->GetOrigin(origin);
-    Volume3DType::PointType imOrigin;
+    ScalarImage3DType::PointType imOrigin;
     imOrigin[0] = origin[0];
     imOrigin[1] = origin[1];
     imOrigin[2] = origin[2];
@@ -165,7 +165,7 @@ void DWIDICOMConverterBase::LoadDicomDirectory()
   }
 
   {
-    Volume3DType::DirectionType LPSDirCos;
+    ScalarImage3DType::DirectionType LPSDirCos;
     LPSDirCos.SetIdentity();
 
     // check ImageOrientationPatient and figure out slice direction in
@@ -293,7 +293,7 @@ void DWIDICOMConverterBase::SetDirectionsFromSliceOrder()
   else
   {
     std::cout << "Slice order is SI" << std::endl;
-    Volume3DType::DirectionType LPSDirCos = this->m_3DUnwrappedVolume->GetDirection();
+    ScalarImage3DType::DirectionType LPSDirCos = this->m_3DUnwrappedVolume->GetDirection();
     LPSDirCos[0][2] *= -1;
     LPSDirCos[1][2] *= -1;
     LPSDirCos[2][2] *= -1;
@@ -313,19 +313,19 @@ void DWIDICOMConverterBase::DeInterleaveVolume()
 {
   size_t NVolumes = this->m_NSlice / this->m_SlicesPerVolume;
 
-  Volume3DType::RegionType R = this->m_3DUnwrappedVolume->GetLargestPossibleRegion();
+  ScalarImage3DType::RegionType R = this->m_3DUnwrappedVolume->GetLargestPossibleRegion();
 
   R.SetSize(2, 1);
-  std::vector<Volume3DType::PixelType> v(this->m_NSlice);
-  std::vector<Volume3DType::PixelType> w(this->m_NSlice);
+  std::vector<ScalarImage3DType::PixelType> v(this->m_NSlice);
+  std::vector<ScalarImage3DType::PixelType> w(this->m_NSlice);
 
-  itk::ImageRegionIteratorWithIndex<Volume3DType> I(this->m_3DUnwrappedVolume, R );
+  itk::ImageRegionIteratorWithIndex<ScalarImage3DType> I(this->m_3DUnwrappedVolume, R );
   // permute the slices by extracting the 1D array of voxels for
   // a particular {x,y} position, then re-ordering the voxels such
   // that all the voxels for a particular volume are adjacent
   for( I.GoToBegin(); !I.IsAtEnd(); ++I )
   {
-    Volume3DType::IndexType idx = I.GetIndex();
+    ScalarImage3DType::IndexType idx = I.GetIndex();
     // extract all values in one "column"
     for( unsigned int k = 0; k < this->m_NSlice; ++k )
     {
@@ -376,7 +376,7 @@ void DWIDICOMConverterBase::DetermineSliceOrderIS()
   image1Origin[0] -= image0Origin[0];
   image1Origin[1] -= image0Origin[1];
   image1Origin[2] -= image0Origin[2];
-  const RotationMatrixType & NRRDSpaceDirection = GetNRRDSpaceDirection<Volume3DType>(this->m_3DUnwrappedVolume);
+  const RotationMatrixType & NRRDSpaceDirection = GetNRRDSpaceDirection<ScalarImage3DType>(this->m_3DUnwrappedVolume);
   double x1 = image1Origin[0] * (NRRDSpaceDirection[0][2])
               + image1Origin[1] * (NRRDSpaceDirection[1][2])
               + image1Origin[2] * (NRRDSpaceDirection[2][2]);
@@ -387,23 +387,23 @@ void DWIDICOMConverterBase::DetermineSliceOrderIS()
 }
 
 
-Volume4DType::Pointer DWIDICOMConverterBase::ThreeDUnwrappedToFourDImage(Volume3DType::Pointer img) const
+ScalarImage4DType::Pointer DWIDICOMConverterBase::ThreeDUnwrappedToFourDImage(ScalarImage3DType::Pointer img) const
 {
   const int nVolumes = this->GetNVolume();
 
-  Volume3DType::SizeType size3D(img->GetLargestPossibleRegion().GetSize());
-  Volume3DType::DirectionType direction3D(img->GetDirection());
-  Volume3DType::SpacingType spacing3D(img->GetSpacing());
-  Volume3DType::PointType origin3D(img->GetOrigin());
+  ScalarImage3DType::SizeType size3D(img->GetLargestPossibleRegion().GetSize());
+  ScalarImage3DType::DirectionType direction3D(img->GetDirection());
+  ScalarImage3DType::SpacingType spacing3D(img->GetSpacing());
+  ScalarImage3DType::PointType origin3D(img->GetOrigin());
 
-  Volume4DType::RegionType region4D;
+  ScalarImage4DType::RegionType region4D;
   {
-    Volume4DType::SizeType size4D;
+    ScalarImage4DType::SizeType size4D;
     size4D[0] = size3D[0];
     size4D[1] = size3D[1];
     size4D[2] = size3D[2]/nVolumes;
     size4D[3] = nVolumes;
-    Volume4DType::IndexType index4D;
+    ScalarImage4DType::IndexType index4D;
     index4D.Fill(0);
     region4D.SetIndex(index4D);
     region4D.SetSize(size4D);
@@ -416,11 +416,11 @@ Volume4DType::Pointer DWIDICOMConverterBase::ThreeDUnwrappedToFourDImage(Volume3
               << size3D[2] % nVolumes << std::endl);
     }
   }
-  Volume4DType::DirectionType direction4D;
+  ScalarImage4DType::DirectionType direction4D;
   direction4D.SetIdentity();
-  Volume4DType::SpacingType   spacing4D;
+  ScalarImage4DType::SpacingType   spacing4D;
   spacing4D.Fill(1.0);
-  Volume4DType::PointType     origin4D;
+  ScalarImage4DType::PointType     origin4D;
   origin4D.Fill(0.0);
   for( unsigned i = 0; i < 3; ++i )
   {
@@ -433,7 +433,7 @@ Volume4DType::Pointer DWIDICOMConverterBase::ThreeDUnwrappedToFourDImage(Volume3
   }
 
 
-  Volume4DType::Pointer img4D = Volume4DType::New();
+  ScalarImage4DType::Pointer img4D = ScalarImage4DType::New();
   img4D->SetRegions(region4D);
   img4D->SetDirection(direction4D);
   img4D->SetSpacing(spacing4D);
@@ -456,22 +456,22 @@ Volume4DType::Pointer DWIDICOMConverterBase::ThreeDUnwrappedToFourDImage(Volume3
 }
 
 
-Volume3DType::Pointer DWIDICOMConverterBase::FourDToThreeDUnwrappedImage(Volume4DType::Pointer img4D) const
+ScalarImage3DType::Pointer DWIDICOMConverterBase::FourDToThreeDUnwrappedImage(ScalarImage4DType::Pointer img4D) const
 {
-  Volume4DType::SizeType      size4D(img4D->GetLargestPossibleRegion().GetSize() );
-  Volume4DType::DirectionType direction4D(img4D->GetDirection() );
-  Volume4DType::SpacingType   spacing4D(img4D->GetSpacing() );
-  Volume4DType::PointType     origin4D(img4D->GetOrigin() );
+  ScalarImage4DType::SizeType      size4D(img4D->GetLargestPossibleRegion().GetSize() );
+  ScalarImage4DType::DirectionType direction4D(img4D->GetDirection() );
+  ScalarImage4DType::SpacingType   spacing4D(img4D->GetSpacing() );
+  ScalarImage4DType::PointType     origin4D(img4D->GetOrigin() );
 
-  Volume3DType::RegionType region3D;
+  ScalarImage3DType::RegionType region3D;
   {
-    Volume3DType::SizeType size3D;
+    ScalarImage3DType::SizeType size3D;
     size3D[0] = size4D[0];
     size3D[1] = size4D[1];
     const int nVolumes = img4D->GetLargestPossibleRegion().GetSize()[3];
     size3D[2] = size4D[2] * nVolumes;
 
-    Volume3DType::IndexType index3D;
+    ScalarImage3DType::IndexType index3D;
     index3D.Fill(0);
     region3D.SetIndex(index3D);
     region3D.SetSize(size3D);
@@ -485,11 +485,11 @@ Volume3DType::Pointer DWIDICOMConverterBase::FourDToThreeDUnwrappedImage(Volume4
               << size3D[2] % nVolumes << std::endl);
     }
   }
-  Volume3DType::DirectionType direction3D;
+  ScalarImage3DType::DirectionType direction3D;
   direction3D.SetIdentity();
-  Volume3DType::SpacingType   spacing3D;
+  ScalarImage3DType::SpacingType   spacing3D;
   spacing3D.Fill(1.0);
-  Volume3DType::PointType     origin3D;
+  ScalarImage3DType::PointType     origin3D;
   origin3D.Fill(0.0);
   for( unsigned i = 0; i < 3; ++i )
   {
@@ -501,7 +501,7 @@ Volume3DType::Pointer DWIDICOMConverterBase::FourDToThreeDUnwrappedImage(Volume4
     origin3D[i] = origin4D[i];
   }
 
-  Volume3DType::Pointer img = Volume3DType::New();
+  ScalarImage3DType::Pointer img = ScalarImage3DType::New();
   img->SetRegions(region3D);
   img->SetDirection(direction3D);
   img->SetSpacing(spacing3D);

--- a/DWIConvert/DWIDICOMConverterBase.h
+++ b/DWIConvert/DWIDICOMConverterBase.h
@@ -118,7 +118,7 @@ protected:
      */
     /** the image read from the DICOM dataset */
 
-    ScalarImage3DType::Pointer m_3DUnwrappedVolume;
+    ScalarImage3DType::Pointer m_scalarImage3DUnwrapped;
 
     ScalarImage4DType::Pointer ThreeDUnwrappedToFourDImage(ScalarImage3DType::Pointer img) const;
 

--- a/DWIConvert/DWIDICOMConverterBase.h
+++ b/DWIConvert/DWIDICOMConverterBase.h
@@ -18,6 +18,16 @@
 class DWIDICOMConverterBase : public DWIConverter {
  public:
 
+    /* The internal format is an unwrapped 3D scalar image that is x,y,slices
+   * where slices is all the slices in both 3D and 4d directions.
+   * If each volume is 3DSlices, and their are NumGradients, then
+   * the last direction of the unwrapped direction is (3DSlices*NumGradients).
+   */
+  typedef itk::Image<PixelValueType, 3>  Volume3DUnwrappedType;
+
+  typedef itk::ImageSeriesReader<Volume3DUnwrappedType> ReaderType;
+  //typedef ReaderType::FileNamesContainer                FileNamesContainer;
+
   typedef itk::DCMTKSeriesFileNames           InputNamesGeneratorType;
   typedef std::vector<itk::DCMTKFileReader *> DCMTKFileVector;
 
@@ -73,6 +83,9 @@ protected:
   /* determine if slice order is inferior to superior */
   void DetermineSliceOrderIS();
 
+    unsigned int GetSlicesPerVolume() const;
+    unsigned int GetNVolume() const;
+
   /** force use of the BMatrix to compute gradients in Siemens data instead of
    *  the reported gradients. which are in many cases bogus.
    */
@@ -91,6 +104,24 @@ protected:
 
   /** track if images is interleaved */
   bool                        m_IsInterleaved;
+
+    /** dimensions */
+    unsigned int        m_SlicesPerVolume;
+    /** number of total slices */
+    unsigned int        m_NSlice;
+    /** number of gradient volumes */
+    unsigned int        m_NVolume;
+    /* The following variables make up the primary data model for diffusion weighted images
+     * in the most generic sense.  These variables all need to be manipulated together in
+     * order to maintain a consistent data model.
+     */
+    /** the image read from the DICOM dataset */
+
+    Volume3DUnwrappedType::Pointer m_3DUnwrappedVolume;
+
+    Volume4DType::Pointer ThreeDUnwrappedToFourDImage(Volume3DUnwrappedType::Pointer img) const;
+
+    Volume3DUnwrappedType::Pointer FourDToThreeDUnwrappedImage(Volume4DType::Pointer img4D) const;
 
 
 

--- a/DWIConvert/DWIDICOMConverterBase.h
+++ b/DWIConvert/DWIDICOMConverterBase.h
@@ -18,14 +18,15 @@
 class DWIDICOMConverterBase : public DWIConverter {
  public:
 
-    /* The internal format is an unwrapped 3D scalar image that is x,y,slices
+    /* Volume3DType:
+     *
+     * The internal format is an unwrapped 3D scalar image that is x,y,slices
    * where slices is all the slices in both 3D and 4d directions.
    * If each volume is 3DSlices, and their are NumGradients, then
    * the last direction of the unwrapped direction is (3DSlices*NumGradients).
    */
-  typedef itk::Image<PixelValueType, 3>  Volume3DUnwrappedType;
 
-  typedef itk::ImageSeriesReader<Volume3DUnwrappedType> ReaderType;
+  typedef itk::ImageSeriesReader<Volume3DType> ReaderType;
   //typedef ReaderType::FileNamesContainer                FileNamesContainer;
 
   typedef itk::DCMTKSeriesFileNames           InputNamesGeneratorType;
@@ -117,11 +118,11 @@ protected:
      */
     /** the image read from the DICOM dataset */
 
-    Volume3DUnwrappedType::Pointer m_3DUnwrappedVolume;
+    Volume3DType::Pointer m_3DUnwrappedVolume;
 
-    Volume4DType::Pointer ThreeDUnwrappedToFourDImage(Volume3DUnwrappedType::Pointer img) const;
+    Volume4DType::Pointer ThreeDUnwrappedToFourDImage(Volume3DType::Pointer img) const;
 
-    Volume3DUnwrappedType::Pointer FourDToThreeDUnwrappedImage(Volume4DType::Pointer img4D) const;
+    Volume3DType::Pointer FourDToThreeDUnwrappedImage(Volume4DType::Pointer img4D) const;
 
 
 

--- a/DWIConvert/DWIDICOMConverterBase.h
+++ b/DWIConvert/DWIDICOMConverterBase.h
@@ -84,8 +84,7 @@ protected:
   /* determine if slice order is inferior to superior */
   void DetermineSliceOrderIS();
 
-    unsigned int GetSlicesPerVolume() const;
-    unsigned int GetNVolume() const;
+
 
   /** force use of the BMatrix to compute gradients in Siemens data instead of
    *  the reported gradients. which are in many cases bogus.
@@ -106,23 +105,16 @@ protected:
   /** track if images is interleaved */
   bool                        m_IsInterleaved;
 
-    /** dimensions */
-    unsigned int        m_SlicesPerVolume;
-    /** number of total slices */
-    unsigned int        m_NSlice;
-    /** number of gradient volumes */
-    unsigned int        m_NVolume;
+
     /* The following variables make up the primary data model for diffusion weighted images
      * in the most generic sense.  These variables all need to be manipulated together in
      * order to maintain a consistent data model.
      */
     /** the image read from the DICOM dataset */
 
-    ScalarImage3DType::Pointer m_scalarImage3DUnwrapped;
+    //ScalarImage3DType::Pointer m_scalarImage3DUnwrapped;
 
-    ScalarImage4DType::Pointer ThreeDUnwrappedToFourDImage(ScalarImage3DType::Pointer img) const;
 
-    ScalarImage3DType::Pointer FourDToThreeDUnwrappedImage(ScalarImage4DType::Pointer img4D) const;
 
 
 

--- a/DWIConvert/DWIDICOMConverterBase.h
+++ b/DWIConvert/DWIDICOMConverterBase.h
@@ -18,7 +18,7 @@
 class DWIDICOMConverterBase : public DWIConverter {
  public:
 
-    /* Volume3DType:
+    /* ScalarImage3DType:
      *
      * The internal format is an unwrapped 3D scalar image that is x,y,slices
    * where slices is all the slices in both 3D and 4d directions.
@@ -26,7 +26,7 @@ class DWIDICOMConverterBase : public DWIConverter {
    * the last direction of the unwrapped direction is (3DSlices*NumGradients).
    */
 
-  typedef itk::ImageSeriesReader<Volume3DType> ReaderType;
+  typedef itk::ImageSeriesReader<ScalarImage3DType> ReaderType;
   //typedef ReaderType::FileNamesContainer                FileNamesContainer;
 
   typedef itk::DCMTKSeriesFileNames           InputNamesGeneratorType;
@@ -118,11 +118,11 @@ protected:
      */
     /** the image read from the DICOM dataset */
 
-    Volume3DType::Pointer m_3DUnwrappedVolume;
+    ScalarImage3DType::Pointer m_3DUnwrappedVolume;
 
-    Volume4DType::Pointer ThreeDUnwrappedToFourDImage(Volume3DType::Pointer img) const;
+    ScalarImage4DType::Pointer ThreeDUnwrappedToFourDImage(ScalarImage3DType::Pointer img) const;
 
-    Volume3DType::Pointer FourDToThreeDUnwrappedImage(Volume4DType::Pointer img4D) const;
+    ScalarImage3DType::Pointer FourDToThreeDUnwrappedImage(ScalarImage4DType::Pointer img4D) const;
 
 
 

--- a/DWIConvert/FSLDWIConverter.cxx
+++ b/DWIConvert/FSLDWIConverter.cxx
@@ -34,7 +34,7 @@ FSLDWIConverter::LoadFromDisk()
   ReadScalarVolume<ScalarImage4DType>(inputVol, fslNIFTIFile, this->m_allowLossyConversion);
   // Reorient from FSL standard format to ITK/Dicom standard format
 
-  this->m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume(inputVol);
+  this->m_vectorImage3D = convertScalarImage4DToVectorImage3D(inputVol);
 
 }
 

--- a/DWIConvert/FSLDWIConverter.cxx
+++ b/DWIConvert/FSLDWIConverter.cxx
@@ -34,7 +34,12 @@ FSLDWIConverter::LoadFromDisk()
   ReadScalarVolume<ScalarImage4DType>(inputVol, fslNIFTIFile, this->m_allowLossyConversion);
   // Reorient from FSL standard format to ITK/Dicom standard format
 
-  this->m_vectorImage3D = convertScalarImage4DToVectorImage3D(inputVol);
+  //this->m_vectorImage3D = convertScalarImage4DToVectorImage3D(inputVol);
+  // Reorient from FSL standard format to ITK/Dicom standard format
+  this->m_SlicesPerVolume = inputVol->GetLargestPossibleRegion().GetSize()[2];
+  this->m_NVolume = inputVol->GetLargestPossibleRegion().GetSize()[3];
+  this->m_NSlice = this->m_SlicesPerVolume * this->m_NVolume;
+  this->m_scalarImage3D = FourDToThreeDUnwrappedImage(inputVol);
 
 }
 

--- a/DWIConvert/FSLDWIConverter.cxx
+++ b/DWIConvert/FSLDWIConverter.cxx
@@ -28,10 +28,10 @@ FSLDWIConverter::LoadFromDisk()
 {
   const std::string fslNIFTIFile = m_InputFileNames[0];
 
-  Volume4DType::Pointer inputVol;
+  ScalarImage4DType::Pointer inputVol;
 
   // string to use as template if no bval or bvec filename is given.
-  ReadScalarVolume<Volume4DType>(inputVol, fslNIFTIFile, this->m_allowLossyConversion);
+  ReadScalarVolume<ScalarImage4DType>(inputVol, fslNIFTIFile, this->m_allowLossyConversion);
   // Reorient from FSL standard format to ITK/Dicom standard format
 
   this->m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume(inputVol);

--- a/DWIConvert/FSLDWIConverter.cxx
+++ b/DWIConvert/FSLDWIConverter.cxx
@@ -35,6 +35,7 @@ FSLDWIConverter::LoadFromDisk()
   // Reorient from FSL standard format to ITK/Dicom standard format
 
   this->m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume(inputVol);
+
 }
 
 void

--- a/DWIConvert/FSLDWIConverter.cxx
+++ b/DWIConvert/FSLDWIConverter.cxx
@@ -33,10 +33,8 @@ FSLDWIConverter::LoadFromDisk()
   // string to use as template if no bval or bvec filename is given.
   ReadScalarVolume<Volume4DType>(inputVol, fslNIFTIFile, this->m_allowLossyConversion);
   // Reorient from FSL standard format to ITK/Dicom standard format
-  this->m_SlicesPerVolume = inputVol->GetLargestPossibleRegion().GetSize()[2];
-  this->m_NVolume = inputVol->GetLargestPossibleRegion().GetSize()[3];
-  this->m_NSlice = this->m_SlicesPerVolume * this->m_NVolume;
-  this->m_Volume = FourDToThreeDImage(inputVol);
+
+  this->m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume(inputVol);
 }
 
 void

--- a/DWIConvert/FSLToNrrd.cxx
+++ b/DWIConvert/FSLToNrrd.cxx
@@ -30,8 +30,7 @@
 #include "DWIMetaDataDictionaryValidator.h"
 
 typedef short                               PixelValueType;
-typedef itk::Image<PixelValueType, 4>       Volume4DType;
-typedef itk::Image<PixelValueType, 3>       Volume3DType;
+
 
 
 int

--- a/DWIConvert/FSLToNrrd.cxx
+++ b/DWIConvert/FSLToNrrd.cxx
@@ -50,19 +50,19 @@ FSLToNrrd(const std::string & inputVolume,
     return EXIT_FAILURE;
     }
 
-  Volume4DType::Pointer inputVol;
+  ScalarImage4DType::Pointer inputVol;
 
   // string to use as template if no bval or bvec filename is given.
   std::string inputVolumeNameTemplate = inputVolume;
   if(fslNIFTIFile.size() > 0)
     {
-    if( ReadVolume<Volume4DType>(inputVol, fslNIFTIFile, allowLossyConversion) != EXIT_SUCCESS )
+    if( ReadVolume<ScalarImage4DType>(inputVol, fslNIFTIFile, allowLossyConversion) != EXIT_SUCCESS )
       {
       return EXIT_FAILURE;
       }
     inputVolumeNameTemplate = fslNIFTIFile;
     }
-  else if( inputVolume.size() == 0 || ReadVolume<Volume4DType>(inputVol, inputVolume, allowLossyConversion) != EXIT_SUCCESS )
+  else if( inputVolume.size() == 0 || ReadVolume<ScalarImage4DType>(inputVol, inputVolume, allowLossyConversion) != EXIT_SUCCESS )
     {
     return EXIT_FAILURE;
     }
@@ -148,10 +148,10 @@ FSLToNrrd(const std::string & inputVolume,
       }
     }
 
-  Volume4DType::SizeType inputSize =
+  ScalarImage4DType::SizeType inputSize =
     inputVol->GetLargestPossibleRegion().GetSize();
 
-  Volume4DType::IndexType inputIndex =
+  ScalarImage4DType::IndexType inputIndex =
     inputVol->GetLargestPossibleRegion().GetIndex();
 
   const unsigned int volumeCount = inputSize[3];
@@ -164,24 +164,24 @@ FSLToNrrd(const std::string & inputVolume,
     }
 
   // convert from image series to vector voxels
-  Volume4DType::SpacingType   inputSpacing = inputVol->GetSpacing();
+  ScalarImage4DType::SpacingType   inputSpacing = inputVol->GetSpacing();
   std::cout << "Spacing :" << inputSpacing << std::endl;
 
   ////////
-  // "inputVol" is read as a 4D image. Here we convert that to a Vector3DType:
+  // "inputVol" is read as a 4D image. Here we convert that to a VectorImage3DType:
   //
-  typedef itk::ExtractImageFilter< Volume4DType, Volume3DType > ExtractFilterType;
+  typedef itk::ExtractImageFilter< ScalarImage4DType, ScalarImage3DType > ExtractFilterType;
 
-  typedef itk::ComposeImageFilter<Volume3DType, Vector3DType> ComposeImageFilterType;
+  typedef itk::ComposeImageFilter<ScalarImage3DType, VectorImage3DType> ComposeImageFilterType;
   ComposeImageFilterType::Pointer composer= ComposeImageFilterType::New();
 
   for( size_t componentNumber = 0; componentNumber < inputSize[3]; ++componentNumber )
      {
-     Volume4DType::SizeType extractSize = inputSize;
+     ScalarImage4DType::SizeType extractSize = inputSize;
      extractSize[3] = 0;
-     Volume4DType::IndexType extractIndex = inputIndex;
+     ScalarImage4DType::IndexType extractIndex = inputIndex;
      extractIndex[3] = componentNumber;
-     Volume4DType::RegionType extractRegion(extractIndex, extractSize);
+     ScalarImage4DType::RegionType extractRegion(extractIndex, extractSize);
 
      ExtractFilterType::Pointer extracter = ExtractFilterType::New();
      extracter->SetExtractionRegion( extractRegion );
@@ -192,7 +192,7 @@ FSLToNrrd(const std::string & inputVolume,
      composer->SetInput(componentNumber,extracter->GetOutput());
      }
   composer->Update();
-  Vector3DType::Pointer nrrdVolume = composer->GetOutput();
+  VectorImage3DType::Pointer nrrdVolume = composer->GetOutput();
 
   const unsigned int nrrdNumOfComponents = nrrdVolume->GetNumberOfComponentsPerPixel();
   std::cout << "Number of components in converted Nrrd volume: " << nrrdNumOfComponents << std::endl;
@@ -263,7 +263,7 @@ FSLToNrrd(const std::string & inputVolume,
   // Add metaDataDictionary to Nrrd volume
   nrrdVolume->SetMetaDataDictionary(nrrdVolumeValidator.GetMetaDataDictionary());
   // Write Nrrd volume to disk
-  typedef itk::ImageFileWriter<Vector3DType> WriterType;
+  typedef itk::ImageFileWriter<VectorImage3DType> WriterType;
   WriterType::Pointer nrrdWriter = WriterType::New();
   nrrdWriter->UseCompressionOn();
   nrrdWriter->UseInputMetaDataDictionaryOn();

--- a/DWIConvert/FSLToNrrd.cxx
+++ b/DWIConvert/FSLToNrrd.cxx
@@ -32,7 +32,7 @@
 typedef short                               PixelValueType;
 typedef itk::Image<PixelValueType, 4>       Volume4DType;
 typedef itk::Image<PixelValueType, 3>       Volume3DType;
-typedef itk::VectorImage<PixelValueType, 3> VectorVolumeType;
+
 
 int
 FSLToNrrd(const std::string & inputVolume,
@@ -169,11 +169,11 @@ FSLToNrrd(const std::string & inputVolume,
   std::cout << "Spacing :" << inputSpacing << std::endl;
 
   ////////
-  // "inputVol" is read as a 4D image. Here we convert that to a VectorImageType:
+  // "inputVol" is read as a 4D image. Here we convert that to a Vector3DType:
   //
   typedef itk::ExtractImageFilter< Volume4DType, Volume3DType > ExtractFilterType;
 
-  typedef itk::ComposeImageFilter<Volume3DType, VectorVolumeType> ComposeImageFilterType;
+  typedef itk::ComposeImageFilter<Volume3DType, Vector3DType> ComposeImageFilterType;
   ComposeImageFilterType::Pointer composer= ComposeImageFilterType::New();
 
   for( size_t componentNumber = 0; componentNumber < inputSize[3]; ++componentNumber )
@@ -193,7 +193,7 @@ FSLToNrrd(const std::string & inputVolume,
      composer->SetInput(componentNumber,extracter->GetOutput());
      }
   composer->Update();
-  VectorVolumeType::Pointer nrrdVolume = composer->GetOutput();
+  Vector3DType::Pointer nrrdVolume = composer->GetOutput();
 
   const unsigned int nrrdNumOfComponents = nrrdVolume->GetNumberOfComponentsPerPixel();
   std::cout << "Number of components in converted Nrrd volume: " << nrrdNumOfComponents << std::endl;
@@ -264,7 +264,7 @@ FSLToNrrd(const std::string & inputVolume,
   // Add metaDataDictionary to Nrrd volume
   nrrdVolume->SetMetaDataDictionary(nrrdVolumeValidator.GetMetaDataDictionary());
   // Write Nrrd volume to disk
-  typedef itk::ImageFileWriter<VectorVolumeType> WriterType;
+  typedef itk::ImageFileWriter<Vector3DType> WriterType;
   WriterType::Pointer nrrdWriter = WriterType::New();
   nrrdWriter->UseCompressionOn();
   nrrdWriter->UseInputMetaDataDictionaryOn();

--- a/DWIConvert/GEDWIConverter.cxx
+++ b/DWIConvert/GEDWIConverter.cxx
@@ -15,11 +15,11 @@ GEDWIConverter::~GEDWIConverter() {}
 void GEDWIConverter::LoadDicomDirectory()
 {
       this->DWIDICOMConverterBase::LoadDicomDirectory();
-      this->m_MeasurementFrame = this->m_3DUnwrappedVolume->GetDirection();
+      this->m_MeasurementFrame = this->m_scalarImage3DUnwrapped->GetDirection();
       this->DetermineSliceOrderIS();
       this->SetDirectionsFromSliceOrder();
       this->m_NVolume = this->m_NSlice / this->m_SlicesPerVolume;
-      m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume( ThreeDUnwrappedToFourDImage(m_3DUnwrappedVolume));
+      m_vectorImage3D = convertScalarImage4DToVectorImage3D( ThreeDUnwrappedToFourDImage(m_scalarImage3DUnwrapped));
     }
 
 void GEDWIConverter::ExtractDWIData()

--- a/DWIConvert/GEDWIConverter.cxx
+++ b/DWIConvert/GEDWIConverter.cxx
@@ -15,10 +15,11 @@ GEDWIConverter::~GEDWIConverter() {}
 void GEDWIConverter::LoadDicomDirectory()
 {
       this->DWIDICOMConverterBase::LoadDicomDirectory();
-      this->m_MeasurementFrame = this->m_Volume->GetDirection();
+      this->m_MeasurementFrame = this->m_3DUnwrappedVolume->GetDirection();
       this->DetermineSliceOrderIS();
       this->SetDirectionsFromSliceOrder();
       this->m_NVolume = this->m_NSlice / this->m_SlicesPerVolume;
+      m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume( ThreeDUnwrappedToFourDImage(m_3DUnwrappedVolume));
     }
 
 void GEDWIConverter::ExtractDWIData()

--- a/DWIConvert/GEDWIConverter.cxx
+++ b/DWIConvert/GEDWIConverter.cxx
@@ -15,11 +15,11 @@ GEDWIConverter::~GEDWIConverter() {}
 void GEDWIConverter::LoadDicomDirectory()
 {
       this->DWIDICOMConverterBase::LoadDicomDirectory();
-      this->m_MeasurementFrame = this->m_scalarImage3DUnwrapped->GetDirection();
+      this->m_MeasurementFrame = this->m_scalarImage3D->GetDirection();
       this->DetermineSliceOrderIS();
       this->SetDirectionsFromSliceOrder();
       this->m_NVolume = this->m_NSlice / this->m_SlicesPerVolume;
-      m_vectorImage3D = convertScalarImage4DToVectorImage3D( ThreeDUnwrappedToFourDImage(m_scalarImage3DUnwrapped));
+      //m_vectorImage3D = convertScalarImage4DToVectorImage3D( ThreeDUnwrappedToFourDImage(m_scalarImage3DUnwrapped));
     }
 
 void GEDWIConverter::ExtractDWIData()

--- a/DWIConvert/HitachiDWIConverter.cxx
+++ b/DWIConvert/HitachiDWIConverter.cxx
@@ -22,6 +22,7 @@ void HitachiDWIConverter::LoadDicomDirectory()
       this->m_SliceOrderIS = false;
       this->SetDirectionsFromSliceOrder();
       this->m_NVolume = this->m_NSlice / this->m_SlicesPerVolume;
+    m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume( ThreeDUnwrappedToFourDImage(m_3DUnwrappedVolume));
     }
   /** extract gradient vectors.
    *  Hitachi apparently supports the Supplement 49 definition

--- a/DWIConvert/HitachiDWIConverter.cxx
+++ b/DWIConvert/HitachiDWIConverter.cxx
@@ -22,7 +22,7 @@ void HitachiDWIConverter::LoadDicomDirectory()
       this->m_SliceOrderIS = false;
       this->SetDirectionsFromSliceOrder();
       this->m_NVolume = this->m_NSlice / this->m_SlicesPerVolume;
-    m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume( ThreeDUnwrappedToFourDImage(m_3DUnwrappedVolume));
+    m_vectorImage3D = convertScalarImage4DToVectorImage3D( ThreeDUnwrappedToFourDImage(m_scalarImage3DUnwrapped));
     }
   /** extract gradient vectors.
    *  Hitachi apparently supports the Supplement 49 definition

--- a/DWIConvert/HitachiDWIConverter.cxx
+++ b/DWIConvert/HitachiDWIConverter.cxx
@@ -22,7 +22,7 @@ void HitachiDWIConverter::LoadDicomDirectory()
       this->m_SliceOrderIS = false;
       this->SetDirectionsFromSliceOrder();
       this->m_NVolume = this->m_NSlice / this->m_SlicesPerVolume;
-    m_vectorImage3D = convertScalarImage4DToVectorImage3D( ThreeDUnwrappedToFourDImage(m_scalarImage3DUnwrapped));
+    //m_vectorImage3D = convertScalarImage4DToVectorImage3D( ThreeDUnwrappedToFourDImage(m_scalarImage3DUnwrapped));
     }
   /** extract gradient vectors.
    *  Hitachi apparently supports the Supplement 49 definition

--- a/DWIConvert/NRRDDWIConverter.cxx
+++ b/DWIConvert/NRRDDWIConverter.cxx
@@ -102,6 +102,7 @@ NRRDDWIConverter::LoadFromDisk()
       itkGenericExceptionMacro(<< "ERROR Reading NRRD File : " << nrrdNRRDFile << std::endl;);
   }
 
+
 }
 
 void

--- a/DWIConvert/NRRDDWIConverter.cxx
+++ b/DWIConvert/NRRDDWIConverter.cxx
@@ -94,10 +94,10 @@ NRRDDWIConverter::LoadFromDisk()
 
   //Conert vector 3D volume to 4DVolume
   ScalarImage4DType::Pointer                 fourDVolume = CreateVolume(vector3DVolume);
-  this->m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume(fourDVolume);*/
+  this->m_vectorImage3D = convertScalarImage4DToVectorImage3D(fourDVolume);*/
 
   // modified by Hui Xie Jan 6th, 2016
-  if( ReadVectorVolume<VectorImage3DType>( m_Vector3DVolume, nrrdNRRDFile, this->m_allowLossyConversion ) != EXIT_SUCCESS )
+  if( ReadVectorVolume<VectorImage3DType>( m_vectorImage3D, nrrdNRRDFile, this->m_allowLossyConversion ) != EXIT_SUCCESS )
   {
       itkGenericExceptionMacro(<< "ERROR Reading NRRD File : " << nrrdNRRDFile << std::endl;);
   }
@@ -108,9 +108,9 @@ NRRDDWIConverter::LoadFromDisk()
 void
 NRRDDWIConverter::ExtractDWIData()
 {
-  RecoverMeasurementFrame<VectorImage3DType>(this->m_Vector3DVolume.GetPointer(), this->m_MeasurementFrame);
-  RecoverBVectors<VectorImage3DType>(this->m_Vector3DVolume.GetPointer(), this->m_DiffusionVectors);
-  RecoverBValues<VectorImage3DType>(this->m_Vector3DVolume.GetPointer(), this->m_DiffusionVectors, this->m_BValues);
+  RecoverMeasurementFrame<VectorImage3DType>(this->m_vectorImage3D.GetPointer(), this->m_MeasurementFrame);
+  RecoverBVectors<VectorImage3DType>(this->m_vectorImage3D.GetPointer(), this->m_DiffusionVectors);
+  RecoverBValues<VectorImage3DType>(this->m_vectorImage3D.GetPointer(), this->m_DiffusionVectors, this->m_BValues);
 }
 
 DWIConverter::CommonDicomFieldMapType NRRDDWIConverter::GetCommonDicomFieldsMap() const

--- a/DWIConvert/NRRDDWIConverter.cxx
+++ b/DWIConvert/NRRDDWIConverter.cxx
@@ -86,7 +86,7 @@ NRRDDWIConverter::LoadFromDisk()
 {
   const std::string nrrdNRRDFile = m_InputFileNames[0];
 
-  /*VectorImage3DType::Pointer vector3DVolume;
+  VectorImage3DType::Pointer vector3DVolume;
   if( ReadVectorVolume<VectorImage3DType>( vector3DVolume, nrrdNRRDFile, this->m_allowLossyConversion ) != EXIT_SUCCESS )
   {
     itkGenericExceptionMacro(<< "ERROR Reading NRRD File : " << nrrdNRRDFile << std::endl;);
@@ -94,13 +94,10 @@ NRRDDWIConverter::LoadFromDisk()
 
   //Conert vector 3D volume to 4DVolume
   ScalarImage4DType::Pointer                 fourDVolume = CreateVolume(vector3DVolume);
-  this->m_vectorImage3D = convertScalarImage4DToVectorImage3D(fourDVolume);*/
-
-  // modified by Hui Xie Jan 6th, 2016
-  if( ReadVectorVolume<VectorImage3DType>( m_vectorImage3D, nrrdNRRDFile, this->m_allowLossyConversion ) != EXIT_SUCCESS )
-  {
-      itkGenericExceptionMacro(<< "ERROR Reading NRRD File : " << nrrdNRRDFile << std::endl;);
-  }
+  this->m_SlicesPerVolume = fourDVolume->GetLargestPossibleRegion().GetSize()[2];
+  this->m_NVolume = fourDVolume->GetLargestPossibleRegion().GetSize()[3];
+  this->m_NSlice = this->m_SlicesPerVolume * this->m_NVolume;
+  this->m_scalarImage3D = FourDToThreeDUnwrappedImage(fourDVolume);
 
 
 }
@@ -108,9 +105,9 @@ NRRDDWIConverter::LoadFromDisk()
 void
 NRRDDWIConverter::ExtractDWIData()
 {
-  RecoverMeasurementFrame<VectorImage3DType>(this->m_vectorImage3D.GetPointer(), this->m_MeasurementFrame);
-  RecoverBVectors<VectorImage3DType>(this->m_vectorImage3D.GetPointer(), this->m_DiffusionVectors);
-  RecoverBValues<VectorImage3DType>(this->m_vectorImage3D.GetPointer(), this->m_DiffusionVectors, this->m_BValues);
+  RecoverMeasurementFrame<ScalarImage3DType>(this->m_scalarImage3D.GetPointer(), this->m_MeasurementFrame);
+  RecoverBVectors<ScalarImage3DType>(this->m_scalarImage3D.GetPointer(), this->m_DiffusionVectors);
+  RecoverBValues<ScalarImage3DType>(this->m_scalarImage3D.GetPointer(), this->m_DiffusionVectors, this->m_BValues);
 }
 
 DWIConverter::CommonDicomFieldMapType NRRDDWIConverter::GetCommonDicomFieldsMap() const

--- a/DWIConvert/NRRDDWIConverter.cxx
+++ b/DWIConvert/NRRDDWIConverter.cxx
@@ -18,19 +18,19 @@ NRRDDWIConverter::AddFlagsToDictionary()
 }
 
 
-Volume4DType::Pointer
-NRRDDWIConverter::CreateVolume(Vector3DType::Pointer & vector3DVolume)
+ScalarImage4DType::Pointer
+NRRDDWIConverter::CreateVolume(VectorImage3DType::Pointer & vector3DVolume)
 {
-  Vector3DType::SizeType      inputSize = vector3DVolume->GetLargestPossibleRegion().GetSize();
-  Vector3DType::SpacingType   inputSpacing = vector3DVolume->GetSpacing();
-  Vector3DType::PointType     inputOrigin = vector3DVolume->GetOrigin();
-  Vector3DType::DirectionType inputDirection = vector3DVolume->GetDirection();
+  VectorImage3DType::SizeType      inputSize = vector3DVolume->GetLargestPossibleRegion().GetSize();
+  VectorImage3DType::SpacingType   inputSpacing = vector3DVolume->GetSpacing();
+  VectorImage3DType::PointType     inputOrigin = vector3DVolume->GetOrigin();
+  VectorImage3DType::DirectionType inputDirection = vector3DVolume->GetDirection();
 
-  Volume4DType::Pointer fourDVolume = Volume4DType::New();
-  Volume4DType::SizeType      volSize;
-  Volume4DType::SpacingType   volSpacing;
-  Volume4DType::PointType     volOrigin;
-  Volume4DType::DirectionType volDirection;
+  ScalarImage4DType::Pointer fourDVolume = ScalarImage4DType::New();
+  ScalarImage4DType::SizeType      volSize;
+  ScalarImage4DType::SpacingType   volSpacing;
+  ScalarImage4DType::PointType     volOrigin;
+  ScalarImage4DType::DirectionType volDirection;
 
   for( unsigned int i = 0; i < 3; ++i )
   {
@@ -55,20 +55,20 @@ NRRDDWIConverter::CreateVolume(Vector3DType::Pointer & vector3DVolume)
   fourDVolume->SetDirection(volDirection);
   fourDVolume->Allocate();
 
-  const Volume4DType::IndexType::IndexValueType vecLength = vector3DVolume->GetNumberOfComponentsPerPixel();
+  const ScalarImage4DType::IndexType::IndexValueType vecLength = vector3DVolume->GetNumberOfComponentsPerPixel();
 
-  Vector3DType::IndexType vecIndex;
-  Volume4DType::IndexType       volIndex;
+  VectorImage3DType::IndexType vecIndex;
+  ScalarImage4DType::IndexType       volIndex;
   // convert from vector image to 4D volume image
   for( volIndex[3] = 0; volIndex[3] < vecLength; ++volIndex[3] )
   {
-    for( volIndex[2] = 0; volIndex[2] < static_cast<Volume4DType::IndexType::IndexValueType>( inputSize[2] ); ++volIndex[2] )
+    for( volIndex[2] = 0; volIndex[2] < static_cast<ScalarImage4DType::IndexType::IndexValueType>( inputSize[2] ); ++volIndex[2] )
     {
       vecIndex[2] = volIndex[2];
-      for( volIndex[1] = 0; volIndex[1] < static_cast<Volume4DType::IndexType::IndexValueType>( inputSize[1] ); ++volIndex[1] )
+      for( volIndex[1] = 0; volIndex[1] < static_cast<ScalarImage4DType::IndexType::IndexValueType>( inputSize[1] ); ++volIndex[1] )
       {
         vecIndex[1] = volIndex[1];
-        for( volIndex[0] = 0; volIndex[0] < static_cast<Volume4DType::IndexType::IndexValueType>( inputSize[0] ); ++volIndex[0] )
+        for( volIndex[0] = 0; volIndex[0] < static_cast<ScalarImage4DType::IndexType::IndexValueType>( inputSize[0] ); ++volIndex[0] )
         {
           vecIndex[0] = volIndex[0];
           fourDVolume->SetPixel(volIndex, vector3DVolume->GetPixel(vecIndex)[volIndex[3]]);
@@ -86,18 +86,18 @@ NRRDDWIConverter::LoadFromDisk()
 {
   const std::string nrrdNRRDFile = m_InputFileNames[0];
 
-  /*Vector3DType::Pointer vector3DVolume;
-  if( ReadVectorVolume<Vector3DType>( vector3DVolume, nrrdNRRDFile, this->m_allowLossyConversion ) != EXIT_SUCCESS )
+  /*VectorImage3DType::Pointer vector3DVolume;
+  if( ReadVectorVolume<VectorImage3DType>( vector3DVolume, nrrdNRRDFile, this->m_allowLossyConversion ) != EXIT_SUCCESS )
   {
     itkGenericExceptionMacro(<< "ERROR Reading NRRD File : " << nrrdNRRDFile << std::endl;);
   }
 
   //Conert vector 3D volume to 4DVolume
-  Volume4DType::Pointer                 fourDVolume = CreateVolume(vector3DVolume);
+  ScalarImage4DType::Pointer                 fourDVolume = CreateVolume(vector3DVolume);
   this->m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume(fourDVolume);*/
 
   // modified by Hui Xie Jan 6th, 2016
-  if( ReadVectorVolume<Vector3DType>( m_Vector3DVolume, nrrdNRRDFile, this->m_allowLossyConversion ) != EXIT_SUCCESS )
+  if( ReadVectorVolume<VectorImage3DType>( m_Vector3DVolume, nrrdNRRDFile, this->m_allowLossyConversion ) != EXIT_SUCCESS )
   {
       itkGenericExceptionMacro(<< "ERROR Reading NRRD File : " << nrrdNRRDFile << std::endl;);
   }
@@ -108,9 +108,9 @@ NRRDDWIConverter::LoadFromDisk()
 void
 NRRDDWIConverter::ExtractDWIData()
 {
-  RecoverMeasurementFrame<Vector3DType>(this->m_Vector3DVolume.GetPointer(), this->m_MeasurementFrame);
-  RecoverBVectors<Vector3DType>(this->m_Vector3DVolume.GetPointer(), this->m_DiffusionVectors);
-  RecoverBValues<Vector3DType>(this->m_Vector3DVolume.GetPointer(), this->m_DiffusionVectors, this->m_BValues);
+  RecoverMeasurementFrame<VectorImage3DType>(this->m_Vector3DVolume.GetPointer(), this->m_MeasurementFrame);
+  RecoverBVectors<VectorImage3DType>(this->m_Vector3DVolume.GetPointer(), this->m_DiffusionVectors);
+  RecoverBValues<VectorImage3DType>(this->m_Vector3DVolume.GetPointer(), this->m_DiffusionVectors, this->m_BValues);
 }
 
 DWIConverter::CommonDicomFieldMapType NRRDDWIConverter::GetCommonDicomFieldsMap() const

--- a/DWIConvert/NRRDDWIConverter.cxx
+++ b/DWIConvert/NRRDDWIConverter.cxx
@@ -19,12 +19,12 @@ NRRDDWIConverter::AddFlagsToDictionary()
 
 
 Volume4DType::Pointer
-NRRDDWIConverter::CreateVolume(VectorVolumeType::Pointer & vector3DVolume)
+NRRDDWIConverter::CreateVolume(Vector3DType::Pointer & vector3DVolume)
 {
-  VectorVolumeType::SizeType      inputSize = vector3DVolume->GetLargestPossibleRegion().GetSize();
-  VectorVolumeType::SpacingType   inputSpacing = vector3DVolume->GetSpacing();
-  VectorVolumeType::PointType     inputOrigin = vector3DVolume->GetOrigin();
-  VectorVolumeType::DirectionType inputDirection = vector3DVolume->GetDirection();
+  Vector3DType::SizeType      inputSize = vector3DVolume->GetLargestPossibleRegion().GetSize();
+  Vector3DType::SpacingType   inputSpacing = vector3DVolume->GetSpacing();
+  Vector3DType::PointType     inputOrigin = vector3DVolume->GetOrigin();
+  Vector3DType::DirectionType inputDirection = vector3DVolume->GetDirection();
 
   Volume4DType::Pointer fourDVolume = Volume4DType::New();
   Volume4DType::SizeType      volSize;
@@ -57,7 +57,7 @@ NRRDDWIConverter::CreateVolume(VectorVolumeType::Pointer & vector3DVolume)
 
   const Volume4DType::IndexType::IndexValueType vecLength = vector3DVolume->GetNumberOfComponentsPerPixel();
 
-  VectorVolumeType::IndexType vecIndex;
+  Vector3DType::IndexType vecIndex;
   Volume4DType::IndexType       volIndex;
   // convert from vector image to 4D volume image
   for( volIndex[3] = 0; volIndex[3] < vecLength; ++volIndex[3] )
@@ -86,8 +86,8 @@ NRRDDWIConverter::LoadFromDisk()
 {
   const std::string nrrdNRRDFile = m_InputFileNames[0];
 
-  /*VectorVolumeType::Pointer vector3DVolume;
-  if( ReadVectorVolume<VectorVolumeType>( vector3DVolume, nrrdNRRDFile, this->m_allowLossyConversion ) != EXIT_SUCCESS )
+  /*Vector3DType::Pointer vector3DVolume;
+  if( ReadVectorVolume<Vector3DType>( vector3DVolume, nrrdNRRDFile, this->m_allowLossyConversion ) != EXIT_SUCCESS )
   {
     itkGenericExceptionMacro(<< "ERROR Reading NRRD File : " << nrrdNRRDFile << std::endl;);
   }
@@ -97,7 +97,7 @@ NRRDDWIConverter::LoadFromDisk()
   this->m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume(fourDVolume);*/
 
   // modified by Hui Xie Jan 6th, 2016
-  if( ReadVectorVolume<VectorVolumeType>( m_Vector3DVolume, nrrdNRRDFile, this->m_allowLossyConversion ) != EXIT_SUCCESS )
+  if( ReadVectorVolume<Vector3DType>( m_Vector3DVolume, nrrdNRRDFile, this->m_allowLossyConversion ) != EXIT_SUCCESS )
   {
       itkGenericExceptionMacro(<< "ERROR Reading NRRD File : " << nrrdNRRDFile << std::endl;);
   }
@@ -108,9 +108,9 @@ NRRDDWIConverter::LoadFromDisk()
 void
 NRRDDWIConverter::ExtractDWIData()
 {
-  RecoverMeasurementFrame<VectorVolumeType>(this->m_Vector3DVolume.GetPointer(), this->m_MeasurementFrame);
-  RecoverBVectors<VectorVolumeType>(this->m_Vector3DVolume.GetPointer(), this->m_DiffusionVectors);
-  RecoverBValues<VectorVolumeType>(this->m_Vector3DVolume.GetPointer(), this->m_DiffusionVectors, this->m_BValues);
+  RecoverMeasurementFrame<Vector3DType>(this->m_Vector3DVolume.GetPointer(), this->m_MeasurementFrame);
+  RecoverBVectors<Vector3DType>(this->m_Vector3DVolume.GetPointer(), this->m_DiffusionVectors);
+  RecoverBValues<Vector3DType>(this->m_Vector3DVolume.GetPointer(), this->m_DiffusionVectors, this->m_BValues);
 }
 
 DWIConverter::CommonDicomFieldMapType NRRDDWIConverter::GetCommonDicomFieldsMap() const

--- a/DWIConvert/NRRDDWIConverter.cxx
+++ b/DWIConvert/NRRDDWIConverter.cxx
@@ -8,6 +8,7 @@
 NRRDDWIConverter::NRRDDWIConverter( const DWIConverter::FileNamesContainer & inputFileNames,
   const bool FSLFileFormatHorizontalBy3Rows)
   : DWIConverter( inputFileNames, FSLFileFormatHorizontalBy3Rows )
+
 {
 }
 
@@ -93,18 +94,15 @@ NRRDDWIConverter::LoadFromDisk()
 
   //Conert vector 3D volume to 4DVolume
   Volume4DType::Pointer                 fourDVolume = CreateVolume(vector3DVolume);
-  this->m_SlicesPerVolume = fourDVolume->GetLargestPossibleRegion().GetSize()[2];
-  this->m_NVolume = fourDVolume->GetLargestPossibleRegion().GetSize()[3];
-  this->m_NSlice = this->m_SlicesPerVolume * this->m_NVolume;
-  this->m_Volume = FourDToThreeDImage(fourDVolume);
+  this->m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume(fourDVolume);
 }
 
 void
 NRRDDWIConverter::ExtractDWIData()
 {
-  RecoverMeasurementFrame<Volume3DUnwrappedType>(this->m_Volume.GetPointer(), this->m_MeasurementFrame);
-  RecoverBVectors<Volume3DUnwrappedType>(this->m_Volume.GetPointer(), this->m_DiffusionVectors);
-  RecoverBValues<Volume3DUnwrappedType>(this->m_Volume.GetPointer(), this->m_DiffusionVectors, this->m_BValues);
+  RecoverMeasurementFrame<VectorVolumeType>(this->m_Vector3DVolume.GetPointer(), this->m_MeasurementFrame);
+  RecoverBVectors<VectorVolumeType>(this->m_Vector3DVolume.GetPointer(), this->m_DiffusionVectors);
+  RecoverBValues<VectorVolumeType>(this->m_Vector3DVolume.GetPointer(), this->m_DiffusionVectors, this->m_BValues);
 }
 
 DWIConverter::CommonDicomFieldMapType NRRDDWIConverter::GetCommonDicomFieldsMap() const

--- a/DWIConvert/NRRDDWIConverter.cxx
+++ b/DWIConvert/NRRDDWIConverter.cxx
@@ -86,7 +86,7 @@ NRRDDWIConverter::LoadFromDisk()
 {
   const std::string nrrdNRRDFile = m_InputFileNames[0];
 
-  VectorVolumeType::Pointer vector3DVolume;
+  /*VectorVolumeType::Pointer vector3DVolume;
   if( ReadVectorVolume<VectorVolumeType>( vector3DVolume, nrrdNRRDFile, this->m_allowLossyConversion ) != EXIT_SUCCESS )
   {
     itkGenericExceptionMacro(<< "ERROR Reading NRRD File : " << nrrdNRRDFile << std::endl;);
@@ -94,7 +94,14 @@ NRRDDWIConverter::LoadFromDisk()
 
   //Conert vector 3D volume to 4DVolume
   Volume4DType::Pointer                 fourDVolume = CreateVolume(vector3DVolume);
-  this->m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume(fourDVolume);
+  this->m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume(fourDVolume);*/
+
+  // modified by Hui Xie Jan 6th, 2016
+  if( ReadVectorVolume<VectorVolumeType>( m_Vector3DVolume, nrrdNRRDFile, this->m_allowLossyConversion ) != EXIT_SUCCESS )
+  {
+      itkGenericExceptionMacro(<< "ERROR Reading NRRD File : " << nrrdNRRDFile << std::endl;);
+  }
+
 }
 
 void

--- a/DWIConvert/NRRDDWIConverter.h
+++ b/DWIConvert/NRRDDWIConverter.h
@@ -40,7 +40,7 @@ public:
 
 
 private:
-  Volume4DType::Pointer CreateVolume(VectorVolumeType::Pointer & inputVol);
+  Volume4DType::Pointer CreateVolume(Vector3DType::Pointer & inputVol);
   std::string m_inputBValues;
   std::string m_inputBVectors;
 

--- a/DWIConvert/NRRDDWIConverter.h
+++ b/DWIConvert/NRRDDWIConverter.h
@@ -40,7 +40,7 @@ public:
 
 
 private:
-  Volume4DType::Pointer CreateVolume(Vector3DType::Pointer & inputVol);
+  ScalarImage4DType::Pointer CreateVolume(VectorImage3DType::Pointer & inputVol);
   std::string m_inputBValues;
   std::string m_inputBVectors;
 

--- a/DWIConvert/NRRDDWIConverter.h
+++ b/DWIConvert/NRRDDWIConverter.h
@@ -37,10 +37,15 @@ public:
    */
   virtual CommonDicomFieldMapType GetCommonDicomFieldsMap() const ITK_OVERRIDE;
 
+
+
 private:
   Volume4DType::Pointer CreateVolume(VectorVolumeType::Pointer & inputVol);
   std::string m_inputBValues;
   std::string m_inputBVectors;
+
+
+
 };
 
 

--- a/DWIConvert/NrrdToFSL.cxx
+++ b/DWIConvert/NrrdToFSL.cxx
@@ -20,20 +20,20 @@
 
 typedef short                               PixelValueType;
 
-Volume4DType::Pointer CreateVolume(Vector3DType::Pointer & inputVol)
+ScalarImage4DType::Pointer CreateVolume(VectorImage3DType::Pointer & inputVol)
 {
-  Vector3DType::SizeType inputSize =
+  VectorImage3DType::SizeType inputSize =
     inputVol->GetLargestPossibleRegion().GetSize();
-  Vector3DType::SpacingType   inputSpacing = inputVol->GetSpacing();
-  Vector3DType::PointType     inputOrigin = inputVol->GetOrigin();
-  Vector3DType::DirectionType inputDirection = inputVol->GetDirection();
+  VectorImage3DType::SpacingType   inputSpacing = inputVol->GetSpacing();
+  VectorImage3DType::PointType     inputOrigin = inputVol->GetOrigin();
+  VectorImage3DType::DirectionType inputDirection = inputVol->GetDirection();
 
-  Volume4DType::Pointer niftiVolume =
-    Volume4DType::New();
-  Volume4DType::SizeType      volSize;
-  Volume4DType::SpacingType   volSpacing;
-  Volume4DType::PointType     volOrigin;
-  Volume4DType::DirectionType volDirection;
+  ScalarImage4DType::Pointer niftiVolume =
+    ScalarImage4DType::New();
+  ScalarImage4DType::SizeType      volSize;
+  ScalarImage4DType::SpacingType   volSpacing;
+  ScalarImage4DType::PointType     volOrigin;
+  ScalarImage4DType::DirectionType volDirection;
 
   for( unsigned int i = 0; i < 3; ++i )
     {
@@ -113,27 +113,27 @@ int NrrdToFSL(const std::string & inputVolume,
     _outputBVectors = outputBVectors;
     }
 
-  Vector3DType::Pointer inputVol;
-  if( ReadVolume<Vector3DType>( inputVol, inputVolume, allowLossyConversion ) != EXIT_SUCCESS )
+  VectorImage3DType::Pointer inputVol;
+  if( ReadVolume<VectorImage3DType>( inputVol, inputVolume, allowLossyConversion ) != EXIT_SUCCESS )
     {
     return EXIT_FAILURE;
     }
-  Volume4DType::Pointer                         niftiVolume = CreateVolume(inputVol);
-  const Vector3DType::SizeType            inputSize( inputVol->GetLargestPossibleRegion().GetSize() );
-  const Volume4DType::IndexType::IndexValueType vecLength = inputVol->GetNumberOfComponentsPerPixel();
+  ScalarImage4DType::Pointer                         niftiVolume = CreateVolume(inputVol);
+  const VectorImage3DType::SizeType            inputSize( inputVol->GetLargestPossibleRegion().GetSize() );
+  const ScalarImage4DType::IndexType::IndexValueType vecLength = inputVol->GetNumberOfComponentsPerPixel();
 
-  Vector3DType::IndexType vecIndex;
-  Volume4DType::IndexType       volIndex;
+  VectorImage3DType::IndexType vecIndex;
+  ScalarImage4DType::IndexType       volIndex;
   // convert from vector image to 4D volume image
   for( volIndex[3] = 0; volIndex[3] < vecLength; ++volIndex[3] )
     {
-    for( volIndex[2] = 0; volIndex[2] < static_cast<Volume4DType::IndexType::IndexValueType>( inputSize[2] ); ++volIndex[2] )
+    for( volIndex[2] = 0; volIndex[2] < static_cast<ScalarImage4DType::IndexType::IndexValueType>( inputSize[2] ); ++volIndex[2] )
       {
       vecIndex[2] = volIndex[2];
-      for( volIndex[1] = 0; volIndex[1] < static_cast<Volume4DType::IndexType::IndexValueType>( inputSize[1] ); ++volIndex[1] )
+      for( volIndex[1] = 0; volIndex[1] < static_cast<ScalarImage4DType::IndexType::IndexValueType>( inputSize[1] ); ++volIndex[1] )
         {
         vecIndex[1] = volIndex[1];
-        for( volIndex[0] = 0; volIndex[0] < static_cast<Volume4DType::IndexType::IndexValueType>( inputSize[0] ); ++volIndex[0] )
+        for( volIndex[0] = 0; volIndex[0] < static_cast<ScalarImage4DType::IndexType::IndexValueType>( inputSize[0] ); ++volIndex[0] )
           {
           vecIndex[0] = volIndex[0];
           niftiVolume->SetPixel(volIndex, inputVol->GetPixel(vecIndex)[volIndex[3]]);
@@ -141,12 +141,12 @@ int NrrdToFSL(const std::string & inputVolume,
         }
       }
     }
-  if( WriteVolume<Volume4DType>(niftiVolume, outputVolume) != EXIT_SUCCESS )
+  if( WriteVolume<ScalarImage4DType>(niftiVolume, outputVolume) != EXIT_SUCCESS )
     {
     return EXIT_FAILURE;
     }
   DWIMetaDataDictionaryValidator::GradientTableType bVectors;
-  if( RecoverBVectors<Vector3DType>(inputVol, bVectors) != EXIT_SUCCESS )
+  if( RecoverBVectors<VectorImage3DType>(inputVol, bVectors) != EXIT_SUCCESS )
     {
     std::cerr << "No gradient vectors found in "
               << inputVolume << std::endl;
@@ -160,7 +160,7 @@ int NrrdToFSL(const std::string & inputVolume,
     }
 
   std::vector<double> bValues;
-  RecoverBValues<Vector3DType>(inputVol, bVectors, bValues);
+  RecoverBValues<VectorImage3DType>(inputVol, bVectors, bValues);
 
   if( WriteBValues(bValues, _outputBValues) != EXIT_SUCCESS )
     {

--- a/DWIConvert/NrrdToFSL.cxx
+++ b/DWIConvert/NrrdToFSL.cxx
@@ -19,7 +19,6 @@
 #include "DWIConvertUtils.h"
 
 typedef short                               PixelValueType;
-typedef itk::Image<PixelValueType, 4>       Volume4DType;
 
 Volume4DType::Pointer CreateVolume(Vector3DType::Pointer & inputVol)
 {

--- a/DWIConvert/NrrdToFSL.cxx
+++ b/DWIConvert/NrrdToFSL.cxx
@@ -20,15 +20,14 @@
 
 typedef short                               PixelValueType;
 typedef itk::Image<PixelValueType, 4>       Volume4DType;
-typedef itk::VectorImage<PixelValueType, 3> VectorVolume4DType;
 
-Volume4DType::Pointer CreateVolume(VectorVolume4DType::Pointer & inputVol)
+Volume4DType::Pointer CreateVolume(Vector3DType::Pointer & inputVol)
 {
-  VectorVolume4DType::SizeType inputSize =
+  Vector3DType::SizeType inputSize =
     inputVol->GetLargestPossibleRegion().GetSize();
-  VectorVolume4DType::SpacingType   inputSpacing = inputVol->GetSpacing();
-  VectorVolume4DType::PointType     inputOrigin = inputVol->GetOrigin();
-  VectorVolume4DType::DirectionType inputDirection = inputVol->GetDirection();
+  Vector3DType::SpacingType   inputSpacing = inputVol->GetSpacing();
+  Vector3DType::PointType     inputOrigin = inputVol->GetOrigin();
+  Vector3DType::DirectionType inputDirection = inputVol->GetDirection();
 
   Volume4DType::Pointer niftiVolume =
     Volume4DType::New();
@@ -115,16 +114,16 @@ int NrrdToFSL(const std::string & inputVolume,
     _outputBVectors = outputBVectors;
     }
 
-  VectorVolume4DType::Pointer inputVol;
-  if( ReadVolume<VectorVolume4DType>( inputVol, inputVolume, allowLossyConversion ) != EXIT_SUCCESS )
+  Vector3DType::Pointer inputVol;
+  if( ReadVolume<Vector3DType>( inputVol, inputVolume, allowLossyConversion ) != EXIT_SUCCESS )
     {
     return EXIT_FAILURE;
     }
   Volume4DType::Pointer                         niftiVolume = CreateVolume(inputVol);
-  const VectorVolume4DType::SizeType            inputSize( inputVol->GetLargestPossibleRegion().GetSize() );
+  const Vector3DType::SizeType            inputSize( inputVol->GetLargestPossibleRegion().GetSize() );
   const Volume4DType::IndexType::IndexValueType vecLength = inputVol->GetNumberOfComponentsPerPixel();
 
-  VectorVolume4DType::IndexType vecIndex;
+  Vector3DType::IndexType vecIndex;
   Volume4DType::IndexType       volIndex;
   // convert from vector image to 4D volume image
   for( volIndex[3] = 0; volIndex[3] < vecLength; ++volIndex[3] )
@@ -148,7 +147,7 @@ int NrrdToFSL(const std::string & inputVolume,
     return EXIT_FAILURE;
     }
   DWIMetaDataDictionaryValidator::GradientTableType bVectors;
-  if( RecoverBVectors<VectorVolume4DType>(inputVol, bVectors) != EXIT_SUCCESS )
+  if( RecoverBVectors<Vector3DType>(inputVol, bVectors) != EXIT_SUCCESS )
     {
     std::cerr << "No gradient vectors found in "
               << inputVolume << std::endl;
@@ -162,7 +161,7 @@ int NrrdToFSL(const std::string & inputVolume,
     }
 
   std::vector<double> bValues;
-  RecoverBValues<VectorVolume4DType>(inputVol, bVectors, bValues);
+  RecoverBValues<Vector3DType>(inputVol, bVectors, bValues);
 
   if( WriteBValues(bValues, _outputBValues) != EXIT_SUCCESS )
     {

--- a/DWIConvert/PhilipsDWIConverter.cxx
+++ b/DWIConvert/PhilipsDWIConverter.cxx
@@ -320,11 +320,11 @@ void PhilipsDWIConverter::ExtractDWIData()
     std::cout << "# of Volumes " << this->m_NVolume << " # of Diffusion Vectors "
               << this->m_DiffusionVectors.size() << " Removing "
               << trailingVolumes << " Isotropic volumes." << std::endl;
-    typedef itk::ExtractImageFilter<Volume3DUnwrappedType,Volume3DUnwrappedType> ExtractImageFilterType;
+    typedef itk::ExtractImageFilter<Volume3DType,Volume3DType> ExtractImageFilterType;
     ExtractImageFilterType::Pointer extractImageFilter = ExtractImageFilterType::New();
 
-    Volume3DUnwrappedType::RegionType desiredRegion = this->m_3DUnwrappedVolume->GetLargestPossibleRegion();
-    Volume3DUnwrappedType::SizeType desiredSize = desiredRegion.GetSize();
+    Volume3DType::RegionType desiredRegion = this->m_3DUnwrappedVolume->GetLargestPossibleRegion();
+    Volume3DType::SizeType desiredSize = desiredRegion.GetSize();
     desiredSize[2] -= (trailingVolumes * this->m_SlicesPerVolume);
     desiredRegion.SetSize(desiredSize);
     extractImageFilter->SetExtractionRegion(desiredRegion);

--- a/DWIConvert/PhilipsDWIConverter.cxx
+++ b/DWIConvert/PhilipsDWIConverter.cxx
@@ -20,11 +20,11 @@ void PhilipsDWIConverter::LoadDicomDirectory()
   if(!this->m_MultiSliceVolume)
   {
     this->m_NVolume = this->m_NSlice / this->m_SlicesPerVolume;
-    this->m_MeasurementFrame = this->m_3DUnwrappedVolume->GetDirection();
+    this->m_MeasurementFrame = this->m_scalarImage3DUnwrapped->GetDirection();
     this->DetermineSliceOrderIS();
     this->SetDirectionsFromSliceOrder();
   }
-  m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume( ThreeDUnwrappedToFourDImage(m_3DUnwrappedVolume));
+  m_vectorImage3D = convertScalarImage4DToVectorImage3D( ThreeDUnwrappedToFourDImage(m_scalarImage3DUnwrapped));
   // single-frame file handled specially
 }
 
@@ -288,13 +288,13 @@ void PhilipsDWIConverter::ExtractDWIData()
     this->m_SlicesPerVolume = sliceLocations.size();
 
 
-    std::cout << "LPS Matrix: " << std::endl << this->m_3DUnwrappedVolume->GetDirection() << std::endl;
-    std::cout << "Volume Origin: " << std::endl << this->m_3DUnwrappedVolume->GetOrigin() << std::endl;
+    std::cout << "LPS Matrix: " << std::endl << this->m_scalarImage3DUnwrapped->GetDirection() << std::endl;
+    std::cout << "Volume Origin: " << std::endl << this->m_scalarImage3DUnwrapped->GetOrigin() << std::endl;
     std::cout << "Number of slices per volume: " << this->m_SlicesPerVolume << std::endl;
     std::cout << "Slice matrix size: " << this->GetRows() << " X " << this->GetCols() << std::endl;
-    std::cout << "Image resolution: " << this->m_3DUnwrappedVolume->GetSpacing() << std::endl;
+    std::cout << "Image resolution: " << this->m_scalarImage3DUnwrapped->GetSpacing() << std::endl;
 
-    this->m_MeasurementFrame = this->m_3DUnwrappedVolume->GetDirection();
+    this->m_MeasurementFrame = this->m_scalarImage3DUnwrapped->GetDirection();
 
     this->m_NVolume = this->m_NSlice / this->m_SlicesPerVolume;
     for( unsigned int k2 = 0; k2 < this->m_BValues.size(); ++k2 )
@@ -323,14 +323,14 @@ void PhilipsDWIConverter::ExtractDWIData()
     typedef itk::ExtractImageFilter<ScalarImage3DType,ScalarImage3DType> ExtractImageFilterType;
     ExtractImageFilterType::Pointer extractImageFilter = ExtractImageFilterType::New();
 
-    ScalarImage3DType::RegionType desiredRegion = this->m_3DUnwrappedVolume->GetLargestPossibleRegion();
+    ScalarImage3DType::RegionType desiredRegion = this->m_scalarImage3DUnwrapped->GetLargestPossibleRegion();
     ScalarImage3DType::SizeType desiredSize = desiredRegion.GetSize();
     desiredSize[2] -= (trailingVolumes * this->m_SlicesPerVolume);
     desiredRegion.SetSize(desiredSize);
     extractImageFilter->SetExtractionRegion(desiredRegion);
-    extractImageFilter->SetInput(this->m_3DUnwrappedVolume);
+    extractImageFilter->SetInput(this->m_scalarImage3DUnwrapped);
     extractImageFilter->Update();
-    this->m_3DUnwrappedVolume = extractImageFilter->GetOutput();
+    this->m_scalarImage3DUnwrapped = extractImageFilter->GetOutput();
     this->m_NVolume -= trailingVolumes;
   }
 }

--- a/DWIConvert/PhilipsDWIConverter.cxx
+++ b/DWIConvert/PhilipsDWIConverter.cxx
@@ -20,10 +20,11 @@ void PhilipsDWIConverter::LoadDicomDirectory()
   if(!this->m_MultiSliceVolume)
   {
     this->m_NVolume = this->m_NSlice / this->m_SlicesPerVolume;
-    this->m_MeasurementFrame = this->m_Volume->GetDirection();
+    this->m_MeasurementFrame = this->m_3DUnwrappedVolume->GetDirection();
     this->DetermineSliceOrderIS();
     this->SetDirectionsFromSliceOrder();
   }
+  m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume( ThreeDUnwrappedToFourDImage(m_3DUnwrappedVolume));
   // single-frame file handled specially
 }
 
@@ -287,13 +288,13 @@ void PhilipsDWIConverter::ExtractDWIData()
     this->m_SlicesPerVolume = sliceLocations.size();
 
 
-    std::cout << "LPS Matrix: " << std::endl << this->m_Volume->GetDirection() << std::endl;
-    std::cout << "Volume Origin: " << std::endl << this->m_Volume->GetOrigin() << std::endl;
+    std::cout << "LPS Matrix: " << std::endl << this->m_3DUnwrappedVolume->GetDirection() << std::endl;
+    std::cout << "Volume Origin: " << std::endl << this->m_3DUnwrappedVolume->GetOrigin() << std::endl;
     std::cout << "Number of slices per volume: " << this->m_SlicesPerVolume << std::endl;
     std::cout << "Slice matrix size: " << this->GetRows() << " X " << this->GetCols() << std::endl;
-    std::cout << "Image resolution: " << this->m_Volume->GetSpacing() << std::endl;
+    std::cout << "Image resolution: " << this->m_3DUnwrappedVolume->GetSpacing() << std::endl;
 
-    this->m_MeasurementFrame = this->m_Volume->GetDirection();
+    this->m_MeasurementFrame = this->m_3DUnwrappedVolume->GetDirection();
 
     this->m_NVolume = this->m_NSlice / this->m_SlicesPerVolume;
     for( unsigned int k2 = 0; k2 < this->m_BValues.size(); ++k2 )
@@ -322,14 +323,14 @@ void PhilipsDWIConverter::ExtractDWIData()
     typedef itk::ExtractImageFilter<Volume3DUnwrappedType,Volume3DUnwrappedType> ExtractImageFilterType;
     ExtractImageFilterType::Pointer extractImageFilter = ExtractImageFilterType::New();
 
-    Volume3DUnwrappedType::RegionType desiredRegion = this->m_Volume->GetLargestPossibleRegion();
+    Volume3DUnwrappedType::RegionType desiredRegion = this->m_3DUnwrappedVolume->GetLargestPossibleRegion();
     Volume3DUnwrappedType::SizeType desiredSize = desiredRegion.GetSize();
     desiredSize[2] -= (trailingVolumes * this->m_SlicesPerVolume);
     desiredRegion.SetSize(desiredSize);
     extractImageFilter->SetExtractionRegion(desiredRegion);
-    extractImageFilter->SetInput(this->m_Volume);
+    extractImageFilter->SetInput(this->m_3DUnwrappedVolume);
     extractImageFilter->Update();
-    this->m_Volume = extractImageFilter->GetOutput();
+    this->m_3DUnwrappedVolume = extractImageFilter->GetOutput();
     this->m_NVolume -= trailingVolumes;
   }
 }

--- a/DWIConvert/PhilipsDWIConverter.cxx
+++ b/DWIConvert/PhilipsDWIConverter.cxx
@@ -320,11 +320,11 @@ void PhilipsDWIConverter::ExtractDWIData()
     std::cout << "# of Volumes " << this->m_NVolume << " # of Diffusion Vectors "
               << this->m_DiffusionVectors.size() << " Removing "
               << trailingVolumes << " Isotropic volumes." << std::endl;
-    typedef itk::ExtractImageFilter<Volume3DType,Volume3DType> ExtractImageFilterType;
+    typedef itk::ExtractImageFilter<ScalarImage3DType,ScalarImage3DType> ExtractImageFilterType;
     ExtractImageFilterType::Pointer extractImageFilter = ExtractImageFilterType::New();
 
-    Volume3DType::RegionType desiredRegion = this->m_3DUnwrappedVolume->GetLargestPossibleRegion();
-    Volume3DType::SizeType desiredSize = desiredRegion.GetSize();
+    ScalarImage3DType::RegionType desiredRegion = this->m_3DUnwrappedVolume->GetLargestPossibleRegion();
+    ScalarImage3DType::SizeType desiredSize = desiredRegion.GetSize();
     desiredSize[2] -= (trailingVolumes * this->m_SlicesPerVolume);
     desiredRegion.SetSize(desiredSize);
     extractImageFilter->SetExtractionRegion(desiredRegion);

--- a/DWIConvert/PhilipsDWIConverter.cxx
+++ b/DWIConvert/PhilipsDWIConverter.cxx
@@ -20,11 +20,11 @@ void PhilipsDWIConverter::LoadDicomDirectory()
   if(!this->m_MultiSliceVolume)
   {
     this->m_NVolume = this->m_NSlice / this->m_SlicesPerVolume;
-    this->m_MeasurementFrame = this->m_scalarImage3DUnwrapped->GetDirection();
+    this->m_MeasurementFrame = this->m_scalarImage3D->GetDirection();
     this->DetermineSliceOrderIS();
     this->SetDirectionsFromSliceOrder();
   }
-  m_vectorImage3D = convertScalarImage4DToVectorImage3D( ThreeDUnwrappedToFourDImage(m_scalarImage3DUnwrapped));
+  //m_vectorImage3D = convertScalarImage4DToVectorImage3D( ThreeDUnwrappedToFourDImage(m_scalarImage3DUnwrapped));
   // single-frame file handled specially
 }
 
@@ -288,13 +288,13 @@ void PhilipsDWIConverter::ExtractDWIData()
     this->m_SlicesPerVolume = sliceLocations.size();
 
 
-    std::cout << "LPS Matrix: " << std::endl << this->m_scalarImage3DUnwrapped->GetDirection() << std::endl;
-    std::cout << "Volume Origin: " << std::endl << this->m_scalarImage3DUnwrapped->GetOrigin() << std::endl;
+    std::cout << "LPS Matrix: " << std::endl << this->m_scalarImage3D->GetDirection() << std::endl;
+    std::cout << "Volume Origin: " << std::endl << this->m_scalarImage3D->GetOrigin() << std::endl;
     std::cout << "Number of slices per volume: " << this->m_SlicesPerVolume << std::endl;
     std::cout << "Slice matrix size: " << this->GetRows() << " X " << this->GetCols() << std::endl;
-    std::cout << "Image resolution: " << this->m_scalarImage3DUnwrapped->GetSpacing() << std::endl;
+    std::cout << "Image resolution: " << this->m_scalarImage3D->GetSpacing() << std::endl;
 
-    this->m_MeasurementFrame = this->m_scalarImage3DUnwrapped->GetDirection();
+    this->m_MeasurementFrame = this->m_scalarImage3D->GetDirection();
 
     this->m_NVolume = this->m_NSlice / this->m_SlicesPerVolume;
     for( unsigned int k2 = 0; k2 < this->m_BValues.size(); ++k2 )
@@ -323,14 +323,14 @@ void PhilipsDWIConverter::ExtractDWIData()
     typedef itk::ExtractImageFilter<ScalarImage3DType,ScalarImage3DType> ExtractImageFilterType;
     ExtractImageFilterType::Pointer extractImageFilter = ExtractImageFilterType::New();
 
-    ScalarImage3DType::RegionType desiredRegion = this->m_scalarImage3DUnwrapped->GetLargestPossibleRegion();
+    ScalarImage3DType::RegionType desiredRegion = this->m_scalarImage3D->GetLargestPossibleRegion();
     ScalarImage3DType::SizeType desiredSize = desiredRegion.GetSize();
     desiredSize[2] -= (trailingVolumes * this->m_SlicesPerVolume);
     desiredRegion.SetSize(desiredSize);
     extractImageFilter->SetExtractionRegion(desiredRegion);
-    extractImageFilter->SetInput(this->m_scalarImage3DUnwrapped);
+    extractImageFilter->SetInput(this->m_scalarImage3D);
     extractImageFilter->Update();
-    this->m_scalarImage3DUnwrapped = extractImageFilter->GetOutput();
+    this->m_scalarImage3D = extractImageFilter->GetOutput();
     this->m_NVolume -= trailingVolumes;
   }
 }

--- a/DWIConvert/SiemensDWIConverter.cxx
+++ b/DWIConvert/SiemensDWIConverter.cxx
@@ -163,7 +163,7 @@ void SiemensDWIConverter::LoadDicomDirectory()
     this->SetDirectionsFromSliceOrder();
   }
   this->CheckCSAHeaderAvailable();
-  m_vectorImage3D = convertScalarImage4DToVectorImage3D( ThreeDUnwrappedToFourDImage(m_scalarImage3DUnwrapped));
+  //m_vectorImage3D = convertScalarImage4DToVectorImage3D( ThreeDUnwrappedToFourDImage(m_scalarImage3DUnwrapped));
 }
 
 double SiemensDWIConverter::ExtractBValue(CSAHeader *csaHeader, unsigned int strideVolume)
@@ -442,7 +442,7 @@ void SiemensDWIConverter::DeMosaic()
    * voxel size, and dimension, the origin can be computed.
    */
 
-  ScalarImage3DType::Pointer previousImage = this->m_scalarImage3DUnwrapped;
+  ScalarImage3DType::Pointer previousImage = this->m_scalarImage3D;
 
   ScalarImage3DType::RegionType region = previousImage->GetLargestPossibleRegion();
   ScalarImage3DType::SizeType   size = region.GetSize();
@@ -465,20 +465,20 @@ void SiemensDWIConverter::DeMosaic()
   sliceSize[2] = 0;
 
   region.SetSize( dmSize );
-  this->m_scalarImage3DUnwrapped = ScalarImage3DType::New();
-  this->m_scalarImage3DUnwrapped->CopyInformation( previousImage );
-  this->m_scalarImage3DUnwrapped->SetRegions( region );
-  this->m_scalarImage3DUnwrapped->Allocate();
+  this->m_scalarImage3D = ScalarImage3DType::New();
+  this->m_scalarImage3D->CopyInformation( previousImage );
+  this->m_scalarImage3D->SetRegions( region );
+  this->m_scalarImage3D->Allocate();
 
   //Fix Origin
   // http://nipy.org/nibabel/dicom/dicom_mosaic.html
-  this->m_scalarImage3DUnwrapped->SetOrigin(
+  this->m_scalarImage3D->SetOrigin(
           previousImage->GetOrigin()
-          + GetNRRDSpaceDirection<ScalarImage3DType>(this->m_scalarImage3DUnwrapped) * ( ( mosaicSize - sliceSize) / 2 )
+          + GetNRRDSpaceDirection<ScalarImage3DType>(this->m_scalarImage3D) * ( ( mosaicSize - sliceSize) / 2 )
   );
 
 
-  ScalarImage3DType::RegionType dmRegion = this->m_scalarImage3DUnwrapped->GetLargestPossibleRegion();
+  ScalarImage3DType::RegionType dmRegion = this->m_scalarImage3D->GetLargestPossibleRegion();
   dmRegion.SetSize(2, 1);
   region.SetSize(0, dmSize[0]);
   region.SetSize(1, dmSize[1]);
@@ -489,7 +489,7 @@ void SiemensDWIConverter::DeMosaic()
     unsigned int new_k = k /* - bad_slice_counter */;
 
     dmRegion.SetIndex(2, new_k);
-    itk::ImageRegionIteratorWithIndex<ScalarImage3DType> dmIt( this->m_scalarImage3DUnwrapped, dmRegion );
+    itk::ImageRegionIteratorWithIndex<ScalarImage3DType> dmIt( this->m_scalarImage3D, dmRegion );
 
     // figure out the mosaic region for this slice
     int sliceIndex = k;

--- a/DWIConvert/SiemensDWIConverter.cxx
+++ b/DWIConvert/SiemensDWIConverter.cxx
@@ -474,7 +474,7 @@ void SiemensDWIConverter::DeMosaic()
   // http://nipy.org/nibabel/dicom/dicom_mosaic.html
   this->m_3DUnwrappedVolume->SetOrigin(
           previousImage->GetOrigin()
-          + this->GetNRRDSpaceDirection() * ( ( mosaicSize - sliceSize) / 2 )
+          + GetNRRDSpaceDirection<Volume3DUnwrappedType>(this->m_3DUnwrappedVolume) * ( ( mosaicSize - sliceSize) / 2 )
   );
 
 

--- a/DWIConvert/SiemensDWIConverter.cxx
+++ b/DWIConvert/SiemensDWIConverter.cxx
@@ -442,10 +442,10 @@ void SiemensDWIConverter::DeMosaic()
    * voxel size, and dimension, the origin can be computed.
    */
 
-  Volume3DUnwrappedType::Pointer previousImage = this->m_3DUnwrappedVolume;
+  Volume3DType::Pointer previousImage = this->m_3DUnwrappedVolume;
 
-  Volume3DUnwrappedType::RegionType region = previousImage->GetLargestPossibleRegion();
-  Volume3DUnwrappedType::SizeType   size = region.GetSize();
+  Volume3DType::RegionType region = previousImage->GetLargestPossibleRegion();
+  Volume3DType::SizeType   size = region.GetSize();
 
   // de-mosaic
   PointType mosaicSize;
@@ -453,7 +453,7 @@ void SiemensDWIConverter::DeMosaic()
   mosaicSize[1]=size[1];
   mosaicSize[2]=0;
 
-  Volume3DUnwrappedType::SizeType dmSize = size;
+  Volume3DType::SizeType dmSize = size;
   unsigned int         original_slice_number = dmSize[2] * m_SlicesPerVolume;
   dmSize[0] /= this->m_MMosaic;
   dmSize[1] /= this->m_NMosaic;
@@ -465,7 +465,7 @@ void SiemensDWIConverter::DeMosaic()
   sliceSize[2] = 0;
 
   region.SetSize( dmSize );
-  this->m_3DUnwrappedVolume = Volume3DUnwrappedType::New();
+  this->m_3DUnwrappedVolume = Volume3DType::New();
   this->m_3DUnwrappedVolume->CopyInformation( previousImage );
   this->m_3DUnwrappedVolume->SetRegions( region );
   this->m_3DUnwrappedVolume->Allocate();
@@ -474,11 +474,11 @@ void SiemensDWIConverter::DeMosaic()
   // http://nipy.org/nibabel/dicom/dicom_mosaic.html
   this->m_3DUnwrappedVolume->SetOrigin(
           previousImage->GetOrigin()
-          + GetNRRDSpaceDirection<Volume3DUnwrappedType>(this->m_3DUnwrappedVolume) * ( ( mosaicSize - sliceSize) / 2 )
+          + GetNRRDSpaceDirection<Volume3DType>(this->m_3DUnwrappedVolume) * ( ( mosaicSize - sliceSize) / 2 )
   );
 
 
-  Volume3DUnwrappedType::RegionType dmRegion = this->m_3DUnwrappedVolume->GetLargestPossibleRegion();
+  Volume3DType::RegionType dmRegion = this->m_3DUnwrappedVolume->GetLargestPossibleRegion();
   dmRegion.SetSize(2, 1);
   region.SetSize(0, dmSize[0]);
   region.SetSize(1, dmSize[1]);
@@ -489,7 +489,7 @@ void SiemensDWIConverter::DeMosaic()
     unsigned int new_k = k /* - bad_slice_counter */;
 
     dmRegion.SetIndex(2, new_k);
-    itk::ImageRegionIteratorWithIndex<Volume3DUnwrappedType> dmIt( this->m_3DUnwrappedVolume, dmRegion );
+    itk::ImageRegionIteratorWithIndex<Volume3DType> dmIt( this->m_3DUnwrappedVolume, dmRegion );
 
     // figure out the mosaic region for this slice
     int sliceIndex = k;
@@ -503,7 +503,7 @@ void SiemensDWIConverter::DeMosaic()
     region.SetIndex( 1, colMosaic * dmSize[1] );
     region.SetIndex( 2, slcMosaic );
 
-    itk::ImageRegionConstIteratorWithIndex<Volume3DUnwrappedType> imIt( previousImage, region );
+    itk::ImageRegionConstIteratorWithIndex<Volume3DType> imIt( previousImage, region );
     for( dmIt.GoToBegin(), imIt.GoToBegin(); !dmIt.IsAtEnd(); ++dmIt, ++imIt )
     {
       dmIt.Set( imIt.Get() );

--- a/DWIConvert/SiemensDWIConverter.cxx
+++ b/DWIConvert/SiemensDWIConverter.cxx
@@ -163,7 +163,7 @@ void SiemensDWIConverter::LoadDicomDirectory()
     this->SetDirectionsFromSliceOrder();
   }
   this->CheckCSAHeaderAvailable();
-  m_Vector3DVolume = Convert4DVolumeTo3DVectorVolume( ThreeDUnwrappedToFourDImage(m_3DUnwrappedVolume));
+  m_vectorImage3D = convertScalarImage4DToVectorImage3D( ThreeDUnwrappedToFourDImage(m_scalarImage3DUnwrapped));
 }
 
 double SiemensDWIConverter::ExtractBValue(CSAHeader *csaHeader, unsigned int strideVolume)
@@ -442,7 +442,7 @@ void SiemensDWIConverter::DeMosaic()
    * voxel size, and dimension, the origin can be computed.
    */
 
-  ScalarImage3DType::Pointer previousImage = this->m_3DUnwrappedVolume;
+  ScalarImage3DType::Pointer previousImage = this->m_scalarImage3DUnwrapped;
 
   ScalarImage3DType::RegionType region = previousImage->GetLargestPossibleRegion();
   ScalarImage3DType::SizeType   size = region.GetSize();
@@ -465,20 +465,20 @@ void SiemensDWIConverter::DeMosaic()
   sliceSize[2] = 0;
 
   region.SetSize( dmSize );
-  this->m_3DUnwrappedVolume = ScalarImage3DType::New();
-  this->m_3DUnwrappedVolume->CopyInformation( previousImage );
-  this->m_3DUnwrappedVolume->SetRegions( region );
-  this->m_3DUnwrappedVolume->Allocate();
+  this->m_scalarImage3DUnwrapped = ScalarImage3DType::New();
+  this->m_scalarImage3DUnwrapped->CopyInformation( previousImage );
+  this->m_scalarImage3DUnwrapped->SetRegions( region );
+  this->m_scalarImage3DUnwrapped->Allocate();
 
   //Fix Origin
   // http://nipy.org/nibabel/dicom/dicom_mosaic.html
-  this->m_3DUnwrappedVolume->SetOrigin(
+  this->m_scalarImage3DUnwrapped->SetOrigin(
           previousImage->GetOrigin()
-          + GetNRRDSpaceDirection<ScalarImage3DType>(this->m_3DUnwrappedVolume) * ( ( mosaicSize - sliceSize) / 2 )
+          + GetNRRDSpaceDirection<ScalarImage3DType>(this->m_scalarImage3DUnwrapped) * ( ( mosaicSize - sliceSize) / 2 )
   );
 
 
-  ScalarImage3DType::RegionType dmRegion = this->m_3DUnwrappedVolume->GetLargestPossibleRegion();
+  ScalarImage3DType::RegionType dmRegion = this->m_scalarImage3DUnwrapped->GetLargestPossibleRegion();
   dmRegion.SetSize(2, 1);
   region.SetSize(0, dmSize[0]);
   region.SetSize(1, dmSize[1]);
@@ -489,7 +489,7 @@ void SiemensDWIConverter::DeMosaic()
     unsigned int new_k = k /* - bad_slice_counter */;
 
     dmRegion.SetIndex(2, new_k);
-    itk::ImageRegionIteratorWithIndex<ScalarImage3DType> dmIt( this->m_3DUnwrappedVolume, dmRegion );
+    itk::ImageRegionIteratorWithIndex<ScalarImage3DType> dmIt( this->m_scalarImage3DUnwrapped, dmRegion );
 
     // figure out the mosaic region for this slice
     int sliceIndex = k;

--- a/DWIConvert/SiemensDWIConverter.cxx
+++ b/DWIConvert/SiemensDWIConverter.cxx
@@ -442,10 +442,10 @@ void SiemensDWIConverter::DeMosaic()
    * voxel size, and dimension, the origin can be computed.
    */
 
-  Volume3DType::Pointer previousImage = this->m_3DUnwrappedVolume;
+  ScalarImage3DType::Pointer previousImage = this->m_3DUnwrappedVolume;
 
-  Volume3DType::RegionType region = previousImage->GetLargestPossibleRegion();
-  Volume3DType::SizeType   size = region.GetSize();
+  ScalarImage3DType::RegionType region = previousImage->GetLargestPossibleRegion();
+  ScalarImage3DType::SizeType   size = region.GetSize();
 
   // de-mosaic
   PointType mosaicSize;
@@ -453,7 +453,7 @@ void SiemensDWIConverter::DeMosaic()
   mosaicSize[1]=size[1];
   mosaicSize[2]=0;
 
-  Volume3DType::SizeType dmSize = size;
+  ScalarImage3DType::SizeType dmSize = size;
   unsigned int         original_slice_number = dmSize[2] * m_SlicesPerVolume;
   dmSize[0] /= this->m_MMosaic;
   dmSize[1] /= this->m_NMosaic;
@@ -465,7 +465,7 @@ void SiemensDWIConverter::DeMosaic()
   sliceSize[2] = 0;
 
   region.SetSize( dmSize );
-  this->m_3DUnwrappedVolume = Volume3DType::New();
+  this->m_3DUnwrappedVolume = ScalarImage3DType::New();
   this->m_3DUnwrappedVolume->CopyInformation( previousImage );
   this->m_3DUnwrappedVolume->SetRegions( region );
   this->m_3DUnwrappedVolume->Allocate();
@@ -474,11 +474,11 @@ void SiemensDWIConverter::DeMosaic()
   // http://nipy.org/nibabel/dicom/dicom_mosaic.html
   this->m_3DUnwrappedVolume->SetOrigin(
           previousImage->GetOrigin()
-          + GetNRRDSpaceDirection<Volume3DType>(this->m_3DUnwrappedVolume) * ( ( mosaicSize - sliceSize) / 2 )
+          + GetNRRDSpaceDirection<ScalarImage3DType>(this->m_3DUnwrappedVolume) * ( ( mosaicSize - sliceSize) / 2 )
   );
 
 
-  Volume3DType::RegionType dmRegion = this->m_3DUnwrappedVolume->GetLargestPossibleRegion();
+  ScalarImage3DType::RegionType dmRegion = this->m_3DUnwrappedVolume->GetLargestPossibleRegion();
   dmRegion.SetSize(2, 1);
   region.SetSize(0, dmSize[0]);
   region.SetSize(1, dmSize[1]);
@@ -489,7 +489,7 @@ void SiemensDWIConverter::DeMosaic()
     unsigned int new_k = k /* - bad_slice_counter */;
 
     dmRegion.SetIndex(2, new_k);
-    itk::ImageRegionIteratorWithIndex<Volume3DType> dmIt( this->m_3DUnwrappedVolume, dmRegion );
+    itk::ImageRegionIteratorWithIndex<ScalarImage3DType> dmIt( this->m_3DUnwrappedVolume, dmRegion );
 
     // figure out the mosaic region for this slice
     int sliceIndex = k;
@@ -503,7 +503,7 @@ void SiemensDWIConverter::DeMosaic()
     region.SetIndex( 1, colMosaic * dmSize[1] );
     region.SetIndex( 2, slcMosaic );
 
-    itk::ImageRegionConstIteratorWithIndex<Volume3DType> imIt( previousImage, region );
+    itk::ImageRegionConstIteratorWithIndex<ScalarImage3DType> imIt( previousImage, region );
     for( dmIt.GoToBegin(), imIt.GoToBegin(); !dmIt.IsAtEnd(); ++dmIt, ++imIt )
     {
       dmIt.Set( imIt.Get() );

--- a/DWIConvert/TestSuite/DWISimpleCompare.cxx
+++ b/DWIConvert/TestSuite/DWISimpleCompare.cxx
@@ -145,6 +145,7 @@ int compareVectorAndScaleImage( const std::string & inputVectorImage, const std:
                        << "scalar image voxel: "<< scalarImageVoxel << std::endl;
              if( nUnmatchVoxels >= 5 )
              {
+               std::cerr<<"find at least 5 voxels unmatching" <<std::endl;
                return EXIT_FAILURE;
              }
            }

--- a/DWIConvert/TestSuite/DWISimpleCompare.cxx
+++ b/DWIConvert/TestSuite/DWISimpleCompare.cxx
@@ -81,6 +81,7 @@ RecoverGVector(typename itk::Image<PixelType, DIMENSION>::Pointer & img)
   return rval;
 }
 
+    /*
 int compareVectorAndScaleImage( const std::string & inputVectorImage, const std::string & inputScalarImage, bool CheckDWIData )
 {
   typedef itk::ImageFileReader<VectorImage3DType> VectorImage3DReaderType;
@@ -156,7 +157,7 @@ int compareVectorAndScaleImage( const std::string & inputVectorImage, const std:
 
   return EXIT_SUCCESS;
 }
-
+*/
 
 template <class PixelType>
 int DoIt( const std::string & inputVolume1, const std::string & inputVolume2, PixelType, bool CheckDWIData )
@@ -363,8 +364,8 @@ int main( int argc, char * argv[] )
         rval = DoIt( inputVolume1, inputVolume2, static_cast<unsigned short>(0), CheckDWIData );
         break;
       case itk::ImageIOBase::SHORT:
-        //rval = DoIt( inputVolume1, inputVolume2, static_cast<short>(0), CheckDWIData );
-        rval = compareVectorAndScaleImage(inputVolume1, inputVolume2, CheckDWIData);
+        rval = DoIt( inputVolume1, inputVolume2, static_cast<short>(0), CheckDWIData );
+        //rval = compareVectorAndScaleImage(inputVolume1, inputVolume2, CheckDWIData);
         break;
       case itk::ImageIOBase::UINT:
         rval = DoIt( inputVolume1, inputVolume2, static_cast<unsigned int>(0), CheckDWIData );

--- a/DWIConvert/TestSuite/DWISimpleCompare.cxx
+++ b/DWIConvert/TestSuite/DWISimpleCompare.cxx
@@ -83,20 +83,39 @@ RecoverGVector(typename itk::Image<PixelType, DIMENSION>::Pointer & img)
 
 int compareVectorAndScaleImage( const std::string & inputVectorImage, const std::string & inputScalarImage, bool CheckDWIData ){
   typedef itk::ImageFileReader<VectorImage3DType> VectorImage3DReaderType;
-  typename VectorImage3DReaderType::Pointer vectorImageReader = VectorImage3DReaderType::New();
+  VectorImage3DReaderType::Pointer vectorImageReader = VectorImage3DReaderType::New();
   vectorImageReader->SetFileName(inputVectorImage.c_str());
   vectorImageReader->Update();
-  typename VectorImage3DType::Pointer vectorImage = vectorImageReader->GetOutput();
+  VectorImage3DType::Pointer vectorImage = vectorImageReader->GetOutput();
 
   typedef itk::ImageFileReader<ScalarImage4DType> ScalarImage4DReaderType;
-  typename ScalarImage4DReaderType::Pointer scalarImageReader = ScalarImage4DReaderType::New();
+  ScalarImage4DReaderType::Pointer scalarImageReader = ScalarImage4DReaderType::New();
   scalarImageReader->SetFileName(inputScalarImage.c_str());
   scalarImageReader->Update();
-  typename ScalarImage4DType::Pointer scalarImage = scalarImageReader->GetOutput();
+  ScalarImage4DType::Pointer scalarImage = scalarImageReader->GetOutput();
 
+  //check total number of voxel is equal
+  VectorImage3DType::RegionType vectorImageRegion = vectorImage->GetLargestPossibleRegion();
+  VectorImage3DType::SizeType vectorImageSize =   vectorImageRegion.GetSize();
+  unsigned long vectorImageNVoxel = vectorImageSize[0]*vectorImageSize[1]* vectorImageSize[2]*vectorImage->GetVectorLength();
 
+  ScalarImage4DType::RegionType scalarImageRegion = scalarImage->GetLargestPossibleRegion();
+  ScalarImage4DType::SizeType scalarImageSize =   scalarImageRegion.GetSize();
+  unsigned long scalarImageNVoxel = scalarImageSize[0]*scalarImageSize[1]* scalarImageSize[2]*scalarImageSize[3];
 
+  if (vectorImageNVoxel != scalarImageNVoxel){
+      std::cerr <<"inputVectorImage and inputScalarImage have different number of voxels:\n"
+                <<"vector Image: " << vectorImageNVoxel
+                <<"scalar Image: " << scalarImageNVoxel << std::endl;
+      return EXIT_FAILURE;
+  }
+  else{
+      std::cout<<"\nGood. inputVectorImage and inputScalarImage have same number of voxels.\n" << std::endl;
+  }
 
+  //compare voxel value
+
+  return EXIT_SUCCESS;
 }
 
 template <class PixelType>
@@ -304,7 +323,8 @@ int main( int argc, char * argv[] )
         rval = DoIt( inputVolume1, inputVolume2, static_cast<unsigned short>(0), CheckDWIData );
         break;
       case itk::ImageIOBase::SHORT:
-        rval = DoIt( inputVolume1, inputVolume2, static_cast<short>(0), CheckDWIData );
+        //rval = DoIt( inputVolume1, inputVolume2, static_cast<short>(0), CheckDWIData );
+        rval = compareVectorAndScaleImage(inputVolume1, inputVolume2, CheckDWIData);
         break;
       case itk::ImageIOBase::UINT:
         rval = DoIt( inputVolume1, inputVolume2, static_cast<unsigned int>(0), CheckDWIData );

--- a/DWIConvert/TestSuite/DWISimpleCompare.cxx
+++ b/DWIConvert/TestSuite/DWISimpleCompare.cxx
@@ -81,6 +81,24 @@ RecoverGVector(typename itk::Image<PixelType, DIMENSION>::Pointer & img)
   return rval;
 }
 
+int compareVectorAndScaleImage( const std::string & inputVectorImage, const std::string & inputScalarImage, bool CheckDWIData ){
+  typedef itk::ImageFileReader<VectorImage3DType> VectorImage3DReaderType;
+  typename VectorImage3DReaderType::Pointer vectorImageReader = VectorImage3DReaderType::New();
+  vectorImageReader->SetFileName(inputVectorImage.c_str());
+  vectorImageReader->Update();
+  typename VectorImage3DType::Pointer vectorImage = vectorImageReader->GetOutput();
+
+  typedef itk::ImageFileReader<ScalarImage4DType> ScalarImage4DReaderType;
+  typename ScalarImage4DReaderType::Pointer scalarImageReader = ScalarImage4DReaderType::New();
+  scalarImageReader->SetFileName(inputScalarImage.c_str());
+  scalarImageReader->Update();
+  typename ScalarImage4DType::Pointer scalarImage = scalarImageReader->GetOutput();
+
+
+
+
+}
+
 template <class PixelType>
 int DoIt( const std::string & inputVolume1, const std::string & inputVolume2, PixelType, bool CheckDWIData )
 {

--- a/DWIConvert/TestSuite/DWISimpleCompare.cxx
+++ b/DWIConvert/TestSuite/DWISimpleCompare.cxx
@@ -105,8 +105,8 @@ int compareVectorAndScaleImage( const std::string & inputVectorImage, const std:
   unsigned long scalarImageNVoxel = scalarImageSize[0]*scalarImageSize[1]* scalarImageSize[2]*scalarImageSize[3];
 
   if (vectorImageNVoxel != scalarImageNVoxel){
-      std::cerr <<"inputVectorImage and inputScalarImage have different number of voxels:\n"
-                <<"vector Image: " << vectorImageNVoxel
+      std::cerr <<"inputVectorImage and inputScalarImage have different number of voxels:\n"<< std::endl
+                <<"vector Image: " << vectorImageNVoxel << std::endl
                 <<"scalar Image: " << scalarImageNVoxel << std::endl;
       return EXIT_FAILURE;
   }

--- a/DWIConvert/TestSuite/NrrdToNIfTI.cxx
+++ b/DWIConvert/TestSuite/NrrdToNIfTI.cxx
@@ -29,13 +29,13 @@ typedef itk::Image<PixelValueType, DIMENSION>     Image4DType;
 typedef itk::Image<PixelValueType, DIMENSION - 1> Image3DType;
 
 void
-ConvertVectorImageTo4DImage(const Vector3DType * img,
+ConvertVectorImageTo4DImage(const VectorImage3DType * img,
                             Image4DType::Pointer & img4D)
 {
-  Vector3DType::SizeType      size3D(img->GetLargestPossibleRegion().GetSize() );
-  Vector3DType::DirectionType direction3D(img->GetDirection() );
-  Vector3DType::SpacingType   spacing3D(img->GetSpacing() );
-  Vector3DType::PointType     origin3D(img->GetOrigin() );
+  VectorImage3DType::SizeType      size3D(img->GetLargestPossibleRegion().GetSize() );
+  VectorImage3DType::DirectionType direction3D(img->GetDirection() );
+  VectorImage3DType::SpacingType   spacing3D(img->GetSpacing() );
+  VectorImage3DType::PointType     origin3D(img->GetOrigin() );
 
   Image4DType::SizeType size4D;
 
@@ -70,21 +70,21 @@ ConvertVectorImageTo4DImage(const Vector3DType * img,
   img4D->Allocate();
 
   Image4DType::IndexType     index4D;
-  Vector3DType::IndexType vectorIndex;
-  for( vectorIndex[2] = 0; vectorIndex[2] < static_cast<Vector3DType::IndexType::IndexValueType>( size3D[2] );
+  VectorImage3DType::IndexType vectorIndex;
+  for( vectorIndex[2] = 0; vectorIndex[2] < static_cast<VectorImage3DType::IndexType::IndexValueType>( size3D[2] );
        ++vectorIndex[2] )
     {
     index4D[2] = vectorIndex[2];
-    for( vectorIndex[1] = 0; vectorIndex[1] < static_cast<Vector3DType::IndexType::IndexValueType>( size3D[1] );
+    for( vectorIndex[1] = 0; vectorIndex[1] < static_cast<VectorImage3DType::IndexType::IndexValueType>( size3D[1] );
          ++vectorIndex[1] )
       {
       index4D[1] = vectorIndex[1];
-      for( vectorIndex[0] = 0; vectorIndex[0] < static_cast<Vector3DType::IndexType::IndexValueType>( size3D[0] );
+      for( vectorIndex[0] = 0; vectorIndex[0] < static_cast<VectorImage3DType::IndexType::IndexValueType>( size3D[0] );
            ++vectorIndex[0] )
         {
         index4D[0] = vectorIndex[0];
-        const Vector3DType::PixelType pixel = img->GetPixel(vectorIndex);
-        for( index4D[3] = 0; index4D[3] < static_cast<Vector3DType::IndexType::IndexValueType>( size4D[3] );
+        const VectorImage3DType::PixelType pixel = img->GetPixel(vectorIndex);
+        for( index4D[3] = 0; index4D[3] < static_cast<VectorImage3DType::IndexType::IndexValueType>( size4D[3] );
              ++index4D[3] )
           {
           img4D->SetPixel(index4D, pixel[index4D[3]]);
@@ -102,11 +102,11 @@ int main(int argc, char *argv[])
     std::cout << "USAGE: " << argv[0] << "input output outputName3D" << std::endl;
     return EXIT_FAILURE;
     }
-  Vector3DType::Pointer img;
+  VectorImage3DType::Pointer img;
   std::string              inputName(argv[1]), outputName(argv[2]),
   outputName3D(argv[3]);
 
-  ReadVectorVolume<Vector3DType>(img, inputName, false);
+  ReadVectorVolume<VectorImage3DType>(img, inputName, false);
   std::cout << "input directions" << std::endl
             << img->GetDirection() << std::endl;
 

--- a/DWIConvert/TestSuite/NrrdToNIfTI.cxx
+++ b/DWIConvert/TestSuite/NrrdToNIfTI.cxx
@@ -25,19 +25,17 @@
 #include "itkImageRegionIterator.h"
 
 const int DIMENSION(4);
-typedef unsigned short                       PixelType;
-typedef itk::Image<PixelType, DIMENSION>     Image4DType;
-typedef itk::Image<PixelType, DIMENSION - 1> Image3DType;
-typedef itk::VectorImage<PixelType, 3>       VectorImageType;
+typedef itk::Image<PixelValueType, DIMENSION>     Image4DType;
+typedef itk::Image<PixelValueType, DIMENSION - 1> Image3DType;
 
 void
-ConvertVectorImageTo4DImage(const VectorImageType * img,
+ConvertVectorImageTo4DImage(const Vector3DType * img,
                             Image4DType::Pointer & img4D)
 {
-  VectorImageType::SizeType      size3D(img->GetLargestPossibleRegion().GetSize() );
-  VectorImageType::DirectionType direction3D(img->GetDirection() );
-  VectorImageType::SpacingType   spacing3D(img->GetSpacing() );
-  VectorImageType::PointType     origin3D(img->GetOrigin() );
+  Vector3DType::SizeType      size3D(img->GetLargestPossibleRegion().GetSize() );
+  Vector3DType::DirectionType direction3D(img->GetDirection() );
+  Vector3DType::SpacingType   spacing3D(img->GetSpacing() );
+  Vector3DType::PointType     origin3D(img->GetOrigin() );
 
   Image4DType::SizeType size4D;
 
@@ -72,21 +70,21 @@ ConvertVectorImageTo4DImage(const VectorImageType * img,
   img4D->Allocate();
 
   Image4DType::IndexType     index4D;
-  VectorImageType::IndexType vectorIndex;
-  for( vectorIndex[2] = 0; vectorIndex[2] < static_cast<VectorImageType::IndexType::IndexValueType>( size3D[2] );
+  Vector3DType::IndexType vectorIndex;
+  for( vectorIndex[2] = 0; vectorIndex[2] < static_cast<Vector3DType::IndexType::IndexValueType>( size3D[2] );
        ++vectorIndex[2] )
     {
     index4D[2] = vectorIndex[2];
-    for( vectorIndex[1] = 0; vectorIndex[1] < static_cast<VectorImageType::IndexType::IndexValueType>( size3D[1] );
+    for( vectorIndex[1] = 0; vectorIndex[1] < static_cast<Vector3DType::IndexType::IndexValueType>( size3D[1] );
          ++vectorIndex[1] )
       {
       index4D[1] = vectorIndex[1];
-      for( vectorIndex[0] = 0; vectorIndex[0] < static_cast<VectorImageType::IndexType::IndexValueType>( size3D[0] );
+      for( vectorIndex[0] = 0; vectorIndex[0] < static_cast<Vector3DType::IndexType::IndexValueType>( size3D[0] );
            ++vectorIndex[0] )
         {
         index4D[0] = vectorIndex[0];
-        const VectorImageType::PixelType pixel = img->GetPixel(vectorIndex);
-        for( index4D[3] = 0; index4D[3] < static_cast<VectorImageType::IndexType::IndexValueType>( size4D[3] );
+        const Vector3DType::PixelType pixel = img->GetPixel(vectorIndex);
+        for( index4D[3] = 0; index4D[3] < static_cast<Vector3DType::IndexType::IndexValueType>( size4D[3] );
              ++index4D[3] )
           {
           img4D->SetPixel(index4D, pixel[index4D[3]]);
@@ -104,11 +102,11 @@ int main(int argc, char *argv[])
     std::cout << "USAGE: " << argv[0] << "input output outputName3D" << std::endl;
     return EXIT_FAILURE;
     }
-  VectorImageType::Pointer img;
+  Vector3DType::Pointer img;
   std::string              inputName(argv[1]), outputName(argv[2]),
   outputName3D(argv[3]);
 
-  ReadVectorVolume<VectorImageType>(img, inputName, false);
+  ReadVectorVolume<Vector3DType>(img, inputName, false);
   std::cout << "input directions" << std::endl
             << img->GetDirection() << std::endl;
 


### PR DESCRIPTION
1  current support itk scalar image DWIConvert version;
2  it unifies a lot of naming of type as a basis for further refactor version;
3  in order to avoid differ from master too much in the future, I request this pull request;
4  all code passed Ctest case of DWIConvert module;
