### PR TITLE
BUG: Two landmark input files were ignored. Fixed

### DIFF
--- a/BRAINSConstellationDetector/landmarkStatistics/GenerateAverageLmkFile.cxx
+++ b/BRAINSConstellationDetector/landmarkStatistics/GenerateAverageLmkFile.cxx
@@ -46,7 +46,7 @@ int main( int argc, char * argv[] )
   PARSE_ARGS;
 
   std::vector<std::string> inputFileNames;
-  if( inputLandmarkFiles.size() > 2 )
+  if( inputLandmarkFiles.size() >= 2 )
     {
     inputFileNames = inputLandmarkFiles;
     }


### PR DESCRIPTION
Regarding #442  
Two landmark input files were ignored. 
Typo in the condition has been fixed to include two input landmark files. 

