### PR TITLE
BUG: fix computed bvec & bval path for same directory usage

### DIFF
--- a/DWIConvert/DWIConverter.cxx
+++ b/DWIConvert/DWIConverter.cxx
@@ -292,7 +292,7 @@ std::string  DWIConverter::MakeFileComment(
                    << "# part of the BRAINSTools package." << std::endl
                    << "# Command line options:" << std::endl
                    << "# --inputFileType " << inputFileType << std::endl;
-    if( std::abs( smallGradientThreshold- 0.2 ) > 1e-4 )
+    if( std::abs( smallGradientThreshold - 0.2 ) > 1e-4 )
     {
       commentSection << "# --smallGradientThreshold " << smallGradientThreshold << std::endl;
     }

--- a/DWIConvert/DWIConverter.cxx
+++ b/DWIConvert/DWIConverter.cxx
@@ -175,8 +175,11 @@ void DWIConverter::ReadGradientInformation(const std::string& inputBValues, cons
   if( CheckArg<std::string>("B Values", inputBValues, "") == EXIT_FAILURE )
   {
     std::vector<std::string> pathElements;
-    pathElements.push_back(baseDirectory);
-    pathElements.push_back("/");
+    if (!baseDirectory.empty())
+    {
+      pathElements.push_back(baseDirectory);
+      pathElements.push_back("/");
+    }
     pathElements.push_back( itksys::SystemTools::GetFilenameWithoutExtension (inputVolumeNameTemplate) + ".bval");
     _inputBValues = itksys::SystemTools::JoinPath(pathElements);
     std::cout << "   From template " << inputVolumeNameTemplate << std::endl;
@@ -186,8 +189,11 @@ void DWIConverter::ReadGradientInformation(const std::string& inputBValues, cons
   if( CheckArg<std::string>("B Vectors", inputBVectors, "") == EXIT_FAILURE )
   {
     std::vector<std::string> pathElements;
-    pathElements.push_back(baseDirectory);
-    pathElements.push_back("/");
+    if (!baseDirectory.empty())
+    {
+      pathElements.push_back(baseDirectory);
+      pathElements.push_back("/");
+    }
     pathElements.push_back( itksys::SystemTools::GetFilenameWithoutExtension(inputVolumeNameTemplate) + ".bvec" );
     _inputBVectors = itksys::SystemTools::JoinPath(pathElements);
     std::cout << "   From template " << inputVolumeNameTemplate << std::endl;

--- a/DWIConvert/DWIConverterFactory.cxx
+++ b/DWIConvert/DWIConverterFactory.cxx
@@ -177,7 +177,8 @@ DWIConverter* DWIConverterFactory::New()
     {
       converter = new SiemensDWIConverter(m_Headers,m_InputFileNames,
                                           m_UseBMatrixGradientDirections,
-                                          m_SmallGradientThreshold, m_FSLFileFormatHorizontalBy3Rows);
+                                          m_FSLFileFormatHorizontalBy3Rows,
+                                          m_SmallGradientThreshold);
     }
     else if(StringContains(this->m_Vendor,"GE"))
     {

--- a/DWIConvert/SiemensDWIConverter.cxx
+++ b/DWIConvert/SiemensDWIConverter.cxx
@@ -4,17 +4,18 @@
 #include "SiemensDWIConverter.h"
 
 SiemensDWIConverter::SiemensDWIConverter (DWIDICOMConverterBase::DCMTKFileVector &allHeaders,
-DWIConverter::FileNamesContainer &inputFileNames,
-const bool useBMatrixGradientDirections,
-const bool FSLFileFormatHorizontalBy3Rows,
-const double smallGradientThreshold) : DWIDICOMConverterBase(allHeaders,inputFileNames,
-        useBMatrixGradientDirections,
-        FSLFileFormatHorizontalBy3Rows),
-m_SmallGradientThreshold(smallGradientThreshold),
-m_MMosaic(0),
-m_NMosaic(0),
-m_Stride(0),
-m_HasCSAHeader(false)
+                                          DWIConverter::FileNamesContainer &inputFileNames,
+                                          const bool useBMatrixGradientDirections,
+                                          const bool FSLFileFormatHorizontalBy3Rows,
+                                          const double smallGradientThreshold) :
+      DWIDICOMConverterBase(allHeaders,inputFileNames,
+                            useBMatrixGradientDirections,
+                            FSLFileFormatHorizontalBy3Rows),
+      m_SmallGradientThreshold(smallGradientThreshold),
+      m_MMosaic(0),
+      m_NMosaic(0),
+      m_Stride(0),
+      m_HasCSAHeader(false)
 {
 }
 


### PR DESCRIPTION
Otherwise, with `--inputVolume test.nii` we end up looking for e.g. `/test.bvec`, which doesn't exist.