### PR TITLE
BUG: fix #334

### DIFF
--- a/DWIConvert/DWIDICOMConverterBase.h
+++ b/DWIConvert/DWIDICOMConverterBase.h
@@ -36,6 +36,7 @@ class DWIDICOMConverterBase : public DWIConverter {
 
   virtual void LoadDicomDirectory();
   double readThicknessFromDicom() const;
+  int getDicomSpacing(double * const spacing) const;
 
 protected:
   enum VRType{


### PR DESCRIPTION
As the modification of itk::itkDCMTKFileReader::GetSpacing for getting correct zSpace using use (0020, 0032) Image Position (Patient)  needs to handle the frame order of various MR vendors, e.g. Siemens Mosaic format, this work, I guess, needs a lot of time. Maybe one month or 3 month, I don't know.

Therefore, I implemented temporarily a bypass solution inside BRAINSTools named int DWIDICOMConverterBase::getDicomSpacing(double * const spacing) const.

This modification has passed test case of Felix and DWIConvert module.