### PR TITLE
COMP: Fix USE_BRAINSABC default when C++11 is enabled

### DIFF
--- a/Common.cmake
+++ b/Common.cmake
@@ -93,7 +93,7 @@ cmake_dependent_option(USE_BRAINSConstellationDetectorGUI "Build BRAINSConstella
 mark_as_superbuild(USE_BRAINSConstellationDetectorGUI)
 
 if( USING_MODERN_CXX )
-  cmake_dependent_option(USE_BRAINSABC "Build BRAINSABC" OFF "USE_AutoWorkup;USE_ReferenceAtlas" ON)
+  cmake_dependent_option(USE_BRAINSABC "Build BRAINSABC" ON "USE_AutoWorkup;USE_ReferenceAtlas" OFF)
 else()
   cmake_dependent_option(USE_BRAINSABC "Build BRAINSABC" OFF "USE_AutoWorkup;USE_ReferenceAtlas" OFF)
 endif()


### PR DESCRIPTION
This commit fixes the cmake_dependent_option logic for USE_BRAINSABC.

USE_BRAINSABC should be enabled by default when C++11 is enabled and its
dependent options USE_AutoWorkup and USE_ReferenceAtlas are enabled.

Previously, the cmake_dependent_option logic erroneously enabled USE_BRAINSABC
if its dependent options were false, thus causing the build to fail.