### PR TITLE
COMP: Fix build error including itkMacro.h instead of itkExceptionObject.h

### DIFF
--- a/ARCHIVE/BRAINSSurfaceTools/BRAINSSurfaceCommon/itkMeshToMeshMetric.h
+++ b/ARCHIVE/BRAINSSurfaceTools/BRAINSSurfaceCommon/itkMeshToMeshMetric.h
@@ -22,7 +22,7 @@
 #include "itkTransform.h"
 #include "itkSingleValuedCostFunction.h"
 #include "itkInterpolateMeshFunction.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkSpatialObject.h"
 
 namespace itk

--- a/ARCHIVE/ICCDEF/iccdefRegistration_New.cxx
+++ b/ARCHIVE/ICCDEF/iccdefRegistration_New.cxx
@@ -25,10 +25,10 @@
 // #include <fstream>
 // #include <cstdio>
 #include "itkArray.h"
-// #include "itkExceptionObject.h"
 #include "itkIO.h"
 // #include "itkImage.h"
 #include "itkLabelStatisticsImageFilter.h"
+// #include "itkMacro.h"
 #include "itkPDEDeformableRegistrationFilter.h"
 #include "itkSpatialObjectReader.h"
 #include "BRAINSCommonLib.h"

--- a/ARCHIVE/ICCDEF/itkICCDeformableFunction.hxx
+++ b/ARCHIVE/ICCDEF/itkICCDeformableFunction.hxx
@@ -33,7 +33,7 @@
 #include <sstream>
 
 #include "itkICCDeformableFunction.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkMath.h"
 // #include "itkIterativeInverseDisplacementFieldImageFilter.h"
 // #include "itkIterativeInverseDisplacementFieldImageFilter1.h"

--- a/BRAINSDemonWarp/BRAINSDemonWarpTemplates.h
+++ b/BRAINSDemonWarp/BRAINSDemonWarpTemplates.h
@@ -27,7 +27,7 @@
 #include "itkImage.h"
 #include "itkIndex.h"
 #include "itkSize.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkPDEDeformableRegistrationFilter.h"
 #include "itkDemonsRegistrationFilter.h"
 #include "itkSymmetricForcesDemonsRegistrationFilter.h"

--- a/BRAINSDemonWarp/itkESMDemonsRegistrationWithMaskFunction.hxx
+++ b/BRAINSDemonWarp/itkESMDemonsRegistrationWithMaskFunction.hxx
@@ -20,7 +20,7 @@
 
 #include "itkESMDemonsRegistrationWithMaskFunction.h"
 #include "itkExceptionObject.h"
-#include "itkMath.h"
+#include "itkMacro.h"
 #include "itkImageMaskSpatialObject.h"
 
 namespace itk

--- a/BRAINSDemonWarp/itkVectorESMDemonsRegistrationFunction.hxx
+++ b/BRAINSDemonWarp/itkVectorESMDemonsRegistrationFunction.hxx
@@ -37,7 +37,7 @@
 #define __itkVectorESMDemonsRegistrationFunction_hxx
 
 #include "itkVectorESMDemonsRegistrationFunction.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkMath.h"
 
 namespace itk

--- a/BRAINSMush/itkMixtureStatisticCostFunction.h
+++ b/BRAINSMush/itkMixtureStatisticCostFunction.h
@@ -40,10 +40,10 @@
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
+#include "itkMacro.h"
 #include "itkNumericTraits.h"
 #include "itkProgressReporter.h"
 #include "itkMultipleValuedCostFunction.h"
-#include "itkExceptionObject.h"
 
 namespace itk
 {

--- a/BRAINSResample/BRAINSResize.cxx
+++ b/BRAINSResample/BRAINSResize.cxx
@@ -21,7 +21,7 @@
 #include <itkResampleImageFilter.h>
 #include <itkIdentityTransform.h>
 #include <itkLinearInterpolateImageFunction.h>
-#include <itkExceptionObject.h>
+#include <itkMacro.h>
 #include "BRAINSResizeCLP.h"
 #include <BRAINSCommonLib.h>
 

--- a/GTRACT/Cmdline/gtractAverageBvalues.cxx
+++ b/GTRACT/Cmdline/gtractAverageBvalues.cxx
@@ -44,7 +44,7 @@
 #include <itkVectorImage.h>
 #include <itkImageFileWriter.h>
 #include <itkImageFileReader.h>
-#include <itkExceptionObject.h>
+#include <itkMacro.h>
 #include <itkMetaDataObject.h>
 #include <itkImageRegionIterator.h>
 #include <itkImageRegionConstIterator.h>

--- a/GTRACT/Cmdline/gtractClipAnisotropy.cxx
+++ b/GTRACT/Cmdline/gtractClipAnisotropy.cxx
@@ -42,7 +42,7 @@
 #include <itkImage.h>
 #include <itkImageFileWriter.h>
 #include <itkImageFileReader.h>
-#include <itkExceptionObject.h>
+#include <itkMacro.h>
 #include <itkMetaDataObject.h>
 #include <itkImageRegionIteratorWithIndex.h>
 

--- a/GTRACT/Cmdline/gtractConcatDwi.cxx
+++ b/GTRACT/Cmdline/gtractConcatDwi.cxx
@@ -43,7 +43,7 @@
 #include <metaCommand.h>
 #include <itkImageFileWriter.h>
 #include <itkImageFileReader.h>
-#include <itkExceptionObject.h>
+#include <itkMacro.h>
 #include <itkMetaDataObject.h>
 #include <itkImageRegionIterator.h>
 #include <itkImageRegionConstIterator.h>

--- a/GTRACT/Cmdline/gtractCoregBvalues.cxx
+++ b/GTRACT/Cmdline/gtractCoregBvalues.cxx
@@ -41,7 +41,7 @@
 #include <itkVectorImage.h>
 #include <itkImageFileWriter.h>
 #include <itkImageFileReader.h>
-#include <itkExceptionObject.h>
+#include <itkMacro.h>
 #include <itkVectorImageToImageAdaptor.h>
 #include <itkVectorIndexSelectionCastImageFilter.h>
 #include <itkImageRegionIterator.h>

--- a/GTRACT/Cmdline/gtractResampleDWIInPlace.cxx
+++ b/GTRACT/Cmdline/gtractResampleDWIInPlace.cxx
@@ -37,7 +37,7 @@
 #include <itkVectorImage.h>
 #include <itkImageFileWriter.h>
 #include <itkImageFileReader.h>
-#include <itkExceptionObject.h>
+#include <itkMacro.h>
 #include <itkVectorIndexSelectionCastImageFilter.h>
 #include <itkComposeImageFilter.h>
 #include <itkImageRegionIterator.h>


### PR DESCRIPTION
This commit fixes build error when building against
ITK >= InsightSoftwareConsortium/ITK@ad0007e88 (ENH: Replace ExceptionObjects
with itkExceptionMacro.)

Co-authored-by: Csaba Pinter <csaba.pinter@queensu.ca>