### PR TITLE
COMP: Fix ITK5 ModifiedTimeType related build errors on Windows

### DIFF
--- a/BRAINSCommonLib/genericRegistrationHelper.h
+++ b/BRAINSCommonLib/genericRegistrationHelper.h
@@ -503,7 +503,7 @@ public:
 
   /** Method to return the latest modified time of this object or
     * any of its cached ivars */
-  unsigned long GetMTime() const override;
+  ModifiedTimeType GetMTime() const override;
 
 protected:
   MultiModal3DMutualRegistrationHelper();

--- a/BRAINSCommonLib/genericRegistrationHelper.hxx
+++ b/BRAINSCommonLib/genericRegistrationHelper.hxx
@@ -472,7 +472,7 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
  */
 template <typename TTransformType, typename TOptimizer, typename TFixedImage,
           typename TMovingImage, typename MetricType>
-unsigned long
+ModifiedTimeType
 MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
                                      TMovingImage, MetricType>
 ::GetMTime() const


### PR DESCRIPTION
On 64-bit Windows builds, ITK ModifiedTimeType is not equivalent to unsigned long.
Fixed by using ModifiedTimeType instead of the old hardcoded unsigned long type.

Fix from Andras Lasso (see http://svn.slicer.org/Slicer4/trunk@28448 3bd1e089-480b-0410-8dfb-8563597acbee)

See the [CONTRIBUTING](CONTRIBUTING.md) guide. Specifically:

Start BRAINSTools commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the Pull Request (PR) is based on a single commit, the commit message is usually left as the PR message.

A [reference to a related issue or pull request](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests) in your repository. You can automatically [close a related issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/)

[@mentions](https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams) of the person or team responsible for reviewing proposed changes.

Thanks for contributing to BRAINSTools!
