### PR TITLE
RFC: Fix NRRD output axis order

### DIFF
--- a/DWIConvert/DWIConverter.cxx
+++ b/DWIConvert/DWIConverter.cxx
@@ -342,8 +342,8 @@ void DWIConverter::ManualWriteNRRDFile(
   header << "space: " << this->GetNRRDSpaceDefinition() << "" << std::endl;
 
   const DWIConverter::RotationMatrixType& NRRDSpaceDirection = this->GetNRRDSpaceDirection();
-  header << "sizes: " << this->GetCols()
-         << " " << this->GetRows()
+  header << "sizes: " << this->GetRows()
+         << " " << this->GetCols()
          << " " << this->GetSlicesPerVolume()
          << " " << this->GetNVolume() << std::endl;
   header << "thicknesses:  NaN  NaN " << DoubleConvert(GetThickness()) << " NaN" << std::endl;

--- a/DWIConvert/FSLDWIConverter.cxx
+++ b/DWIConvert/FSLDWIConverter.cxx
@@ -31,7 +31,8 @@ FSLDWIConverter::LoadFromDisk()
   Volume4DType::Pointer inputVol;
 
   // string to use as template if no bval or bvec filename is given.
-  ReadScalarVolume<Volume4DType>(inputVol, fslNIFTIFile, this->m_allowLossyConversion);
+  if (ReadScalarVolume<Volume4DType>(inputVol, fslNIFTIFile, this->m_allowLossyConversion) != EXIT_SUCCESS)
+    throw;
   // Reorient from FSL standard format to ITK/Dicom standard format
   this->m_SlicesPerVolume = inputVol->GetLargestPossibleRegion().GetSize()[2];
   this->m_NVolume = inputVol->GetLargestPossibleRegion().GetSize()[3];


### PR DESCRIPTION
**NOTE: small change -- but please review very carefully and see note below**

| Before: | After: |
| ------- | ------ |
|![image](https://user-images.githubusercontent.com/327706/32986999-aeaebf62-ccac-11e7-84a0-a870629cac70.png)|![image](https://user-images.githubusercontent.com/327706/32987004-bd027bc6-ccac-11e7-9844-2c0ae208fd41.png)|

This turned out to be a little more involved than the pixel precision mismatch I [initially suspected](https://github.com/BRAINSia/BRAINSTools/commit/8693de7c6edec82f1639432c7a9826985ea7687b#commitcomment-25697933): NRRD output size axes appear to be swapped relative to ITK row-major array storage (and have been back at least [5 years or so](https://github.com/BRAINSia/BRAINSTools/commit/8cfbf80e241dd0a9cee8ef0040014a1c7fb97ee4)). In practice, this only matters when x and y axis dimensions are different -- as they happen to be in this particular dataset I was sent after a Slicer [forum post](https://discourse.slicer.org/t/dti-nifti-data-import-via-dwi-convert-module/1460/4).

Input nifti dimensions: 173 207 173 143
Output nrrd - before: `sizes: 207 173 173 143`
Output nrrd - after: `sizes: 173 207 173 143`

Apparently such an acquisition is relatively rare, though I'm still surprised this could have persisted for so long. As such, despite fixing read of this particular dataset, there's a chance I missed some underlying assumption elsewhere in the code. So, **please review carefully and run the test suite if possible before merging**. I'm not set up to run it myself right now, but if needed I can set it up to run on our cluster if it can't otherwise be run.