### PR TITLE
ENH: Use file introspection to determine BVec file format

### DIFF
--- a/DWIConvert/DWIConvert.cxx
+++ b/DWIConvert/DWIConvert.cxx
@@ -79,7 +79,6 @@ int main(int argc, char *argv[])
     dWIConvert.setSmallGradientThreshold (smallGradientThreshold);
 
     dWIConvert.setfMRIOutput (fMRIOutput);
-    dWIConvert.setTranspose (transpose);
     dWIConvert.setAllowLossyConversion (allowLossyConversion);
     dWIConvert.setUseIdentityMeasurementFrame (useIdentityMeaseurementFrame);
     dWIConvert.setUseBMatrixGradientDirections (useBMatrixGradientDirections);

--- a/DWIConvert/DWIConvertLib.cxx
+++ b/DWIConvert/DWIConvertLib.cxx
@@ -27,7 +27,6 @@ DWIConvert::DWIConvert()
     m_outputFileType = emptyString;
 
     m_fMRIOutput = false; //default: false
-    m_transpose = false; //default:false
     m_allowLossyConversion = false; //defualt: false
     m_useIdentityMeasurementFrame = false; //default: false
     m_useBMatrixGradientDirections = false; //default: false
@@ -96,7 +95,7 @@ int DWIConvert::read()
     filesList.push_back(m_inputVolume);
 
     std::cout << "INPUT VOLUME: " << filesList[0] << std::endl;
