### PR TITLE
BUG: fix #334 without changing interface of ITK

### DIFF
--- a/DWIConvert/DWIConverter.h
+++ b/DWIConvert/DWIConverter.h
@@ -130,6 +130,7 @@ public:
  Volume3DUnwrappedType::Pointer GetDiffusionVolume() const ;
 
  SpacingType GetSpacing() const;
+ double GetThickness() const;
 
  Volume3DUnwrappedType::PointType GetOrigin() const;
  void SetOrigin(DWIConverter::Volume3DUnwrappedType::PointType origin);
@@ -191,6 +192,7 @@ public:
 
   //add by Hui Xie
   Volume3DUnwrappedType::Pointer getVolumePointer();
+  double readThicknessFromDict();
 
 
 protected:
@@ -216,6 +218,7 @@ protected:
   unsigned int        m_NSlice;
   /** number of gradient volumes */
   unsigned int        m_NVolume;
+  double             m_thickness;
     /* The following variables make up the primary data model for diffusion weighted images
      * in the most generic sense.  These variables all need to be manipulated together in
      * order to maintain a consistent data model.

--- a/DWIConvert/DWIDICOMConverterBase.cxx
+++ b/DWIConvert/DWIDICOMConverterBase.cxx
@@ -97,6 +97,7 @@ void DWIDICOMConverterBase::LoadDicomDirectory()
     imSpacing[2] = spacing[2];
     m_Volume->SetSpacing(imSpacing);
   }
+  m_thickness = readThicknessFromDicom();
 
   // a map of ints keyed by the slice location string
   // reported in the dicom file.  The number of slices per
@@ -384,4 +385,18 @@ void DWIDICOMConverterBase::DetermineSliceOrderIS()
   {
     this->m_SliceOrderIS = false;
   }
+}
+
+/*
+ * According Dicom standard:(DICOM PS3.6 2016b - Data Dictionary)
+ * (0018, 0050) indicates slice thickness.
+ *  which is also consistent with Dcom2iix software.
+ *  In the 348-bytes header of NifTi, there is no place to store thickness information.
+ *  And 348 bytes which are already occupied compactly leave no space for private information extension.
+ *  In another words, you will loss thickness information from Dicom to FSL, or from Nrrd to FSL.
+ * */
+double DWIDICOMConverterBase::readThicknessFromDicom() const{
+  double thickness= 0.0;
+  m_Headers[0]->GetElementDS<double>(0x0018,0x0050,1,&thickness);
+  return thickness;
 }

--- a/DWIConvert/DWIDICOMConverterBase.h
+++ b/DWIConvert/DWIDICOMConverterBase.h
@@ -35,7 +35,7 @@ class DWIDICOMConverterBase : public DWIConverter {
   virtual void LoadFromDisk() ITK_OVERRIDE;
 
   virtual void LoadDicomDirectory();
-
+  double readThicknessFromDicom() const;
 
 protected:
   enum VRType{

--- a/DWIConvert/NRRDDWIConverter.cxx
+++ b/DWIConvert/NRRDDWIConverter.cxx
@@ -105,6 +105,7 @@ NRRDDWIConverter::ExtractDWIData()
   RecoverMeasurementFrame<Volume3DUnwrappedType>(this->m_Volume.GetPointer(), this->m_MeasurementFrame);
   RecoverBVectors<Volume3DUnwrappedType>(this->m_Volume.GetPointer(), this->m_DiffusionVectors);
   RecoverBValues<Volume3DUnwrappedType>(this->m_Volume.GetPointer(), this->m_DiffusionVectors, this->m_BValues);
+  readThicknessFromDict();
 }
 
 DWIConverter::CommonDicomFieldMapType NRRDDWIConverter::GetCommonDicomFieldsMap() const


### PR DESCRIPTION
1  Fixed the Bug #334 about zSpace error;
2  it also supports get thickness from Dicom to Nrrd only;
3  it does not needs ITK interface change, but the ITK implement of itkDicomReader::GetSpacing() needs modification;
4  I will simultaneously submit a ITK implement modification about itkDicomReader::GetSpacing() to ITK Gerrit ;
5  All modification passed Felix's test case and all DWIConvert 65 test cases ;
