### PR TITLE
Fix average images boarders

### DIFF
--- a/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
+++ b/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
@@ -43,6 +43,8 @@
 
 #include "itkBRAINSROIAutoImageFilter.h"
 
+// #include "itkIO.h"
+
 itk::Transform<double, 3, 3>::Pointer MakeRigidIdentity(void)
 {
   // Also append identity matrix for each image
@@ -333,10 +335,11 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
   this->m_RegisteredIntraSubjectImagesList.clear(); //Ensure that pushing onto clean list
   // Use resampleInPlace to transform all images to the physical space of the first key image.
   // Then, use linear interpolation to resample all within modality images to a same voxel space.
-  this->m_RegisteredIntraSubjectImagesList =
-    ResampleInPlaceImageList("Linear",
-                             this->m_IntraSubjectOriginalImageList,
-                             this->m_IntraSubjectTransforms);
+  ByteImagePointerType FOV =
+      ResampleToFirstImageList("Linear",
+                               this->m_IntraSubjectOriginalImageList,
+                               this->m_IntraSubjectTransforms,
+                               this->m_RegisteredIntraSubjectImagesList);
 
   muLogMacro(<< "Average co-registered Intra subject images" << std::endl);
   this->m_ModalityAveragedOfIntraSubjectImages.clear(); //Ensure that pushing onto clean list

--- a/BRAINSABC/brainseg/BRAINSABCUtilities.cxx
+++ b/BRAINSABC/brainseg/BRAINSABCUtilities.cxx
@@ -22,6 +22,10 @@
  */
 #include "BRAINSABCUtilities.hxx"
 #include "LLSBiasCorrector.h"
+#include "itkMinimumMaximumImageCalculator.h"
+#include "itkBinaryFillholeImageFilter.h"
+#include "itkOtsuThresholdImageFilter.h"
+#include "itkImageMaskSpatialObject.h"
 
 template std::vector<FloatImageType::Pointer> DuplicateImageList<FloatImageType>(
   const std::vector<FloatImageType::Pointer> & );
@@ -66,22 +70,39 @@ ResampleImageListToFirstKeyImage(const std::string & resamplerInterpolatorType,
   return outputImageMap;
 }
 
-MapOfFloatImageVectors
-ResampleInPlaceImageList(const std::string & resamplerInterpolatorType,
-                         const MapOfFloatImageVectors & inputImageMap,
-                         MapOfTransformLists & intraSubjectTransforms)
+ByteImageType::Pointer intersectFOV(const MapOfMaskImageVectors & FOVMap)
 {
-  muLogMacro(<< "ResampleInPlaceImageList..." << std::endl);
+  for(auto inputImageMapIter = FOVMap.begin();
+      inputImageMapIter != FOVMap.end(); ++inputImageMapIter)
+  {
+    auto currModalIter = inputImageMapIter->second.begin();
+    while (currModalIter != inputImageMapIter->second.end())
+    {
+
+    }
+  }
+  return nullptr;
+}
+
+//ByteImagePointer globalFeildOfView::Pointer = intersectFOV(intraSubjectRegisteredFOVMap);
+
+
+ByteImageType::Pointer
+ResampleToFirstImageList(const std::string &resamplerInterpolatorType,
+                         const MapOfFloatImageVectors &inputImageMap,
+                         const MapOfTransformLists &intraSubjectTransforms,
+                         MapOfFloatImageVectors &outputImageMap)
+{
+  outputImageMap.clear();
+  muLogMacro(<< "ResampleToFirstImageList..." << std::endl);
   /*
    * This function, first, transforms all inputImageMap to the space of the first image of the map
-   * using rigid transforms (intraSubjectTransforms) and Resampling InPlace interoplation.
+   * using rigid transforms (intraSubjectTransforms) and Resampling InPlace interpolation.
    * Then, it resamples all images within one modality to the voxel lattice of the fist image of that modality channel
    * using resamplerInterpolatorType and Identity transform.
    */
-
-  MapOfFloatImageVectors resampleInPlaceImageMap;
-  MapOfFloatImageVectors outputImageMap;
-
+  MapOfFloatImageVectors resampledInPlaceMap;
+  MapOfFloatImageVectors resampledToFirstImageMap;
   PrintMapOfImageVectors(inputImageMap);
 
   // ResampleInPlace all images to the physical space of the first image
@@ -91,10 +112,10 @@ ResampleInPlaceImageList(const std::string & resamplerInterpolatorType,
     {
     auto currModalIter = inputImageMapIter->second.begin();
     unsigned int i(0);
-    auto xfrmIt = intraSubjectTransforms[inputImageMapIter->first].begin();
+    auto xfrmIt = intraSubjectTransforms.at(inputImageMapIter->first).begin();
     while( currModalIter != inputImageMapIter->second.end() )
       {
-      muLogMacro(<< "ResamplingInPlace input image " << inputImageMapIter->first << " #" << i
+      muLogMacro(<< "Resampling input image " << inputImageMapIter->first << " #" << i
                  << " to the physical space of the first image." << std::endl);
       using ResampleIPFilterType = itk::ResampleInPlaceImageFilter<FloatImageType, FloatImageType>;
       using ResampleIPFilterPointer = ResampleIPFilterType::Pointer;
@@ -116,7 +137,7 @@ ResampleInPlaceImageList(const std::string & resamplerInterpolatorType,
       FloatImageType::Pointer tmp = resampleIPFilter->GetOutput();
 
       // Add the image
-      resampleInPlaceImageMap[inputImageMapIter->first].push_back(tmp);
+      resampledInPlaceMap[inputImageMapIter->first].push_back(tmp);
       ++currModalIter;
       ++xfrmIt;
       ++i;
@@ -125,73 +146,134 @@ ResampleInPlaceImageList(const std::string & resamplerInterpolatorType,
 
   // Resample each intra subject image to the first image of its modality
   //
-  muLogMacro(<< "Resampling each intra subject image to the first image of its modality using "
+  muLogMacro(<< "Resampling each intra-subject image to the first image of the primary modality using "
              << resamplerInterpolatorType << " interpolation." << std::endl);
-  const FloatImageType::PixelType outsideFOVCode = vnl_huge_val( static_cast<FloatImageType::PixelType>( 1.0f ) );
+  // Set the outsideFOV value to 100x the max floating point value.  This allows for some numerical computations to
+  // occur in the resampling, but also allows identifcation of very large values.
+  // constexpr FloatImageType::PixelType outsideFOVCode = std::numeric_limits<FloatImageType::PixelType>::max()/100.0;
 
-  for(auto & elem : resampleInPlaceImageMap)
+  // Use the first image of the vector from the ordered modality preference as the key image for all others.
+  FloatImageType::Pointer allModalityKeySubjectImage = resampledInPlaceMap.cbegin()->second.cbegin()->GetPointer();
+  ByteImageType::Pointer intraSubjectFOVIntersectionMask = ByteImageType::New();
+  intraSubjectFOVIntersectionMask->CopyInformation( allModalityKeySubjectImage.GetPointer() );
+  intraSubjectFOVIntersectionMask->SetRegions( allModalityKeySubjectImage.GetPointer()->GetLargestPossibleRegion() );
+  intraSubjectFOVIntersectionMask->Allocate();
+  intraSubjectFOVIntersectionMask->FillBuffer(1);//Initialize so that entire FOV is included.
+
+
+  for(auto & modalityMapEntry : resampledInPlaceMap)
     {
-    auto currModalIter = elem.second.begin();
-    FloatImageType::Pointer currModalityKeySubjectImage = (*currModalIter).GetPointer(); // the first image of current modality
-
-    while( currModalIter != elem.second.end() )
+    auto currModalIter = modalityMapEntry.second.begin();
+    while( currModalIter != modalityMapEntry.second.end() )
       {
-      if( (*currModalIter).GetPointer() == currModalityKeySubjectImage.GetPointer() ) // if the current intra subject image
-          // is the first image in current modality list
-        {
-        outputImageMap[elem.first].push_back( (*currModalIter).GetPointer() );
-        }
-      else // resample the current intra subject image to the first image of the current modality
-        {
-        FloatImageType::Pointer tmp =
+        using MinMaxType = itk::MinimumMaximumImageCalculator<FloatImageType >;
+        MinMaxType::Pointer minmaxcalc = MinMaxType::New();
+        minmaxcalc->SetImage((*currModalIter).GetPointer());
+        minmaxcalc->ComputeMinimum();
+        minmaxcalc->Compute();
+
+        const FloatImageType::PixelType minValue = minmaxcalc->GetMinimum();
+        constexpr FloatImageType::PixelType min_background_offset_value = 8.00;
+        const FloatImageType::PixelType background_threshold_value = minValue-min_background_offset_value;
+        //Set background offset so background fill is smaller than
+        FloatImageType::Pointer resampledToFirstImage =
           ResampleImageWithIdentityTransform<FloatImageType>( resamplerInterpolatorType,
-                                                             outsideFOVCode,
+                                                              background_threshold_value,
                                                              (*currModalIter).GetPointer(),
-                                                             currModalityKeySubjectImage.GetPointer() );
+                                                             allModalityKeySubjectImage.GetPointer() );
 
-        // Zero the mask region outside FOV and also the intensities with
-        // outside
-        // FOV code
-        using InternalIteratorType = itk::ImageRegionIterator<FloatImageType>;
-        InternalIteratorType    tmpIt( tmp, tmp->GetLargestPossibleRegion() );
+        using OtsuThresholdType = itk::OtsuThresholdImageFilter<FloatImageType, ByteImageType >;
+        OtsuThresholdType::Pointer otsufilter = OtsuThresholdType::New();
+        otsufilter->SetInput(resampledToFirstImage);
+        otsufilter->SetInsideValue(0);
+        otsufilter->SetOutsideValue(1);
+        otsufilter->Update();
 
-        //TODO:  This code below with masking does not make sense.
-        //        intraSubjectFOVIntersectionMask does not seem to do anything.
-        // HACK:  We can probably remove the mask generation from here.
-        // The FOV mask, regions where intensities in all channels do not
-        // match FOV code
-        ByteImageType::Pointer intraSubjectFOVIntersectionMask = ByteImageType::New();
-        intraSubjectFOVIntersectionMask->CopyInformation( currModalityKeySubjectImage.GetPointer() );
-        intraSubjectFOVIntersectionMask->SetRegions( currModalityKeySubjectImage.GetPointer()->GetLargestPossibleRegion() );
-        intraSubjectFOVIntersectionMask->Allocate();
-        intraSubjectFOVIntersectionMask->FillBuffer(1);
+        using BinaryThresholdType = itk::BinaryThresholdImageFilter<FloatImageType ,ByteImageType >;
+        BinaryThresholdType::Pointer bthresh = BinaryThresholdType::New();
+        bthresh->SetInput(resampledToFirstImage);
+        // Use 1/2 the otsu threshold to get expanded background
+        bthresh->SetLowerThreshold(otsufilter->GetThreshold() * 0.5f );
+        bthresh->Update();
 
-        using MaskIteratorType = itk::ImageRegionIterator<ByteImageType>;
+        using MaskType = itk::ImageMaskSpatialObject< FloatImageType::ImageDimension >;
+
+        MaskType::Pointer  spatialObjectMask = MaskType::New();
+        spatialObjectMask->SetImage( bthresh->GetOutput() );
+        spatialObjectMask->Update();
+        const itk::SpatialObject< FloatImageType::ImageDimension >::BoundingBoxType * bb
+               = spatialObjectMask->GetMyBoundingBoxInWorldSpace();
+
+        // Zero the mask region outside FOV and also the intensities with outside FOV code
+        using InternalIteratorType = itk::ImageRegionConstIterator<FloatImageType>;
+        InternalIteratorType    resampledToFirstIt( resampledToFirstImage,
+            resampledToFirstImage->GetLargestPossibleRegion() );
+
+        using MaskIteratorType = itk::ImageRegionIteratorWithIndex<ByteImageType>;
         MaskIteratorType maskIt( intraSubjectFOVIntersectionMask,
                                 intraSubjectFOVIntersectionMask->GetLargestPossibleRegion() );
         maskIt.GoToBegin();
-        tmpIt.GoToBegin();
+        resampledToFirstIt.GoToBegin();
+        // Any value larger that an unsigned 32 bit integer is too large and assumed .
+        // constexpr FloatImageType::PixelType halfoutsideFOVCode = 8388608; // 2^23 The mantissa of a floating point number.
         while( !maskIt.IsAtEnd() )
           {
-          if( tmpIt.Get() == outsideFOVCode )  // Voxel came from outside
-            // the original FOV during
-            // registration, so
-            // invalidate it.
+          using PT = MaskType::PointType;
+          const PT thisPoint = resampledToFirstImage->TransformIndexToPhysicalPoint<float>( maskIt.GetIndex() );
+          if( resampledToFirstIt.Value() <= background_threshold_value ||
+           ( ! bb->IsInside( thisPoint ) ) )  // Voxel came from outside
+            // the original FOV during registration, so invalidate it.
             {
             maskIt.Set(0); // Set it as an invalid voxel in
-            // intraSubjectFOVIntersectionMask
-            tmpIt.Set(0);  // Set image intensity value to zero.
             }
           ++maskIt;
-          ++tmpIt;
+          ++resampledToFirstIt;
           }
-
-        // Add the image
-        outputImageMap[elem.first].push_back(tmp);
-        }
-      ++currModalIter;
+        ++currModalIter;
+        resampledToFirstImageMap[modalityMapEntry.first].push_back(resampledToFirstImage);
       }
     }
 
-  return outputImageMap;
+  //  //Fill holes filter
+  //  using HoleFillType = itk::BinaryFillholeImageFilter<ByteImageType>;
+  //  HoleFillType::Pointer hole_fill_filter = HoleFillType::New();
+  //  hole_fill_filter->SetInput(intraSubjectFOVIntersectionMask);
+  //  hole_fill_filter->FullyConnectedOn();
+  //  hole_fill_filter->SetForegroundValue(1);
+  //  hole_fill_filter->Update();
+  //  ByteImageType::Pointer intraSubjectFOVIntersectionMaskFilled = hole_fill_filter->GetOutput();
+  //  intraSubjectFOVIntersectionMask=nullptr;
+
+  // Now zero out all values not in the FOV mask for all resampled to first images
+  for(auto & modalityToFirstMapEntry : resampledToFirstImageMap)
+  {
+    auto currModalToFirstIter = modalityToFirstMapEntry.second.begin();
+    while( currModalToFirstIter != modalityToFirstMapEntry.second.end() )
+    {
+        // Zero the mask region outside FOV and also the intensities with outside FOV code
+        using InternalIteratorType = itk::ImageRegionIterator<FloatImageType>;
+        InternalIteratorType    resampledToFirstIt( *currModalToFirstIter,
+          (*currModalToFirstIter)->GetLargestPossibleRegion() );
+
+        using MaskIteratorType = itk::ImageRegionConstIterator<ByteImageType>;
+        MaskIteratorType maskIt( intraSubjectFOVIntersectionMask,
+                                 intraSubjectFOVIntersectionMask->GetLargestPossibleRegion() );
+        maskIt.GoToBegin();
+        resampledToFirstIt.GoToBegin();
+        while( !maskIt.IsAtEnd() )
+        {
+          if( maskIt.Value() < 1 )
+          {
+            // Voxel came from outside
+            // the original FOV during registration, so invalidate it.
+            resampledToFirstIt.Set(0);
+          }
+          ++maskIt;
+          ++resampledToFirstIt;
+        }
+        outputImageMap[modalityToFirstMapEntry.first].push_back(*currModalToFirstIter);
+        ++currModalToFirstIter;
+      }
+  }
+  return intraSubjectFOVIntersectionMask;
 }

--- a/BRAINSABC/brainseg/BRAINSABCUtilities.h
+++ b/BRAINSABC/brainseg/BRAINSABCUtilities.h
@@ -128,6 +128,7 @@ public:
 
 using FloatingPrecision = double;
 using ByteImageType = itk::Image<unsigned char, 3>;
+using ByteImagePointerType = ByteImageType::Pointer;
 using FloatImageType = itk::Image<float, 3>;
 using FloatImagePointerType = FloatImageType::Pointer;
 using ShortImageType = itk::Image<signed short int, 3>;
@@ -138,6 +139,9 @@ using ImageByTypeMap = orderedmap<std::string,std::string>;
 
 using FloatImageVector = std::vector<FloatImagePointerType>;
 using MapOfFloatImageVectors = orderedmap<std::string, FloatImageVector>;
+
+using MaskImageVector = std::vector<ByteImagePointerType>;
+using MapOfMaskImageVectors = orderedmap<std::string, MaskImageVector>;
 
 using GenericTransformType = itk::Transform<double, 3, 3>;
 using TransformList = std::vector<GenericTransformType::Pointer>;
@@ -189,10 +193,12 @@ ResampleImageListToFirstKeyImage(const std::string & resamplerInterpolatorType,
  * Then, it resamples all images within one modality to the voxel lattice of the fist image of that modality channel
  * using resamplerInterpolatorType and Identity transform.
  */
-extern MapOfFloatImageVectors
-ResampleInPlaceImageList(const std::string & resamplerInterpolatorType,
-                         const MapOfFloatImageVectors & inputImageMap,
-                         MapOfTransformLists & intraSubjectTransforms);
+extern ByteImageType::Pointer
+ResampleToFirstImageList(const std::string &resamplerInterpolatorType,
+                         const MapOfFloatImageVectors &inputImageMap,
+                         const MapOfTransformLists &intraSubjectTransforms,
+                         MapOfFloatImageVectors &outputImageMap);
+
 
 extern template std::vector<FloatImagePointerType> DuplicateImageList<FloatImageType>(
   const std::vector<FloatImagePointerType> & );

--- a/BRAINSABC/brainseg/EMSegmentationFilter.hxx
+++ b/BRAINSABC/brainseg/EMSegmentationFilter.hxx
@@ -28,7 +28,6 @@
 #include <cstdlib>
 #include <algorithm>
 
-#include "itkAverageImageFilter.h"
 #include "itkSqrtImageFilter.h"
 #include "itkBSplineDownsampleImageFilter.h"
 #include "itkBinaryBallStructuringElement.h"
@@ -2558,7 +2557,7 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
 
   this->CheckInput();
 
-  // FloatingPrecision logLikelihood = vnl_huge_val(1.0);
+  // constexpr FloatingPrecision logLikelihood = std::numeric_limits<FloatingPrecision>::infinity();
   FloatingPrecision logLikelihood = 1.0 / itk::Math::eps;
   FloatingPrecision deltaLogLikelihood = 1.0;
 

--- a/BRAINSCommonLib/StandardizeMaskIntensity.h
+++ b/BRAINSCommonLib/StandardizeMaskIntensity.h
@@ -95,7 +95,7 @@ ResampleImageWithIdentityTransform(const std::string & resamplerInterpolatorType
 }
 
 
-#define MAX_IMAGE_OUTPUT_VALUE 4096
+constexpr signed short MAX_IMAGE_OUTPUT_VALUE=4096;
 
 /* * * * *
  *   StandardizeMaskIntensity trims the upper and lower fractions of the histogram inside the mask

--- a/SuperBuild/External_ANTs.cmake
+++ b/SuperBuild/External_ANTs.cmake
@@ -38,7 +38,7 @@ if(${SUPERBUILD_TOPLEVEL_PROJECT}_USE_QT)
 endif()
 ### --- End Project specific additions
 set(${proj}_REPOSITORY "https://github.com/ANTsX/ANTs.git")
-set(${proj}_GIT_TAG eecaf603e139c91774d8aa92ca4b4e634b6d17cf) # 20190518 Updated ANTs
+set(${proj}_GIT_TAG 4dda1f75867fd066a52d60bca6d4e76323b833f9) # 20190609
 ExternalProject_Add(${proj}
   ${${proj}_EP_ARGS}
   GIT_REPOSITORY ${${proj}_REPOSITORY}

--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -66,7 +66,7 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     # plus the following patch:
     # * Set CMP0067 to ensure try_compile work as expected
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "52cf5b48c113ff9c4100e10bba2bd45f21eeda62" # 20190331
+    "9304628a87128aba312d401bc4e5fe8d82eb3de5" # 20190530
     QUIET
     )
 

--- a/SuperBuild/External_ITKv5.cmake
+++ b/SuperBuild/External_ITKv5.cmake
@@ -40,7 +40,7 @@ if(NOT DEFINED ITK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   #set(${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git
   set(${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY ${git_protocol}://github.com/hjmjohnson/ITK.git)
-  set(${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG 66737ee424063a391ad64bfc1ed8cbd96b10231b ) #20180518 - GenericLabelmapInterpolator
+  set(${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG ad41f2ef29c2ce393104ba1c6ec417f58ed75260 ) #20190608 - ITKv5 post release
 
   set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
 

--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -82,7 +82,7 @@ if(NOT DEFINED SlicerExecutionModel_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "a88a246fe8122bc11e700226643fcd38dbbbc66e" # Add references for SEM descriptors
+    "6d3148ffcfccfa636298bd74dd38577b57491dde" # format outputs
     QUIET
     )
 


### PR DESCRIPTION
The locations where the FOV of multiple images did not perfectly align caused averaging issues at the borders of the images.  This PR attempts to address those issues by creating and clipping to a FOV mask.