### PR TITLE
BUG: Add try/catch around BrainsFitHelper update

### DIFF
--- a/BRAINSFit/BRAINSFit.cxx
+++ b/BRAINSFit/BRAINSFit.cxx
@@ -537,7 +537,16 @@ int main(int argc, char *argv[])
       {
       myHelper->PrintCommandLine(true, "BF");
       }
-    myHelper->Update();
+    try
+      {
+      myHelper->Update();
+      }
+    catch( itk::ExceptionObject & err )
+      {
+      std::cerr << "Exception during registration: " << std::endl;
+      std::cerr << err << std::endl;
+      return EXIT_FAILURE;
+      }
     currentGenericTransform = myHelper->GetCurrentGenericTransform();
 
     std::string currentGenericTransformFileType;


### PR DESCRIPTION
Without this exception handling, windows may detect the uncaught error and display a microsoft runtime library error dialog.
Adding the try-catch prevents this.