### PR TITLE
DWIConvert: add optional "outputNiftiFile" for Slicer GUI use.

### DIFF
--- a/DWIConvert/DWIConvert.cxx
+++ b/DWIConvert/DWIConvert.cxx
@@ -79,6 +79,9 @@ int main(int argc, char *argv[])
     dWIConvert.setUseIdentityMeasurementFrame (useIdentityMeaseurementFrame);
     dWIConvert.setUseBMatrixGradientDirections (useBMatrixGradientDirections);
 
+    if (!outputNiftiFile.empty())
+      outputVolume = outputNiftiFile;
+
     dWIConvert.setOutputFileType(outputVolume);
     dWIConvert.setOutputDirectory(outputDirectory);
     dWIConvert.setOutputBValues(outputBValues);

--- a/DWIConvert/DWIConvert.xml
+++ b/DWIConvert/DWIConvert.xml
@@ -49,11 +49,12 @@
       <longflag>--inputDicomDirectory</longflag>
       <label>Input Dicom Data Directory</label>
       <channel>input</channel>
+      <default></default>
       <description><![CDATA[Directory holding Dicom series]]></description>
     </directory>
   </parameters>
 
-  <parameters>
+  <parameters advanced="true">
     <label>NiftiFSL To Nrrd Conversion Parameters</label>
     <description><![CDATA[NiftiFSL To Nrrd Conversion Parameters]]></description>
     <file>
@@ -81,7 +82,14 @@
 
   <parameters advanced="true">
     <label>Nrrd To NiftiFSL Conversion Parameters</label>
-    <description><![CDATA[Nrrd To NiftiFSL Conversion Parameters]]></description>
+    <description><![CDATA[Nrrd To NiftiFSL (NrrdToFSL) Conversion Parameters]]></description>
+    <file fileExtensions=".nii,.nii.gz">
+      <name>outputNiftiFile</name>
+      <longflag>--outputNiftiFile</longflag>
+      <label>Output nii file</label>
+      <channel>output</channel>
+      <description><![CDATA[Nifti output filename (for Slicer GUI use).]]></description>
+    </file>
     <file fileExtensions=".bval">
       <name>outputBValues</name>
       <longflag>--outputBValues</longflag>

--- a/DWIConvert/DWIConvertLib.cxx
+++ b/DWIConvert/DWIConvertLib.cxx
@@ -143,7 +143,7 @@ int DWIConvert::read()
     std::cerr << "Invalid conversion mode" << std::endl;
     return EXIT_FAILURE;
   }
-  return EXIT_SUCCESS;
+  return (NULL == m_converter ? EXIT_FAILURE : EXIT_SUCCESS);
 
 }
 
@@ -241,6 +241,11 @@ DWIConverter * DWIConvert::CreateDicomConverter(
   catch( itk::ExceptionObject &excp)
   {
     std::cerr << "Exception creating converter " << excp << std::endl;
+    return ITK_NULLPTR;
+  }
+  if (NULL == converter)
+  {
+    std::cerr << "Unable to create converter!" << std::endl;
     return ITK_NULLPTR;
   }
 

--- a/DWIConvert/DWIConvertLib.cxx
+++ b/DWIConvert/DWIConvertLib.cxx
@@ -65,7 +65,6 @@ int DWIConvert::read()
     return EXIT_FAILURE;
   }
 
-  dcmtk::log4cplus::helpers::LogLog::getLogLog()->setQuietMode(true);
   // register DCMTK codecs, otherwise they will not be available when
   // `itkDCMTKSeriesFileNames` is used to build a list of filenames,
   // so reading series with JPEG transfer syntax will fail.

--- a/DWIConvert/DWIConvertLib.cxx
+++ b/DWIConvert/DWIConvertLib.cxx
@@ -288,7 +288,11 @@ DWIConverter * DWIConvert::CreateDicomConverter(
 void DWIConvert::setInputFileType(const std::string& inputVolume, const std::string& inputDicomDirectory){
   m_inputVolume = inputVolume;
   m_inputDicomDirectory = inputDicomDirectory;
-  if (emptyString == m_inputDicomDirectory && emptyString != m_inputVolume){
+
+  // prefer the inputVolume field if available
+  if ( (!m_inputVolume.empty()) ||
+       m_inputDicomDirectory.empty() )
+  {
     const std::string inputExt = itksys::SystemTools::GetFilenameExtension(m_inputVolume);
     if ( std::string::npos != inputExt.rfind(".nii"))
     {

--- a/DWIConvert/DWIConvertLib.cxx
+++ b/DWIConvert/DWIConvertLib.cxx
@@ -290,9 +290,16 @@ void DWIConvert::setInputFileType(const std::string& inputVolume, const std::str
   m_inputDicomDirectory = inputDicomDirectory;
   if (emptyString == m_inputDicomDirectory && emptyString != m_inputVolume){
     const std::string inputExt = itksys::SystemTools::GetFilenameExtension(m_inputVolume);
-    if ( std::string::npos != inputExt.rfind(".nii")) m_inputFileType = "FSL";
-    else if (std::string::npos != inputExt.rfind(".nrrd") || std::string::npos != inputExt.rfind(".nhdr")) m_inputFileType = "Nrrd";
-    else {
+    if ( std::string::npos != inputExt.rfind(".nii"))
+    {
+      m_inputFileType = "FSL";
+    }
+    else if (std::string::npos != inputExt.rfind(".nrrd") || std::string::npos != inputExt.rfind(".nhdr"))
+    {
+      m_inputFileType = "Nrrd";
+    }
+    else
+    {
       std::cerr <<"Error: file type of inputVoume is not supported currently"<<std::endl;
     }
   }

--- a/DWIConvert/DWIConvertLib.h
+++ b/DWIConvert/DWIConvertLib.h
@@ -24,7 +24,8 @@ public:
     DWIConverter *getConverter() const;
 
     // get and set methods for private data members
-    void setInputFileType(const std::string& inputVolume, const std::string& inputDicomDirectory);
+    void setInputFileType(const std::string& inputVolume,
+                          const std::string& inputDicomDirectory);
 
     void setOutputFileType(const std::string& outputVolume);
 


### PR DESCRIPTION
Main commit is 3aed219
```
ENH: add optional parameter to allow Slicer GUI use  …

In NrrdToFSL mode users need to specify the output Nifti path, but it is not possible
to do so with the Slicer CLI diffusion-weighted node type. The CLI and generated GUI
will always create a MRMLNode selector which links to a temporary NRRD file using
via NRRD I/O. So add an optional outputNiftiFile parameter which can be used in the GUI.

ref:
http://massmail.spl.harvard.edu/public-archives/slicer-users/2017/011994.html
```

Additional commits are minor clean-up for some style and logic issues that I noticed.