### PR TITLE
BUG: don't normalize vectors for GE data

### DIFF
--- a/DWIConvert/GEDWIConverter.cxx
+++ b/DWIConvert/GEDWIConverter.cxx
@@ -124,7 +124,6 @@ void GEDWIConverter::ExtractDWIData()
           }
         else
           {
-          vect3d.normalize();
           this->m_DiffusionVectors.push_back(vect3d);
           }
 


### PR DESCRIPTION
Multi-shell data from (**older**) GE scanners appears to be stored with varying b values recorded
using the same length-based encoding scheme used in NA-MIC DWI NRRD. It is very likely
that GE data was the inspiration for the encoding scheme, considering that Dicom2Nrrd
was developed against GE data.

Normalization was commented out in the code, back to at least 2010 before DWIConvert was split -- which presumably was done to make conversion work correctly:

https://github.com/Slicer/Slicer/blob/cd49baf935197b9270dfe92b8a7b23b0229102e6/Applications/CLI/DicomToNrrdConverter/DicomToNrrdConverter.cxx#L869 (Slicer SVN r13901)

but the comment was inadvertently removed here in the process of a different bug fix:

https://github.com/BRAINSia/BRAINSTools/commit/e1ab2593cd107071a3a8e66b6a2c24f0e2190ea1#diff-94a48c40a695ea6bd7bcc7441e3ff779R127