### PR TITLE
ENH: Add an input option for input file

### DIFF
--- a/BRAINSConstellationDetector/landmarkStatistics/GenerateAverageLmkFile.cxx
+++ b/BRAINSConstellationDetector/landmarkStatistics/GenerateAverageLmkFile.cxx
@@ -46,16 +46,20 @@ int main( int argc, char * argv[] )
   PARSE_ARGS;
 
   std::vector<std::string> inputFileNames;
-  if( inputLandmarkFiles.size() >= 2 )
+  if( inputLandmarkFiles.size() >= 1 && inputLandmarkListFile != "")
+    {
+    std::cout<<"WARNING: inputLandmarkListFile will be ignored!"<<std::endl;
+    }
+  if( inputLandmarkFiles.size() >= 1 )
     {
     inputFileNames = inputLandmarkFiles;
     }
-  else if ( inputLandmarkFiles.size() == 1 )
+  else if ( inputLandmarkListFile != "" )
     {
     inputFileNames.reserve(1000); //Just reserve a huge memory footprint
-    std::cout << "ASSUMING single file is a list of files." << std::endl;
+    std::cout << "Read a list file: " << inputLandmarkListFile << std::endl;
     std::string oneLine;
-    std::ifstream infile(inputLandmarkFiles[0].c_str());
+    std::ifstream infile(inputLandmarkListFile.c_str());
     while (std::getline(infile, oneLine))
       {
       inputFileNames.push_back(oneLine);

--- a/BRAINSConstellationDetector/landmarkStatistics/GenerateAverageLmkFile.xml
+++ b/BRAINSConstellationDetector/landmarkStatistics/GenerateAverageLmkFile.xml
@@ -21,8 +21,17 @@
       <longflag>inputLandmarkFiles</longflag>
       <label>Input file names</label>
       <channel>input</channel>
-      <description>Input landmark files names (.fcsv or .wts).  If a single file is provided with a ".list" extension, then it is assumed to be a list of filenames one per line. </description>
+      <description>Input landmark files names (.fcsv or .wts).</description>
     </string-vector>
+
+    <file>
+      <name>inputLandmarkListFile</name>
+      <longflag>inputLandmarkListFile</longflag>
+      <label>Input landmark list file name</label>
+      <channel>input</channel>
+      <description>A single file for a list of filenames one per line.</description>
+      <default></default>
+    </file>
 
     <file>
       <name>outputLandmarkFile</name>


### PR DESCRIPTION
@hjmjohnson 
Please see the suggested changes. Not sure if this would break any of new BAW. 
The original one would NOT work in the old BAW. Even though computing average of one landmark does not make sense, it did not break the old BAW pipeline. ;) Other suggestions are welcomed too!

Best,  

Sharing the option based on the number of input and extension
was potentially confusing and possibly causing more issues.
Added 'inputLandmarkListFile' as an independent option to
reduce the confusion and keep the backward compatibility

See the [CONTRIBUTING](CONTRIBUTING.md) guide. Specifically:

Start BRAINSTools commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the Pull Request (PR) is based on a single commit, the commit message is usually left as the PR message.

A [reference to a related issue or pull request](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests) in your repository. You can automatically [close a related issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/)

[@mentions](https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams) of the person or team responsible for reviewing proposed changes.

Thanks for contributing to BRAINSTools!
