### PR TITLE
ENH: don't allow matching bvec and bval file names

### DIFF
--- a/DWIConvert/DWIConverter.cxx
+++ b/DWIConvert/DWIConverter.cxx
@@ -40,7 +40,7 @@ void DWIConverter::ConvertToSingleBValueScaledDiffusionVectors()
     BvalueScaledDiffusionVectors.reserve(m_DiffusionVectors.size());
     for( unsigned int k = 0; k < m_DiffusionVectors.size(); ++k )
     {
-      vnl_vector_fixed<double,3> vec(3);
+      vnl_vector_fixed<double,3> vec(0);
       float scaleFactor = 0;
       if( maxBvalue > 0 )
       {

--- a/DWIConvert/NrrdToFSL.cxx
+++ b/DWIConvert/NrrdToFSL.cxx
@@ -97,6 +97,12 @@ int NrrdToFSL(const std::string & inputVolume,
     return EXIT_FAILURE;
     }
 
+  if (outputBVectors == outputBValues)
+    {
+    std::cerr << ".bvec and .bval files must be unique!" << std::endl;
+    return EXIT_FAILURE;
+    }
+
   std::string _outputBValues, _outputBVectors;
   if(CheckArg<std::string>("B Values", outputBValues, "") == EXIT_FAILURE)
     {


### PR DESCRIPTION
Small sanity check for bvec/bval file names. I think it prevented a crash for me on some test data, and I forgot to make the PR until now.

(also change grad vector initializer to use 0 instead of 3 -- doesn't matter in practice because it is always overwritten, but at some point I was bewildered upon hitting a breakpoint in this function and seeing the completely-unexpected `[3,3,3]` vector)