### PR TITLE
Fix build errors with ITK v5.1rc01

### DIFF
--- a/BRAINSFit/PerformMetricTest.cxx
+++ b/BRAINSFit/PerformMetricTest.cxx
@@ -55,11 +55,11 @@ main(int argc, char * argv[])
   using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  using TransformType = itk::BSplineTransform<double, Dimension>;
+  using TransformType = itk::BSplineTransform<PixelType, Dimension, 3>;
 
-  using MIMetricType = itk::MattesMutualInformationImageToImageMetricv4<FixedImageType, MovingImageType>;
-  using MSEMetricType = itk::MeanSquaresImageToImageMetricv4<FixedImageType, MovingImageType>;
-  using GenericMetricType = itk::ImageToImageMetricv4<FixedImageType, MovingImageType>;
+  using MIMetricType = itk::MattesMutualInformationImageToImageMetricv4<FixedImageType, MovingImageType, FixedImageType, PixelType>;
+  using MSEMetricType = itk::MeanSquaresImageToImageMetricv4<FixedImageType, MovingImageType, FixedImageType, PixelType>;
+  using GenericMetricType = itk::ImageToImageMetricv4<FixedImageType, MovingImageType, FixedImageType, PixelType>;
   using MetricSamplePointSetType = GenericMetricType::FixedSampledPointSetType;
 
   // Read input images

--- a/BRAINSStripRotation/BRAINSStripRotation.cxx
+++ b/BRAINSStripRotation/BRAINSStripRotation.cxx
@@ -141,7 +141,7 @@ main(int argc, char * argv[])
   //
   // have to find out what type of file this is.
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(inputVolume.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(inputVolume.c_str(), itk::ImageIOFactory::ReadMode);
   if (imageIO.IsNotNull())
   {
     try

--- a/BRAINSTransformConvert/BRAINSTransformConvert.cxx
+++ b/BRAINSTransformConvert/BRAINSTransformConvert.cxx
@@ -334,13 +334,13 @@ DoConversion(int argc, char * argv[])
         //
         unsigned int numOfTransforms = compToWrite->GetNumberOfTransforms();
         if ((compToWrite->GetNthTransform(numOfTransforms - 1)->GetTransformCategory() ==
-             GenericTransformType::TransformCategoryType::DisplacementField) &&
+             GenericTransformType::DisplacementField) &&
             (compToWrite->GetNthTransform(numOfTransforms - 2)->GetTransformCategory() ==
-             GenericTransformType::TransformCategoryType::DisplacementField) &&
+             GenericTransformType::DisplacementField) &&
             (compToWrite->GetNthTransform(numOfTransforms - 3)->GetTransformCategory() ==
-             GenericTransformType::TransformCategoryType::DisplacementField) &&
+             GenericTransformType::DisplacementField) &&
             (compToWrite->GetNthTransform(numOfTransforms - 4)->GetTransformCategory() ==
-             GenericTransformType::TransformCategoryType::DisplacementField))
+             GenericTransformType::DisplacementField))
         {
           typename DisplacementFieldTransformType::Pointer fixedToMiddleForwardTx =
             dynamic_cast<DisplacementFieldTransformType *>(


### PR DESCRIPTION
We are trying to update Slicer to use latest ITK release (v5.1rc01), but the BRAINSTools version we have been fails to build with it. PerformMetricTest.cxx changes in this pull request fixes the error.

However, latest BRAINSTools is not compatible with latest ITK release (v5.1rc01), due to all the strongly typed enum changes. I've committed changes that undo all the incompatible changes in BRAINSTools in BRAINSStripRotation.cxx and BRAINSTransformConvert.cxx, but probably instead of a simple revert, you would want to use #ifdef to make the code work with both latest ITK release and ITK master. Alternatively, a new ITK stable release could be created that works with BRAINSTools, or a BRAINSTools branch could be created that is compatible with latest ITK release.

