### PR TITLE
ENH: set Siemens MeasurementFrame

### DIFF
--- a/DWIConvert/SiemensDWIConverter.cxx
+++ b/DWIConvert/SiemensDWIConverter.cxx
@@ -103,7 +103,13 @@ void SiemensDWIConverter::LoadDicomDirectory()
 {
   this->DWIDICOMConverterBase::LoadDicomDirectory();
   std::string ImageType;
-  this->m_MeasurementFrame.SetIdentity();
+
+  // Siemens scanners store gradients relative to the magnet, so we need to set
+  // the measurement frame to provide the rotation into patient space.
+  // See discussion and test data on the dcm2nii wiki:
+  //   https://www.nitrc.org/plugins/mwiki/index.php/dcm2nii:MainPage#Diffusion_Tensor_Imaging
+  this->m_MeasurementFrame = this->m_Volume->GetDirection();
+
   this->m_Headers[0]->GetElementCS(0x0008, 0x0008, ImageType);
   if(StringContains(ImageType,"MOSAIC"))
   {


### PR DESCRIPTION
Per this page:

https://www.nitrc.org/plugins/mwiki/index.php/dcm2nii:MainPage#Diffusion_Tensor_Imaging

`Siemens and Philips report gradient direction with respect to the scanner bore.`

DWIConvert does already account for this in the Philips converter, so I believe we should do so for Siemens as well.

I tested this change with one of the large rotation test datasets linked there,
specifically, the 'dtitest_Siemens_GSU_GT/ep2d_DTI_30_ax_roll_4' dataset. 

Example DTI image in Slicer, with direction-coded colors (left: current, right: with this patch):

![image](https://user-images.githubusercontent.com/327706/44880039-49901600-ac79-11e8-9657-a2783641230d.png)