-    FSLDWIConverter * FSLconverter = new FSLDWIConverter(filesList, m_inputBValues, m_inputBVectors,m_transpose);
+    FSLDWIConverter * FSLconverter = new FSLDWIConverter(filesList, m_inputBValues, m_inputBVectors);
     try
     {
       FSLconverter->SetAllowLossyConversion(m_allowLossyConversion);
@@ -118,7 +117,7 @@ int DWIConvert::read()
     filesList.push_back(m_inputVolume);
 
     std::cout << "INPUT VOLUME: " << filesList[0] << std::endl;
-    NRRDDWIConverter * NRRDconverter = new NRRDDWIConverter(filesList, m_transpose);
+    NRRDDWIConverter * NRRDconverter = new NRRDDWIConverter(filesList);
     try
     {
       NRRDconverter->SetAllowLossyConversion(m_allowLossyConversion);
@@ -134,7 +133,7 @@ int DWIConvert::read()
   }
   else if( "Dicom" ==  getInputFileType())
   {
-    m_converter = CreateDicomConverter(m_inputDicomDirectory,m_useBMatrixGradientDirections, m_transpose,
+    m_converter = CreateDicomConverter(m_inputDicomDirectory,m_useBMatrixGradientDirections,
                                      m_smallGradientThreshold,m_allowLossyConversion);
   }
   else
@@ -216,7 +215,6 @@ int  DWIConvert::write(){
 DWIConverter * DWIConvert::CreateDicomConverter(
         const std::string inputDicomDirectory,
         const bool useBMatrixGradientDirections,
-        const bool transpose,
         const double smallGradientThreshold,
         const bool allowLossyConversion)
 {
@@ -230,7 +228,6 @@ DWIConverter * DWIConvert::CreateDicomConverter(
 // use the factor to instantiate a converter object based on the vender.
   DWIConverterFactory converterFactory(inputDicomDirectory,
                                        useBMatrixGradientDirections,
-                                       transpose,
                                        smallGradientThreshold);
   DWIConverter * converter;
   try
@@ -390,14 +387,6 @@ bool DWIConvert::isfMRIOutput() const {
 
 void DWIConvert::setfMRIOutput(bool fMRIOutput) {
   m_fMRIOutput = fMRIOutput;
-}
-
-bool DWIConvert::isTranspose() const {
-  return m_transpose;
-}
-
-void DWIConvert::setTranspose(bool transpose) {
-  m_transpose = transpose;
 }
 
 bool DWIConvert::isAllowLossyConversion() const {

--- a/DWIConvert/DWIConvertLib.h
+++ b/DWIConvert/DWIConvertLib.h
@@ -68,10 +68,6 @@ public:
 
     void setfMRIOutput(bool fMRIOutput);
 
-    bool isTranspose() const;
-
-    void setTranspose(bool transpose);
-
     bool isAllowLossyConversion() const;
 
     void setAllowLossyConversion(bool allowLossyConversion);
@@ -107,7 +103,6 @@ private:
     DWIConverter *CreateDicomConverter(
             const std::string inputDicomDirectory,
             const bool useBMatrixGradientDirections,
-            const bool transpose,
             const double smallGradientThreshold,
             const bool allowLossyConversion);
 
@@ -122,7 +117,6 @@ private:
     double m_smallGradientThreshold; //default = 0.2
 
     bool m_fMRIOutput; //default: false
-    bool m_transpose; //default:false
     bool m_allowLossyConversion; //defualt: false
     bool m_useIdentityMeasurementFrame; //default: false
     bool m_useBMatrixGradientDirections; //default: false

--- a/DWIConvert/DWIConvertUtils.h
+++ b/DWIConvert/DWIConvertUtils.h
@@ -122,7 +122,7 @@ extern int ReadBVals(std::vector<double> & bVals, unsigned int & bValCount,
                      const std::string & bValFilename);
 
 extern int ReadBVecs(DWIMetaDataDictionaryValidator::GradientTableType & bVecs, unsigned int & bVecCount,
-                     const std::string & bVecFilename , bool horizontalBy3Rows );
+                     const std::string & bVecFilename );
 
 template <typename TValue>
 bool

--- a/DWIConvert/DWIConverter.cxx
+++ b/DWIConvert/DWIConverter.cxx
@@ -4,10 +4,9 @@
 
 #include "DWIConverter.h"
 #include "itkFlipImageFilter.h"
-DWIConverter::DWIConverter( const FileNamesContainer &inputFileNames, const bool FSLFileFormatHorizontalBy3Rows )
+DWIConverter::DWIConverter( const FileNamesContainer &inputFileNames )
         :
         m_InputFileNames(inputFileNames),
-        m_FSLFileFormatHorizontalBy3Rows(FSLFileFormatHorizontalBy3Rows),
         m_SlicesPerVolume(0),
         m_NSlice(0),
         m_NVolume(0),
@@ -40,7 +39,7 @@ void DWIConverter::ConvertToSingleBValueScaledDiffusionVectors()
     BvalueScaledDiffusionVectors.reserve(m_DiffusionVectors.size());
     for( unsigned int k = 0; k < m_DiffusionVectors.size(); ++k )
     {
-      vnl_vector_fixed<double,3> vec(0);
+      vnl_vector_fixed<double,3> vec(0.0);
       float scaleFactor = 0;
       if( maxBvalue > 0 )
       {

--- a/DWIConvert/DWIConverter.cxx
+++ b/DWIConvert/DWIConverter.cxx
@@ -209,7 +209,7 @@ void DWIConverter::ReadGradientInformation(const std::string& inputBValues, cons
   }
   DWIMetaDataDictionaryValidator::GradientTableType BVecs;
   unsigned int                      bVecCount = 0;
-  if( ReadBVecs(BVecs, bVecCount, _inputBVectors, m_FSLFileFormatHorizontalBy3Rows) != EXIT_SUCCESS )
+  if( ReadBVecs(BVecs, bVecCount, _inputBVectors ) != EXIT_SUCCESS )
   {
     itkGenericExceptionMacro(<< "ERROR reading BVector " << _inputBVectors);
   }

--- a/DWIConvert/DWIConverter.h
+++ b/DWIConvert/DWIConverter.h
@@ -88,7 +88,7 @@ public:
   typedef itk::Vector<double, 3>                        PointType;
 
   typedef std::map<std::string,std::string> CommonDicomFieldMapType;
-  DWIConverter( const FileNamesContainer &inputFileNames, const bool FSLFileFormatHorizontalBy3Rows );
+  DWIConverter( const FileNamesContainer &inputFileNames );
   virtual ~DWIConverter();
 
   virtual void LoadFromDisk() = 0 ;
@@ -211,7 +211,6 @@ protected:
 
   /** double conversion instance, for optimal printing of numbers as  text */
   itk::NumberToString<double> m_DoubleConvert;
-  bool       m_FSLFileFormatHorizontalBy3Rows; // Format of FSL files on disk
 
   unsigned int        m_SlicesPerVolume;
   /** number of total slices */

--- a/DWIConvert/DWIConverterFactory.cxx
+++ b/DWIConvert/DWIConverterFactory.cxx
@@ -6,11 +6,9 @@
 
 DWIConverterFactory::DWIConverterFactory(const std::string DicomDirectory,
                                          const bool UseBMatrixGradientDirections,
-                                         const bool FSLFileFormatHorizontalBy3Rows,
                                          const double smallGradientThreshold)
         : m_DicomDirectory(DicomDirectory)
         , m_UseBMatrixGradientDirections(UseBMatrixGradientDirections)
-        , m_FSLFileFormatHorizontalBy3Rows(FSLFileFormatHorizontalBy3Rows)
         , m_SmallGradientThreshold(smallGradientThreshold)
 {
 }
@@ -71,7 +69,7 @@ DWIConverter* DWIConverterFactory::New()
   else if( m_InputFileNames.size() == 1 &&  isNIIorNrrd( m_InputFileNames[0])) // FSL Reader or NRRD Reader
   {
     itkGenericExceptionMacro(<< "INVALID PATH, create FSLDWIConverter in main program" << std::endl);
-    converter = new FSLDWIConverter(m_InputFileNames,"","", this->m_FSLFileFormatHorizontalBy3Rows);
+    converter = new FSLDWIConverter(m_InputFileNames,"","");
   }
   else  // Assume multi file dicom file reading
   {
@@ -171,30 +169,29 @@ DWIConverter* DWIConverterFactory::New()
     if(StringContains(this->m_Vendor,"PHILIPS"))
     {
       converter = new PhilipsDWIConverter(m_Headers,m_InputFileNames,
-                                          m_UseBMatrixGradientDirections, m_FSLFileFormatHorizontalBy3Rows);
+                                          m_UseBMatrixGradientDirections);
     }
     else if(StringContains(this->m_Vendor,"SIEMENS"))
     {
       converter = new SiemensDWIConverter(m_Headers,m_InputFileNames,
                                           m_UseBMatrixGradientDirections,
-                                          m_FSLFileFormatHorizontalBy3Rows,
                                           m_SmallGradientThreshold);
     }
     else if(StringContains(this->m_Vendor,"GE"))
     {
       converter = new GEDWIConverter(m_Headers,m_InputFileNames,
-                                     m_UseBMatrixGradientDirections, m_FSLFileFormatHorizontalBy3Rows);
+                                     m_UseBMatrixGradientDirections);
     }
     else if(StringContains(this->m_Vendor,"HITACHI"))
     {
       converter = new HitachiDWIConverter(m_Headers,m_InputFileNames,
-                                          m_UseBMatrixGradientDirections, m_FSLFileFormatHorizontalBy3Rows);
+                                          m_UseBMatrixGradientDirections);
     }
     else
     {
       // generic converter can't do anything except load a DICOM
       // directory
-      converter = new GenericDWIConverter(m_InputFileNames, m_FSLFileFormatHorizontalBy3Rows);
+      converter = new GenericDWIConverter(m_InputFileNames);
       this->m_Vendor = "GENERIC";
     }
   }

--- a/DWIConvert/DWIConverterFactory.h
+++ b/DWIConvert/DWIConverterFactory.h
@@ -39,7 +39,6 @@ class DWIConverterFactory
 public:
   DWIConverterFactory(const std::string DicomDirectory,
                         const bool UseBMatrixGradientDirections,
-                        const bool FSLFileFormatHorizontalBy3Rows,
                         const double smallGradientThreshold);
 
   ~DWIConverterFactory();
@@ -52,7 +51,6 @@ private:
   std::string m_DicomDirectory;
   std::string m_Vendor;
   bool        m_UseBMatrixGradientDirections;
-  bool        m_FSLFileFormatHorizontalBy3Rows;
   double      m_SmallGradientThreshold;
 
   DWIDICOMConverterBase::DCMTKFileVector m_Headers;

--- a/DWIConvert/DWIDICOMConverterBase.cxx
+++ b/DWIConvert/DWIDICOMConverterBase.cxx
@@ -16,9 +16,8 @@ return this->m_CommonDicomFieldsMap;
 
 DWIDICOMConverterBase::DWIDICOMConverterBase(const DCMTKFileVector &allHeaders,
                                              const FileNamesContainer &inputFileNames,
-                                             const bool useBMatrixGradientDirections,
-                                             const bool FSLFileFormatHorizontalBy3Rows) :
-        DWIConverter(inputFileNames, FSLFileFormatHorizontalBy3Rows),
+                                             const bool useBMatrixGradientDirections) :
+        DWIConverter(inputFileNames),
         m_UseBMatrixGradientDirections(useBMatrixGradientDirections),
         m_Headers(allHeaders),
         m_MultiSliceVolume(false),

--- a/DWIConvert/DWIDICOMConverterBase.h
+++ b/DWIConvert/DWIDICOMConverterBase.h
@@ -23,8 +23,8 @@ class DWIDICOMConverterBase : public DWIConverter {
 
   DWIDICOMConverterBase(const DCMTKFileVector &allHeaders,
                           const FileNamesContainer &inputFileNames,
-                          const bool useBMatrixGradientDirections,
-                          const bool FSLFileFormatHorizontalBy3Rows);
+                          const bool useBMatrixGradientDirections
+                        );
 
   /**
    * @brief Return common fields.  Does nothing for FSL

--- a/DWIConvert/FSLDWIConverter.cxx
+++ b/DWIConvert/FSLDWIConverter.cxx
@@ -6,8 +6,8 @@
 
 FSLDWIConverter::FSLDWIConverter( const DWIConverter::FileNamesContainer & inputFileNames,
   const std::string inputBValues,
-  const std::string inputBVectors, const bool FSLFileFormatHorizontalBy3Rows)
-  : DWIConverter( inputFileNames, FSLFileFormatHorizontalBy3Rows )
+  const std::string inputBVectors)
+  : DWIConverter( inputFileNames )
   , m_inputBValues(inputBValues)
   , m_inputBVectors(inputBVectors)
 {

--- a/DWIConvert/FSLDWIConverter.h
+++ b/DWIConvert/FSLDWIConverter.h
@@ -27,7 +27,7 @@ class FSLDWIConverter : public DWIConverter
 public:
 
   FSLDWIConverter( const DWIConverter::FileNamesContainer & inputFileNames,
-  const std::string inputBValues, const std::string inputBVectors, const bool FSLFileFormatHorizontalBy3Rows);
+  const std::string inputBValues, const std::string inputBVectors);
 
   ~FSLDWIConverter() override {}
 

--- a/DWIConvert/GEDWIConverter.cxx
+++ b/DWIConvert/GEDWIConverter.cxx
@@ -6,9 +6,9 @@
 
 GEDWIConverter::GEDWIConverter(DWIDICOMConverterBase::DCMTKFileVector &allHeaders,
                  DWIConverter::FileNamesContainer &inputFileNames,
-                 const bool useBMatrixGradientDirections,
-                 const bool FSLFileFormatHorizontalBy3Rows) : DWIDICOMConverterBase(allHeaders,inputFileNames,
-                                                                   useBMatrixGradientDirections, FSLFileFormatHorizontalBy3Rows)
+                 const bool useBMatrixGradientDirections
+                 ) : DWIDICOMConverterBase(allHeaders,inputFileNames,
+                                           useBMatrixGradientDirections)
 {
 }
 GEDWIConverter::~GEDWIConverter() {}

--- a/DWIConvert/GEDWIConverter.h
+++ b/DWIConvert/GEDWIConverter.h
@@ -26,8 +26,8 @@ class GEDWIConverter : public DWIDICOMConverterBase
 public:
   GEDWIConverter(DWIDICOMConverterBase::DCMTKFileVector &allHeaders,
                  DWIConverter::FileNamesContainer &inputFileNames,
-                 const bool useBMatrixGradientDirections,
-                 const bool FSLFileFormatHorizontalBy3Rows);
+                 const bool useBMatrixGradientDirections
+                 );
 
   ~GEDWIConverter() override;
   void LoadDicomDirectory() override;

--- a/DWIConvert/GenericDWIConverter.cxx
+++ b/DWIConvert/GenericDWIConverter.cxx
@@ -3,8 +3,8 @@
 //
 #include "GenericDWIConverter.h"
 
-GenericDWIConverter::GenericDWIConverter( DWIConverter::FileNamesContainer &inputFileNames , const bool FSLFileFormatHorizontalBy3Rows)
-:  DWIConverter( inputFileNames, FSLFileFormatHorizontalBy3Rows)
+GenericDWIConverter::GenericDWIConverter( DWIConverter::FileNamesContainer &inputFileNames )
+:  DWIConverter( inputFileNames )
 {
 }
 

--- a/DWIConvert/GenericDWIConverter.h
+++ b/DWIConvert/GenericDWIConverter.h
@@ -23,7 +23,7 @@
 class GenericDWIConverter : public DWIConverter
 {
 public:
-  GenericDWIConverter( DWIConverter::FileNamesContainer &inputFileNames , const bool FSLFileFormatHorizontalBy3Rows);
+  GenericDWIConverter( DWIConverter::FileNamesContainer &inputFileNames );
 
   void LoadFromDisk() override;
 

--- a/DWIConvert/HitachiDWIConverter.cxx
+++ b/DWIConvert/HitachiDWIConverter.cxx
@@ -7,9 +7,9 @@
 
 HitachiDWIConverter::HitachiDWIConverter(DWIDICOMConverterBase::DCMTKFileVector &allHeaders,
                       DWIConverter::FileNamesContainer &inputFileNames,
-                      const bool useBMatrixGradientDirections,
-                      const bool FSLFileFormatHorizontalBy3Rows) : DWIDICOMConverterBase(allHeaders,inputFileNames,
-                                                                        useBMatrixGradientDirections, FSLFileFormatHorizontalBy3Rows)
+                      const bool useBMatrixGradientDirections
+                      ) : DWIDICOMConverterBase(allHeaders,inputFileNames,
+                                                useBMatrixGradientDirections)
 {
     }
 

--- a/DWIConvert/HitachiDWIConverter.h
+++ b/DWIConvert/HitachiDWIConverter.h
@@ -28,8 +28,8 @@ class HitachiDWIConverter : public DWIDICOMConverterBase
 public:
   HitachiDWIConverter(DCMTKFileVector &allHeaders,
                       DWIConverter::FileNamesContainer &inputFileNames,
-                      const bool useBMatrixGradientDirections,
-                      const bool FSLFileFormatHorizontalBy3Rows);
+                      const bool useBMatrixGradientDirections
+                      );
 
   ~HitachiDWIConverter() override;
   /* load dicom directory -- no postprocessing necessary after letting

--- a/DWIConvert/NRRDDWIConverter.cxx
+++ b/DWIConvert/NRRDDWIConverter.cxx
@@ -5,9 +5,8 @@
 #include "NRRDDWIConverter.h"
 
 
-NRRDDWIConverter::NRRDDWIConverter( const DWIConverter::FileNamesContainer & inputFileNames,
-  const bool FSLFileFormatHorizontalBy3Rows)
-  : DWIConverter( inputFileNames, FSLFileFormatHorizontalBy3Rows )
+NRRDDWIConverter::NRRDDWIConverter( const DWIConverter::FileNamesContainer & inputFileNames)
+  : DWIConverter( inputFileNames )
 {
 }
 

--- a/DWIConvert/NRRDDWIConverter.h
+++ b/DWIConvert/NRRDDWIConverter.h
@@ -15,7 +15,7 @@ public:
 
 
 
-  NRRDDWIConverter( const DWIConverter::FileNamesContainer & inputFileNames, const bool FSLFileFormatHorizontalBy3Rows );
+  NRRDDWIConverter( const DWIConverter::FileNamesContainer & inputFileNames );
 
   ~NRRDDWIConverter() override {}
 

--- a/DWIConvert/PhilipsDWIConverter.cxx
+++ b/DWIConvert/PhilipsDWIConverter.cxx
@@ -5,10 +5,10 @@
 
 PhilipsDWIConverter::PhilipsDWIConverter(DWIDICOMConverterBase::DCMTKFileVector &allHeaders,
                                          DWIConverter::FileNamesContainer &inputFileNames,
-                                         const bool useBMatrixGradientDirections,
-                                         const bool FSLFileFormatHorizontalBy3Rows)
+                                         const bool useBMatrixGradientDirections
+                                        )
                                         : DWIDICOMConverterBase(allHeaders,inputFileNames,
-                                          useBMatrixGradientDirections, FSLFileFormatHorizontalBy3Rows)
+                                          useBMatrixGradientDirections)
 {
 }
 

--- a/DWIConvert/PhilipsDWIConverter.h
+++ b/DWIConvert/PhilipsDWIConverter.h
@@ -28,8 +28,8 @@ class PhilipsDWIConverter : public DWIDICOMConverterBase
 public:
   PhilipsDWIConverter(DWIDICOMConverterBase::DCMTKFileVector &allHeaders,
                       DWIConverter::FileNamesContainer &inputFileNames,
-                      const bool useBMatrixGradientDirections,
-                      const bool FSLFileFormatHorizontalBy3Rows) ;
+                      const bool useBMatrixGradientDirections
+                      ) ;
   ~PhilipsDWIConverter() override;
 
   void LoadDicomDirectory() override;

--- a/DWIConvert/SiemensDWIConverter.cxx
+++ b/DWIConvert/SiemensDWIConverter.cxx
@@ -6,11 +6,8 @@
 SiemensDWIConverter::SiemensDWIConverter (DWIDICOMConverterBase::DCMTKFileVector &allHeaders,
                                           DWIConverter::FileNamesContainer &inputFileNames,
                                           const bool useBMatrixGradientDirections,
-                                          const bool FSLFileFormatHorizontalBy3Rows,
                                           const double smallGradientThreshold) :
-      DWIDICOMConverterBase(allHeaders,inputFileNames,
-                            useBMatrixGradientDirections,
-                            FSLFileFormatHorizontalBy3Rows),
+      DWIDICOMConverterBase(allHeaders,inputFileNames, useBMatrixGradientDirections),
       m_SmallGradientThreshold(smallGradientThreshold),
       m_MMosaic(0),
       m_NMosaic(0),

--- a/DWIConvert/SiemensDWIConverter.h
+++ b/DWIConvert/SiemensDWIConverter.h
@@ -29,7 +29,6 @@ public:
   SiemensDWIConverter(DCMTKFileVector &allHeaders,
                       DWIConverter::FileNamesContainer &inputFileNames,
                       const bool useBMatrixGradientDirections,
-                      const bool FSLFileFormatHorizontalBy3Rows,
                       const double smallGradientThreshold) ;
   ~SiemensDWIConverter() override;
 

--- a/DWIConvert/TestSuite/CMakeLists.txt
+++ b/DWIConvert/TestSuite/CMakeLists.txt
@@ -312,7 +312,7 @@ ExternalData_Add_Test( ${PROJECT_NAME}FetchData NAME DWIConvertPhilipsAchieva2BM
   -D TEST_COMPARE_PROGRAM=$<TARGET_FILE:DWICompare>
   -D TEST_BASELINE=DATA{${DWIBASELINE_DIR}/PhilipsAchieva2.nrrd}
   -D TEST_INPUT=${DWIConvert_BINARY_DIR}/PhilipsAchieva2
-  -D TEST_TEMP_OUTPUT=${TstOutput}/PhilipsAchieva2Test.nrrd
+  -D TEST_TEMP_OUTPUT=${TstOutput}/DWIConvertPhilipsAchieva2BMatrixTest.nrrd
   -D TEST_PROGRAM_ARGS=--useBMatrixGradientDirections
   -P ${CMAKE_CURRENT_LIST_DIR}/DicomToNrrdDWICompareTest.cmake
   )

--- a/DWIConvert/TestSuite/FSLTextFileCompare.cxx
+++ b/DWIConvert/TestSuite/FSLTextFileCompare.cxx
@@ -34,14 +34,14 @@ int main(int argc, char *argv[])
 
   unsigned int                      bVecCount1;
   DWIMetaDataDictionaryValidator::GradientTableType bvecs1;
-  if( ReadBVecs(bvecs1, bVecCount1, bvecfile1, false) != EXIT_SUCCESS )
+  if( ReadBVecs(bvecs1, bVecCount1, bvecfile1) != EXIT_SUCCESS )
     {
     std::cerr << "Can't read " << bvecfile1 << std::endl;
     return EXIT_FAILURE;
     }
   unsigned int                      bVecCount2;
   DWIMetaDataDictionaryValidator::GradientTableType bvecs2;
-  if( ReadBVecs(bvecs2, bVecCount2, bvecfile2, false) != EXIT_SUCCESS )
+  if( ReadBVecs(bvecs2, bVecCount2, bvecfile2) != EXIT_SUCCESS )
     {
     std::cerr << "Can't read " << bvecfile2 << std::endl;
     return EXIT_FAILURE;


### PR DESCRIPTION
Prefer to inspect the BVec files directly rather than use a flag from
the function call.

Test were failing after 147d810d50645f63555e497443e053dfc89c38b7
and the NRRD files were quite different when round-trip conversion from
DICOM->FSL->NRRD or NRRD->FSL->NRRD conversions were requested.

Rather than depend on user input to select the format of the
BVec file, use introspection to determine the organization of
the files.
