### PR TITLE
COMP: ANTs git has was invalid pre-merge value

### DIFF
--- a/SuperBuild/External_ANTs.cmake
+++ b/SuperBuild/External_ANTs.cmake
@@ -138,7 +138,7 @@ if(${SUPERBUILD_TOPLEVEL_PROJECT}_USE_QT)
 endif()
 ### --- End Project specific additions
 set(${proj}_REPOSITORY "https://github.com/ANTsX/ANTs.git")
-set(${proj}_GIT_TAG 6e5e3276ded38646fcd978c570121964e0a97e49) # 20190914
+set(${proj}_GIT_TAG 1fca2d756979e05f0f3c3f5fbcc568fbaa9b3bf6) # 20190918
 
 ExternalProject_Add(${proj}
   ${${proj}_EP_ARGS}


### PR DESCRIPTION
Fixed the hash to the permanent value on the master
branch.

See the [CONTRIBUTING](CONTRIBUTING.md) guide. Specifically:

Start BRAINSTools commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the Pull Request (PR) is based on a single commit, the commit message is usually left as the PR message.

A [reference to a related issue or pull request](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests) in your repository. You can automatically [close a related issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/)

[@mentions](https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams) of the person or team responsible for reviewing proposed changes.

Thanks for contributing to BRAINSTools!
