### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if]

### DIFF
--- a/ARCHIVE/BRAINSSurfaceTools/BRAINSSurfaceRegister/TestSuite/QuadEdgeMeshSimilarityTest.cxx
+++ b/ARCHIVE/BRAINSSurfaceTools/BRAINSSurfaceRegister/TestSuite/QuadEdgeMeshSimilarityTest.cxx
@@ -76,7 +76,7 @@ int main( int argc, char * argv [] )
   similarityCalculator->Compute();
 
   double diceTest = similarityCalculator->GetDice();
-  double diceExp = atof(argv[4]);
+  double diceExp = std::stod(argv[4]);
   double tolerance = 1.0e-4;
 
   if( fabs(diceTest - diceExp) > tolerance )

--- a/ARCHIVE/BRAINSTalairach/vtkTalairachConversion.cxx
+++ b/ARCHIVE/BRAINSTalairach/vtkTalairachConversion.cxx
@@ -279,7 +279,7 @@ void vtkTalairachConversion::ProcessBOX(bool _left)
       }
     else
       {
-      boxDistancePercentage = atof( distance.c_str() );
+      boxDistancePercentage = std::stod( distance.c_str() );
       }
 
     /* Base the Distance on the High Resolution Grid */
@@ -359,7 +359,7 @@ void vtkTalairachConversion::ProcessBOX(bool _left)
       }
     else
       {
-      boxDistancePercentage = atof( distance.c_str() );
+      boxDistancePercentage = std::stod( distance.c_str() );
       }
 
     /* Base the Distance on the High Resolution Grid */
@@ -413,7 +413,7 @@ void vtkTalairachConversion::ProcessBOX(bool _left)
         }
       else
         {
-        boxDistancePercentage = atof( distance.c_str() );
+        boxDistancePercentage = std::stod( distance.c_str() );
         }
 
       /* Base the Distance on the High Resolution Grid */
@@ -447,7 +447,7 @@ void vtkTalairachConversion::ProcessBOX(bool _left)
         }
       else
         {
-        boxDistancePercentage = atof( distance.c_str() );
+        boxDistancePercentage = std::stod( distance.c_str() );
         }
 
       /* Base the Distance on the High Resolution Grid */
@@ -485,7 +485,7 @@ void vtkTalairachConversion::ProcessBOX(bool _left)
         }
       else
         {
-        boxDistancePercentage = atof( distance.c_str() );
+        boxDistancePercentage = std::stod( distance.c_str() );
         }
 
       /* Base the Distance on the High Resolution Grid */
@@ -525,7 +525,7 @@ void vtkTalairachConversion::ProcessBOX(bool _left)
         }
       else
         {
-        boxDistancePercentage = atof( distance.c_str() );
+        boxDistancePercentage = std::stod( distance.c_str() );
         }
 
       /* Base the Distance on the High Resolution Grid */
@@ -550,7 +550,7 @@ void vtkTalairachConversion::ProcessBOX(bool _left)
     std::string zEnd = tokens[4].substr(0, pos);
     // std::cout << "zEnd: " << zEnd << std::endl;
 
-    zGridEndIndex = TALAIRACH_Z_POINTS - static_cast<int>( floor( atof( zEnd.c_str() ) ) );
+    zGridEndIndex = TALAIRACH_Z_POINTS - static_cast<int>( floor( std::stod( zEnd.c_str() ) ) );
 
     if( pos > 0 && pos < 3 )
       {
@@ -567,7 +567,7 @@ void vtkTalairachConversion::ProcessBOX(bool _left)
       }
     else
       {
-      boxDistancePercentage = atof( distance.c_str() );
+      boxDistancePercentage = std::stod( distance.c_str() );
       }
 
     // std::cout << "zEndIndex: " << zGridEndIndex << std::endl;
@@ -586,7 +586,7 @@ void vtkTalairachConversion::ProcessBOX(bool _left)
     pos = tokens[5].find(".");
     std::string zStart = tokens[5].substr(0, pos);
     // std::cout << "zStart: " << zStart << std::endl;
-    zGridStartIndex = TALAIRACH_Z_POINTS - static_cast<int>( floor( atof( zStart.c_str() ) ) );
+    zGridStartIndex = TALAIRACH_Z_POINTS - static_cast<int>( floor( std::stod( zStart.c_str() ) ) );
 
     // std::cout << "zGridStartIndex: " << zGridStartIndex << std::endl;
 
@@ -605,7 +605,7 @@ void vtkTalairachConversion::ProcessBOX(bool _left)
       }
     else
       {
-      boxDistancePercentage = atof( distance.c_str() );
+      boxDistancePercentage = std::stod( distance.c_str() );
       }
 
     // std::cout << "boxDistancePercentage1: " << boxDistancePercentage <<

