### PR TITLE
COMP: Allow cmake generation on OSX without XCode

### DIFF
--- a/CMake/BlockSetCMakeOSXVariables.cmake
+++ b/CMake/BlockSetCMakeOSXVariables.cmake
@@ -99,7 +99,7 @@ if(APPLE)
     string(REGEX MATCH "MacOSX([0-9]+\\.[0-9]+)\\.sdk" _match "${CMAKE_OSX_SYSROOT}")
     set(SDK_VERSION "${CMAKE_MATCH_1}")
     ## Min version supported is 10.9
-    if( "${SDK_VERSION}" VERSION_LESS "10.9" )
+    if( "${SDK_VERSION}" VERSION_LESS "10.9" AND CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
       # add to cache to allow interactive editing after fatal error
       set(CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE PATH "Deployment target needs to be explicitly set." FORCE)
       message(FATAL_ERROR


### PR DESCRIPTION
The CMake system attempts to glean the local osx version by looking
through xcode sdks which does not work if there is no XCode on the
machine. This commit allows cmake generation to continue by explicitly
setting the CMAKE_OSX_DEPLOYMENT_TARGET variable even if cmake is unable
to determine the SDK_VERSION automatically