--- a/BRAINSCommonLib/Slicer3LandmarkIO.cxx
+++ b/BRAINSCommonLib/Slicer3LandmarkIO.cxx
@@ -42,7 +42,7 @@ LandmarkWeightMapType ReadLandmarkWeights( const std::string & weightFilename )
     {
     const size_t      firstComma = line.find(',', 0);
     const std::string landmark = line.substr( 0, firstComma );
-    const float       weight   = atof( (line.substr( firstComma + 1, line.length() - 1 ) ).c_str() );
+    const float       weight   = std::stod( (line.substr( firstComma + 1, line.length() - 1 ) ).c_str() );
     landmarkWeightMap[landmark] = weight;
     }
 
@@ -177,7 +177,7 @@ ReadSlicer3toITKLmkOldSlicer( const std::string & landmarksFilename )
       for( unsigned int i = 0; i < 3; ++i )
       {
         const size_t pos2 = line.find( ',', pos1 + 1 );
-        labelPos[i] = atof( line.substr(pos1 + 1, pos2 - pos1 - 1 ).c_str() );
+        labelPos[i] = std::stod( line.substr(pos1 + 1, pos2 - pos1 - 1 ).c_str() );
         if( i < 2 )  // Negate first two components for RAS -> LPS
         {
           labelPos[i] *= -1;

--- a/BRAINSCommonLib/Slicer3LandmarkWeightIO.cxx
+++ b/BRAINSCommonLib/Slicer3LandmarkWeightIO.cxx
@@ -97,7 +97,7 @@ ReadSlicer3toITKLmkWts( const std::string & landmarksWeightFilename )
       const std::string name = line.substr( 0, pos1 );
       double            weight;
       const size_t      pos2 = line.find( ' ', pos1 + 1 );
-      weight = atof( line.substr(pos1 + 1, pos2 - pos1 - 1 ).c_str() );
+      weight = std::stod( line.substr(pos1 + 1, pos2 - pos1 - 1 ).c_str() );
 
       landmarks[name] = weight;
       }

--- a/BRAINSCommonLib/itkBRAINSToolsTestMain.h
+++ b/BRAINSCommonLib/itkBRAINSToolsTestMain.h
@@ -167,7 +167,7 @@ int main(int ac, char* av[] )
         }
       else if( ac > 2 && strcmp(av[1], "--compareIntensityTolerance") == 0 )
         {
-        intensityTolerance = atof(av[2]);
+        intensityTolerance = std::stod(av[2]);
         av += 2;
         ac -= 2;
         }

--- a/BRAINSCommonLib/itkV3TestKernel/include/itkTestDriverInclude.h
+++ b/BRAINSCommonLib/itkV3TestKernel/include/itkTestDriverInclude.h
@@ -243,7 +243,7 @@ int ProcessArguments(int *ac, ArgumentStringType *av, ProcessedOutputType * proc
         usage();
         return 1;
         }
-      regressionTestParameters.intensityTolerance = atof( (*av)[i + 1]);
+      regressionTestParameters.intensityTolerance = std::stod( (*av)[i + 1]);
       (*av) += 2;
       *ac -= 2;
       }

--- a/BRAINSConstellationDetector/src/BRAINSLmkTransform.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSLmkTransform.cxx
@@ -279,7 +279,7 @@ LoadLandmarks( std::string filename )
       for( i = 0; i < 3; ++i )
         {
         pos2 = line.find(',', pos1 + 1);
-        labelPos[i] = atof( line.substr( pos1 + 1, pos2 - pos1 - 1 ).c_str() );
+        labelPos[i] = std::stod( line.substr( pos1 + 1, pos2 - pos1 - 1 ).c_str() );
         if( i < 2 )
           {
           labelPos[i] *= -1; // RAS -> LPS

--- a/BRAINSConstellationDetector/src/landmarkIO.cxx
+++ b/BRAINSConstellationDetector/src/landmarkIO.cxx
@@ -724,7 +724,7 @@ loadLLSModel(std::string llsModelFilename,
         while( pos2 < line.size() )
           {
           llsMeans[name].push_back(
-            atof( line.substr(pos1, pos2 - pos1).c_str() ) );
+            std::stod( line.substr(pos1, pos2 - pos1).c_str() ) );
           ++i;
           pos1 = pos2 + 1;
           pos2 = line.find(' ', pos1 + 1);
@@ -743,7 +743,7 @@ loadLLSModel(std::string llsModelFilename,
         }
       else
         {
-        searchRadii[name] = atof( line.c_str() );
+        searchRadii[name] = std::stod( line.c_str() );
         }
 
       // read in the number of linear model coefficients
@@ -773,7 +773,7 @@ loadLLSModel(std::string llsModelFilename,
           while( pos2 < line.size() )
             {
             coefficients(j, i++) =
-              atof( line.substr(pos1, pos2 - pos1).c_str() );
+              std::stod( line.substr(pos1, pos2 - pos1).c_str() );
             pos1 = pos2 + 1;
             pos2 = line.find(' ', pos1 + 1);
             }

--- a/BRAINSConstellationDetector/src/landmarksDataSet.h
+++ b/BRAINSConstellationDetector/src/landmarksDataSet.h
@@ -96,7 +96,7 @@ public:
           throw landmarksDataSet::shortLine;
           }
         std::string datum = CSVs.substr( posA + 1, posB - ( posA + 1 ) );
-        tempPoint[j] = atof( datum.c_str() );
+        tempPoint[j] = std::stod( datum.c_str() );
         posA = posB;
         }
       // NOTE:  RAS is was slicer requires, but ITK is internall LPS, so we need

--- a/BRAINSCut/BRAINSFeatureCreators/HessianToObjectness/HessianToObjectness.cxx
+++ b/BRAINSCut/BRAINSFeatureCreators/HessianToObjectness/HessianToObjectness.cxx
@@ -27,27 +27,27 @@ int main( int argc, char* argv[] )
   bool bright = true;
   if( argc > 3 )
   {
-    sigmaMinimum = atof( argv[3] );
+    sigmaMinimum = std::stod( argv[3] );
   }
   if( argc > 4 )
   {
-    sigmaMaximum = atof( argv[4] );
+    sigmaMaximum = std::stod( argv[4] );
   }
   if( argc > 5 )
   {
-    numberOfSigmaSteps = atof( argv[5] );
+    numberOfSigmaSteps = std::stod( argv[5] );
   }
   if( argc > 6 )
   {
-    alpha = atof( argv[6] );
+    alpha = std::stod( argv[6] );
   }
   if( argc > 7 )
   {
-    beta = atof(argv[7] );
+    beta = std::stod(argv[7] );
   }
   if( argc > 8 )
   {
-    gamma = atof( argv[8] );
+    gamma = std::stod( argv[8] );
   }
   if( argc > 9 )
   {

--- a/DWIConvert/SiemensDWIConverter.cxx
+++ b/DWIConvert/SiemensDWIConverter.cxx
@@ -615,7 +615,7 @@ unsigned int SiemensDWIConverter::ExtractSiemensDiffusionInformation(const std::
       return 0;
     }
     const std::string valueString = infoAsString.substr( offset + 16, itemLength );
-    const double componentValue =  atof(valueString.c_str() );
+    const double componentValue =  std::stod(valueString.c_str() );
     valueArray.push_back( componentValue );
     offset += 16 + strideSize;
   }

--- a/DWIConvert/TestSuite/BFileCompareTool.cpp
+++ b/DWIConvert/TestSuite/BFileCompareTool.cpp
@@ -54,7 +54,7 @@ DataVector convertBufferIntoVector(char* buffer){
       char *dataBuf = new char[dataOffset + 1];
       memcpy(dataBuf, dataBeginning, dataOffset);
       dataBuf[dataOffset] = '\0';
-      double dataValue = atof(dataBuf);
+      double dataValue = std::stod(dataBuf);
       delete[] dataBuf;
       lineData.push_back(dataValue);
       p = nextNoneSpacePointer(p);
@@ -120,8 +120,7 @@ int main(int argc, char * argv[])
     return USAGE_FAILURE_CODE;
     }
   const int linesToCompare = std::stoi(argv[3]);
-  const double tolerance = atof(argv[4]);
-
+  const double tolerance = std::stod(argv[4]);
 
   //Open files to read data into vector
   char* buffer1 = nullptr;

--- a/DWIConvert/TestSuite/checkTagValueInHeader.cxx
+++ b/DWIConvert/TestSuite/checkTagValueInHeader.cxx
@@ -118,8 +118,8 @@ int main(int argc, char * argv[])
 
       //compare the value
       if (numType){
-        double verifyingNum = atof(verifyingValue.c_str());
-        double tagNum = atof(valueStr.c_str());
+        double verifyingNum = std::stod(verifyingValue.c_str());
+        double tagNum = std::stod(valueStr.c_str());
         if (fabs(verifyingNum-tagNum) <= 1e-3)
         {
           result = 0;

--- a/GTRACT/Cmdline/gtractAverageBvalues.cxx
+++ b/GTRACT/Cmdline/gtractAverageBvalues.cxx
@@ -319,13 +319,13 @@ bool areDirectionsEqual(std::string direction1, std::string direction2, double d
   strncpy( tmpDir1, direction1.c_str(), MAXSTR - 1 );
   strncpy( tmpDir2, direction2.c_str(), MAXSTR - 1 );
 
-  const double x1 = atof( strtok(tmpDir1, " ") );
-  const double y1 = atof( strtok(nullptr, " ") );
-  const double z1 = atof( strtok(nullptr, " ") );
+  const double x1 = std::stod( strtok(tmpDir1, " ") );
+  const double y1 = std::stod( strtok(nullptr, " ") );
+  const double z1 = std::stod( strtok(nullptr, " ") );
 
-  const double x2 = atof( strtok(tmpDir2, " ") );
-  const double y2 = atof( strtok(nullptr, " ") );
-  const double z2 = atof( strtok(nullptr, " ") );
+  const double x2 = std::stod( strtok(tmpDir2, " ") );
+  const double y2 = std::stod( strtok(nullptr, " ") );
+  const double z2 = std::stod( strtok(nullptr, " ") );
 
   if( averageB0only )
     {

--- a/GTRACT/Cmdline/gtractTensor.cxx
+++ b/GTRACT/Cmdline/gtractTensor.cxx
@@ -176,7 +176,7 @@ int main(int argc, char *argv[])
   std::string BValue_keyStr("DWMRI_b-value");
   itk::ExposeMetaData<std::string>(vectorImageReader->GetOutput()->GetMetaDataDictionary(),
                                    BValue_keyStr.c_str(), BValue_str);
-  double BValue = atof( BValue_str.c_str() );
+  double BValue = std::stod( BValue_str.c_str() );
   std::cout << "The BValue was found to be " << BValue_str << std::endl;
 
   std::vector<std::vector<double> > msrFrame;
@@ -284,9 +284,9 @@ int main(int argc, char *argv[])
     char tokTmStr[64];
     strcpy( tokTmStr, NrrdValue.c_str() );
     TVector tmpDir(3);
-    tmpDir[0] = atof( strtok(tokTmStr, " ") );
-    tmpDir[1] = atof( strtok(nullptr, " ") );
-    tmpDir[2] = atof( strtok(nullptr, " ") );
+    tmpDir[0] = std::stod( strtok(tokTmStr, " ") );
+    tmpDir[1] = std::stod( strtok(nullptr, " ") );
+    tmpDir[2] = std::stod( strtok(nullptr, " ") );
     if( applyMeasurementFrame )
       {
       std::cout << "Original Direction: " << tmpDir << std::endl;

--- a/ImageCalculator/ImageGenerate.cxx
+++ b/ImageCalculator/ImageGenerate.cxx
@@ -101,7 +101,7 @@ ProcessArgs(int argc, char * *argv,
         }
       --argc;
       ++argv;
-      value = atof(*argv);
+      value = std::stod(*argv);
       }
     else if( arg == "-d" || arg == "--dim" )
       {

--- a/Utilities/Maintenance/replace_atoi_atof.sh
+++ b/Utilities/Maintenance/replace_atoi_atof.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# \author
+
+
+git grep  -l "\<atoi\> *(" |fgrep "(.cxx|.cpp|.cc|.h|.hxx|.hpp|.txx)" > /tmp/atoi_files.list
+for ff in $(cat /tmp/atoi_files.list); do
+  sed -i "" 's/ atoi *(/ std::stoi(/g' $ff
+done
+
+git grep  -l "\<atof\> *(" |fgrep "(.cxx|.cpp|.cc|.h|.hxx|.hpp|.txx)" > /tmp/atoi_files.list
+for ff in $(cat /tmp/atof_files.list); do
+  sed -i "" 's/ atof *(/ std::stod(/g' $ff
+done
+
+echo > /tmp/COMMIT_MESSAGE_atoi <<EOF
+STYLE: Prefer error checked std::sto[id] over ato[if]
+
+The ato[if] functions do not provide mechanisms for distinguishing between
+'0' and the error condion where the input can not be converted.
+
+std::sto[id] provides exception handling and detects when an invalid
+string attempts to be converted to an [integer|double].
+
+ato[if]()
+   Con: No error handling.
+   Con: Handle neither hexadecimal nor octal.
+
+The use of ato[if] in code can cause it to be subtly broken.
+ato[if] makes two very big assumptions indeed:
+   The string represents an integer/floating point value.
+   The integer can fit into an int.
+EOF
+
+echo "Reference commit messsage in /tmp/COMMIT_MESSAGE_atoi"


### PR DESCRIPTION
The ato[if] functions do not provide mechanisms for distinguishing between
'0' and the error condition where the input can not be converted.

std::sto[id] provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

ato[if]()
   Con: No error handling.
   Con: Handle neither hexadecimal nor octal.

The use of ato[if] in code can cause it to be subtly broken.
ato[if] makes two very big assumptions indeed:
   The string represents an integer/floating point value.
   The integer can fit into an int.

See the [CONTRIBUTING](CONTRIBUTING.md) guide. Specifically: