### PR TITLE
BRAINSDeface Update (independent mask generation & application)

### DIFF
--- a/BRAINSDeface/BRAINSDeface.cxx
+++ b/BRAINSDeface/BRAINSDeface.cxx
@@ -19,6 +19,7 @@
 #include "itkSignedMaurerDistanceMapImageFilter.h"
 #include "itkConstantPadImageFilter.h"
 #include "BRAINSCommonLib.h"
+#include "itkUnaryGeneratorImageFilter.h"
 
 
 /*
@@ -37,6 +38,14 @@ main(int argc, char * argv[])
 {
   PARSE_ARGS; // <-- this is not really used yet TODO: Make argument parsing SEM compatible.
 
+
+  // usage check
+  if (!inputMask.empty() && noMaskApplication)
+  {
+    std::cout << "A mask has been provided, but the noMaskApplication flag has been set.\nThis program will do nothing "
+                 "in this configuration.";
+    // TODO exit
+  }
 
   // STEP 1: Using all the anatomical images for this session, generate a label mask defining
   // regions that are 0= in all the images
@@ -62,50 +71,6 @@ main(int argc, char * argv[])
     img_list.emplace_back(itkUtil::ReadImage<InternalImageType>(im_fn));
   }
 
-  // Make a 1/2 mm masked volume
-  MaskImageType::Pointer mask_labels = MaskImageType::New();
-  {
-    const double                               spacing[3] = { 0.5, 0.5, 0.5 };
-    const MaskImageType::RegionType::IndexType starting_index{ 0, 0, 0 };
-    const MaskImageType::RegionType::SizeType  img_size{ 512, 512, 352 };
-    // 512 - 160 (80mm @ 0.5 spacing) = 352
-    // 512 + 80 (40 mm @ 0.5 spacing) = 592
-    // Empirically chosen origin voxel based on standard center of brain  WRONG:   ->  -128.0, -114.0, -132.0
-    const double origin[3] = { AC_pnt[LR] - 128.0, AC_pnt[PA] - 128.0, AC_pnt[SI] - 80.0 };
-    // -132 + 80  = 52 removing 80mm inferior
-    // -114 - 40 = -154 adding 40mm anterior
-
-    MaskImageType::RegionType region;
-    region.SetSize(img_size);
-    region.SetIndex(starting_index);
-    mask_labels->SetRegions(region);
-
-    MaskImageType::DirectionType id;
-    id.SetIdentity();
-    mask_labels->SetDirection(id);
-
-    mask_labels->SetSpacing(spacing);
-    mask_labels->SetOrigin(origin);
-    mask_labels->Allocate(true);
-  }
-
-  using FadeMapType = itk::Image<float, 3>;
-  FadeMapType::Pointer not_face_region = FadeMapType::New();
-  not_face_region->CopyInformation(mask_labels);
-  not_face_region->SetRegions(mask_labels->GetLargestPossibleRegion());
-  not_face_region->Allocate();
-  not_face_region->FillBuffer(1.0);
-
-  MaskImageType::Pointer binaryDistanceMapSeed = MaskImageType::New();
-  binaryDistanceMapSeed->CopyInformation(mask_labels);
-  binaryDistanceMapSeed->SetRegions(mask_labels->GetLargestPossibleRegion());
-  binaryDistanceMapSeed->Allocate();
-  binaryDistanceMapSeed->FillBuffer(0.0);
-
-  // ROIAuto declaration
-  using ROIAutoType = itk::BRAINSROIAutoImageFilter<InternalImageType, MaskImageType>;
-
-
   constexpr int valid_inside_pixel = 0;
   constexpr int face_rm = 1;
   constexpr int below_ac = 2;
@@ -115,108 +80,167 @@ main(int argc, char * argv[])
   // Find all the out of FOV spaces fro the mask image
   MaskImageType::PointType     maskpnt;
   InternalImageType::IndexType imgindex;
-  constexpr double             max_smoothing_size = 0.0; // Try 10.0 for very safe margins
-  for (auto & curr_img : img_list)
-  {
-//    MaskImageType::Pointer roi = [](InternalImageType::Pointer current_image) -> MaskImageType::Pointer {
-//      ROIAutoType::Pointer ROIFilter = ROIAutoType::New();
-//      ROIFilter->SetClosingSize(20);                                  // close 10mm holes
-//      ROIFilter->SetDilateSize(static_cast<int>(max_smoothing_size)); // 55 mm ~ IPD ~ tip of the nose
-//
-//      // pre-compute ROIAuto
-//      ROIFilter->SetInput(current_image);
-//      ROIFilter->Update();
-//
-//      return ROIFilter->GetOutput();
-//    }(curr_img);
-//    itk::NearestNeighborInterpolateImageFunction<MaskImageType>::Pointer roiAutoInterpolator =
-//      itk::NearestNeighborInterpolateImageFunction<MaskImageType>::New();
-//    roiAutoInterpolator->SetInputImage(roi);
-//    if (debugLevel >= 2)
-//    {
-//      itkUtil::WriteImage<MaskImageType>(roi, outputDirectory + "/roi.nii.gz");
-//    }
-    {
-      itk::ImageRegionIteratorWithIndex<MaskImageType> mit(mask_labels, mask_labels->GetLargestPossibleRegion());
-      itk::ImageRegionIteratorWithIndex<FadeMapType> fit(not_face_region, not_face_region->GetLargestPossibleRegion());
-      itk::ImageRegionIteratorWithIndex<MaskImageType> dit(binaryDistanceMapSeed,
-                                                           not_face_region->GetLargestPossibleRegion());
-      constexpr double                                 approx_eye_radius = 9; // Size of eyes
-      while (!mit.IsAtEnd())
-      {
-        if (mit.Value() == 0) // Only change if not yet set.
-        {
-          mask_labels->TransformIndexToPhysicalPoint<double>(mit.GetIndex(), maskpnt);
-          const bool isInside = curr_img->TransformPhysicalPointToIndex(maskpnt, imgindex);
-          if (!isInside)
-          {
-            mit.Set(outside_fov);
-            fit.Set(0.0);
-            dit.Set(1);
-          }
-          else if (maskpnt[SI] < AC_pnt[SI] - 80.0) // removing 80 mm inferior
-          {
-            mit.Set(below_ac);
-            fit.Set(0.0);
-          }
-          // blur nose region
-          else if ((maskpnt[PA] < RE_pnt[PA] || maskpnt[PA] < LE_pnt[PA]) &&
-                   (maskpnt[SI] < (RE_pnt[SI]) || (maskpnt[SI] < LE_pnt[SI])))
-          {
-            mit.Set(face_rm);
-            fit.Set(0.0);
-            dit.Set(1);
-          }
-          // blur Cheak region
-          else if ((maskpnt[PA] < RE_pnt[PA] || maskpnt[PA] < LE_pnt[PA]) &&
-                   (maskpnt[SI] < (RE_pnt[SI]) || (maskpnt[SI] < LE_pnt[SI])))
-          {
-            mit.Set(face_rm);
-            fit.Set(0.0);
-            dit.Set(1);
-          }
 
-          else if ((
-                     // Now remove RE eye boxes
-                     (maskpnt[PA] < (RE_pnt[PA] + approx_eye_radius)) && // anterior to back of eye
-                     (maskpnt[SI] < (RE_pnt[SI] + approx_eye_radius)) && // in si eye region
-                     (maskpnt[LR] < (RE_pnt[LR] + approx_eye_radius))    // lateral to eye
-                     ) ||
-                   (
-                     // Now remove LE eye boxes
-                     (maskpnt[PA] < (RE_pnt[PA] + approx_eye_radius)) && // anterior to back of eye
-                     (maskpnt[SI] < (RE_pnt[SI] + approx_eye_radius)) && // in si eye region
-                     (maskpnt[LR] > (LE_pnt[LR] - approx_eye_radius)))   // lateral to eye
-          )
+  using FadeMapType = itk::Image<float, 3>;
+
+  MaskImageType::Pointer mask_labels;
+
+
+  if (!inputMask.empty())
+  { // Read pre-generated mask
+    mask_labels = itkUtil::ReadImage<MaskImageType>(inputMask);
+  }
+  else
+  { // Generate a new mask
+
+    // Make a 1/2 mm masked volume
+    mask_labels = MaskImageType::New();
+    {
+      const double                               spacing[3] = { 0.5, 0.5, 0.5 };
+      const MaskImageType::RegionType::IndexType starting_index{ 0, 0, 0 };
+      const MaskImageType::RegionType::SizeType  img_size{ 512, 512, 352 };
+      // 512 - 160 (80mm @ 0.5 spacing) = 352
+      // Empirically chosen origin voxel based on standard center of brain  WRONG:   ->  -128.0, -114.0, -132.0
+      const double origin[3] = { AC_pnt[LR] - 128.0, AC_pnt[PA] - 128.0, AC_pnt[SI] - 80.0 };
+      // -132 + 80  = 52 removing 80mm inferior
+      // -114 - 40 = -154 adding 40mm anterior
+
+      MaskImageType::RegionType region;
+      region.SetSize(img_size);
+      region.SetIndex(starting_index);
+      mask_labels->SetRegions(region);
+
+      MaskImageType::DirectionType id;
+      id.SetIdentity();
+      mask_labels->SetDirection(id);
+
+      mask_labels->SetSpacing(spacing);
+      mask_labels->SetOrigin(origin);
+      mask_labels->Allocate(true);
+    }
+
+    // ROIAuto declaration
+    // unused typedef below
+    //  using ROIAutoType = itk::BRAINSROIAutoImageFilter<InternalImageType, MaskImageType>;
+    // Unused variable below
+    //  constexpr double             max_smoothing_size = 0.0; // Try 10.0 for very safe margins
+
+    for (auto & curr_img : img_list)
+    {
+      //    MaskImageType::Pointer roi = [](InternalImageType::Pointer current_image) -> MaskImageType::Pointer {
+      //      ROIAutoType::Pointer ROIFilter = ROIAutoType::New();
+      //      ROIFilter->SetClosingSize(20);                                  // close 10mm holes
+      //      ROIFilter->SetDilateSize(static_cast<int>(max_smoothing_size)); // 55 mm ~ IPD ~ tip of the nose
+      //
+      //      // pre-compute ROIAuto
+      //      ROIFilter->SetInput(current_image);
+      //      ROIFilter->Update();
+      //
+      //      return ROIFilter->GetOutput();
+      //    }(curr_img);
+      //    itk::NearestNeighborInterpolateImageFunction<MaskImageType>::Pointer roiAutoInterpolator =
+      //      itk::NearestNeighborInterpolateImageFunction<MaskImageType>::New();
+      //    roiAutoInterpolator->SetInputImage(roi);
+      //    if (debugLevel >= 2)
+      //    {
+      //      itkUtil::WriteImage<MaskImageType>(roi, outputDirectory + "/roi.nii.gz");
+      //    }
+      {
+        itk::ImageRegionIteratorWithIndex<MaskImageType> mit(mask_labels, mask_labels->GetLargestPossibleRegion());
+        constexpr double                                 approx_eye_radius = 9; // Size of eyes
+        while (!mit.IsAtEnd())
+        {
+          if (mit.Value() == 0) // Only change if not yet set.
           {
-            mit.Set(eye_boxes_code);
-            fit.Set(0.0);
-            dit.Set(1);
+            mask_labels->TransformIndexToPhysicalPoint<double>(mit.GetIndex(), maskpnt);
+            const bool isInside = curr_img->TransformPhysicalPointToIndex(maskpnt, imgindex);
+            if (!isInside)
+            {
+              mit.Set(outside_fov);
+            }
+            else if (maskpnt[SI] < AC_pnt[SI] - 80.0) // removing 80 mm inferior
+            {
+              mit.Set(below_ac);
+            }
+            // blur nose region
+            else if ((maskpnt[PA] < RE_pnt[PA] || maskpnt[PA] < LE_pnt[PA]) &&
+                     (maskpnt[SI] < (RE_pnt[SI]) || (maskpnt[SI] < LE_pnt[SI])))
+            {
+              mit.Set(face_rm);
+            }
+            // blur Cheak region
+            else if ((maskpnt[PA] < RE_pnt[PA] || maskpnt[PA] < LE_pnt[PA]) &&
+                     (maskpnt[SI] < (RE_pnt[SI]) || (maskpnt[SI] < LE_pnt[SI])))
+            {
+              mit.Set(face_rm);
+            }
+
+            else if ((
+                       // Now remove RE eye boxes
+                       (maskpnt[PA] < (RE_pnt[PA] + approx_eye_radius)) && // anterior to back of eye
+                       (maskpnt[SI] < (RE_pnt[SI] + approx_eye_radius)) && // in si eye region
+                       (maskpnt[LR] < (RE_pnt[LR] + approx_eye_radius))    // lateral to eye
+                       ) ||
+                     (
+                       // Now remove LE eye boxes
+                       (maskpnt[PA] < (RE_pnt[PA] + approx_eye_radius)) && // anterior to back of eye
+                       (maskpnt[SI] < (RE_pnt[SI] + approx_eye_radius)) && // in si eye region
+                       (maskpnt[LR] > (LE_pnt[LR] - approx_eye_radius)))   // lateral to eye
+            )
+            {
+              mit.Set(eye_boxes_code);
+            }
+            // Now try to remove eyebrows/forehead
+            else if ((maskpnt[PA] < (RE_pnt[PA] - approx_eye_radius * 3) ||
+                      maskpnt[PA] < (LE_pnt[PA] - approx_eye_radius * 3))
+                     //                   && (maskpnt[SI] < (RE_pnt[SI] + approx_eye_radius * 5) ||
+                     //                    maskpnt[SI] < (LE_pnt[SI] + approx_eye_radius * 5))
+            )
+            {
+              mit.Set(face_rm);
+            }
+            //          else if (roiAutoInterpolator->Evaluate(maskpnt) != 1)
+            //          {
+            //            mit.Set(auto_roi_background);
+            //          }
           }
-          // Now try to remove eyebrows/forehead
-          else if ((maskpnt[PA] < (RE_pnt[PA] - approx_eye_radius * 3) ||
-                    maskpnt[PA] < (LE_pnt[PA] - approx_eye_radius * 3))
-                   //                   && (maskpnt[SI] < (RE_pnt[SI] + approx_eye_radius * 5) ||
-                   //                    maskpnt[SI] < (LE_pnt[SI] + approx_eye_radius * 5))
-          )
-          {
-            mit.Set(face_rm);
-            fit.Set(0.0);
-            dit.Set(1);
-          }
-//          else if (roiAutoInterpolator->Evaluate(maskpnt) != 1)
-//          {
-//            mit.Set(auto_roi_background);
-//            fit.Set(0.0);
-//            dit.Set(1);
-//          }
+          ++mit;
         }
-        ++mit;
-        ++fit;
-        ++dit;
       }
     }
   }
+
+
+  // lambdas for the other two regions based on the mask values
+  using MaskLabelToDistanceMapSeedFilter = typename itk::UnaryGeneratorImageFilter<MaskImageType, MaskImageType>;
+  MaskLabelToDistanceMapSeedFilter::Pointer maskLabelToDistanceMapSeedFilter = MaskLabelToDistanceMapSeedFilter::New();
+  maskLabelToDistanceMapSeedFilter->SetFunctor([&](const typename MaskImageType::PixelType input_mask_value) ->
+                                               typename MaskImageType ::PixelType {
+                                                 if (input_mask_value == valid_inside_pixel)
+                                                 {
+                                                   return static_cast<typename MaskImageType::PixelType>(0);
+                                                 }
+                                                 return static_cast<typename MaskImageType::PixelType>(1);
+                                               });
+
+  maskLabelToDistanceMapSeedFilter->SetInput(mask_labels);
+  maskLabelToDistanceMapSeedFilter->Update();
+  MaskImageType::Pointer binaryDistanceMapSeed = maskLabelToDistanceMapSeedFilter->GetOutput();
+
+  using MaskLabelToNotFaceRegionFilter = typename itk::UnaryGeneratorImageFilter<MaskImageType, FadeMapType>;
+  MaskLabelToNotFaceRegionFilter::Pointer maskLabelToNotFaceRegionFilter = MaskLabelToNotFaceRegionFilter::New();
+  maskLabelToNotFaceRegionFilter->SetFunctor([&](const typename MaskImageType::PixelType input_mask_value) ->
+                                             typename FadeMapType::PixelType {
+                                               if (input_mask_value == valid_inside_pixel)
+                                               {
+                                                 return static_cast<typename MaskImageType::PixelType>(1.0);
+                                               }
+                                               return static_cast<typename MaskImageType::PixelType>(0.0);
+                                             });
+
+  maskLabelToNotFaceRegionFilter->SetInput(mask_labels);
+  maskLabelToNotFaceRegionFilter->Update();
+  FadeMapType::Pointer not_face_region = maskLabelToNotFaceRegionFilter->GetOutput();
 
   if (debugLevel >= 5)
   {
@@ -225,119 +249,126 @@ main(int argc, char * argv[])
   }
 
   // STEP 2: Deface the image values
-  itk::NearestNeighborInterpolateImageFunction<MaskImageType>::Pointer maskInterpolator =
-    itk::NearestNeighborInterpolateImageFunction<MaskImageType>::New();
-  maskInterpolator->SetInputImage(mask_labels);
-
-  // pad the distance map
-  MaskImageType::SizeType lowerPadBound;
-  lowerPadBound.Fill(80); // 40 mm @ 0.5 mm spacing
-  MaskImageType::SizeType upperPadBound;
-  upperPadBound.Fill(80); // 40 mm @ 0.5 mm spacing
-
-  itk::ConstantPadImageFilter<MaskImageType, MaskImageType>::Pointer padImageFilter =
-    itk::ConstantPadImageFilter<MaskImageType, MaskImageType>::New();
-  padImageFilter->SetInput(binaryDistanceMapSeed);
-  padImageFilter->SetPadLowerBound(lowerPadBound);
-  padImageFilter->SetPadUpperBound(upperPadBound);
-  padImageFilter->SetConstant(face_rm);
-  padImageFilter->Update();
-  if (debugLevel >= 5)
+  if (!noMaskApplication)
   {
-    itkUtil::WriteImage<MaskImageType>(padImageFilter->GetOutput(), outputDirectory + "/padded.nii.gz");
-  }
-  // compute the distance map
-  itk::SignedMaurerDistanceMapImageFilter<MaskImageType, InternalImageType>::Pointer signedDistanceMap =
-    itk::SignedMaurerDistanceMapImageFilter<MaskImageType, InternalImageType>::New();
-  signedDistanceMap->SetInput(padImageFilter->GetOutput());
-  signedDistanceMap->SetInsideIsPositive(true);
-  signedDistanceMap->Update();
-  InternalImageType::Pointer distanceMap = signedDistanceMap->GetOutput();
-  for (itk::ImageRegionIterator<InternalImageType> diit(distanceMap, distanceMap->GetLargestPossibleRegion());
-       !diit.IsAtEnd();
-       ++diit)
-  {
-    const auto &                           refvalue = diit.Value();
-    constexpr InternalImageType::PixelType allowed_blurring_area = -2.0; // Allow blurring if distance from edge
-    if (refvalue < allowed_blurring_area)
+    itk::NearestNeighborInterpolateImageFunction<MaskImageType>::Pointer maskInterpolator =
+      itk::NearestNeighborInterpolateImageFunction<MaskImageType>::New();
+    maskInterpolator->SetInputImage(mask_labels);
+
+    // pad the distance map
+    MaskImageType::SizeType lowerPadBound;
+    lowerPadBound.Fill(80); // 40 mm @ 0.5 mm spacing
+    MaskImageType::SizeType upperPadBound;
+    upperPadBound.Fill(80); // 40 mm @ 0.5 mm spacing
+
+    itk::ConstantPadImageFilter<MaskImageType, MaskImageType>::Pointer padImageFilter =
+      itk::ConstantPadImageFilter<MaskImageType, MaskImageType>::New();
+    padImageFilter->SetInput(binaryDistanceMapSeed);
+    padImageFilter->SetPadLowerBound(lowerPadBound);
+    padImageFilter->SetPadUpperBound(upperPadBound);
+    padImageFilter->SetConstant(face_rm);
+    padImageFilter->Update();
+    if (debugLevel >= 5)
     {
-      diit.Set(0.0);
+      itkUtil::WriteImage<MaskImageType>(padImageFilter->GetOutput(), outputDirectory + "/padded.nii.gz");
     }
-    else
+    // compute the distance map
+    itk::SignedMaurerDistanceMapImageFilter<MaskImageType, InternalImageType>::Pointer signedDistanceMap =
+      itk::SignedMaurerDistanceMapImageFilter<MaskImageType, InternalImageType>::New();
+    signedDistanceMap->SetInput(padImageFilter->GetOutput());
+    signedDistanceMap->SetInsideIsPositive(true);
+    signedDistanceMap->Update();
+    InternalImageType::Pointer distanceMap = signedDistanceMap->GetOutput();
+    for (itk::ImageRegionIterator<InternalImageType> diit(distanceMap, distanceMap->GetLargestPossibleRegion());
+         !diit.IsAtEnd();
+         ++diit)
     {
-      diit.Set(std::abs(refvalue));
-    }
-  }
-  if (debugLevel >= 2)
-  {
-    itkUtil::WriteImage<InternalImageType>(distanceMap, outputDirectory + "/dist_img.nii.gz");
-  }
-  itk::LinearInterpolateImageFunction<InternalImageType>::Pointer distanceMapInterpolator =
-    itk::LinearInterpolateImageFunction<InternalImageType>::New();
-  distanceMapInterpolator->SetInputImage(distanceMap);
-
-
-  // blur config
-  //  const int    numSigmas = 2;
-  //  const double sigmas[numSigmas] = { 1.0, 1.1};
-  constexpr size_t numSigmas = 10;
-  // constexpr size_t lastSigmaIndex = numSigmas - 1;
-  constexpr double sigmas[numSigmas] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 };
-  //, 9.0, 10.0, 11.0, 12.0, 13.0  };
-
-  for (auto & curr_img : img_list)
-  {
-    // pre-compute different levels of gaussian blur
-    InternalImageType::Pointer                                      blurredImages[numSigmas];
-    itk::LinearInterpolateImageFunction<InternalImageType>::Pointer blurredImageInterpolators[numSigmas];
-    using BlurFilter = itk::SmoothingRecursiveGaussianImageFilter<FadeMapType, FadeMapType>;
-    for (size_t i = 0; i < numSigmas; ++i)
-    {
-      BlurFilter::Pointer blur = BlurFilter::New();
-      blur->SetInput(curr_img);
-      blur->SetSigma(sigmas[i]);
-      blur->Update();
-      blurredImages[i] = blur->GetOutput();
-      blurredImageInterpolators[i] = itk::LinearInterpolateImageFunction<InternalImageType>::New();
-      blurredImageInterpolators[i]->SetInputImage(blurredImages[i]);
-      if (debugLevel >= 5)
+      const auto &                           refvalue = diit.Value();
+      constexpr InternalImageType::PixelType allowed_blurring_area = -2.0; // Allow blurring if distance from edge
+      if (refvalue < allowed_blurring_area)
       {
-        itkUtil::WriteImage<InternalImageType>(blur->GetOutput(),
-                                               outputDirectory + "/blur_img_" + std::to_string(i) + ".nii.gz");
+        diit.Set(0.0);
+      }
+      else
+      {
+        diit.Set(std::abs(refvalue));
       }
     }
-
-    InternalImageType::PointType                         imgpnt;
-    itk::ImageRegionIteratorWithIndex<InternalImageType> iit(curr_img, curr_img->GetLargestPossibleRegion());
-    while (!iit.IsAtEnd())
+    if (debugLevel >= 2)
     {
-      const auto & curr_index{ iit.GetIndex() };
-      curr_img->TransformIndexToPhysicalPoint<double>(curr_index, imgpnt);
-      if (maskInterpolator->IsInsideBuffer(imgpnt) && distanceMapInterpolator->IsInsideBuffer(imgpnt))
+      itkUtil::WriteImage<InternalImageType>(distanceMap, outputDirectory + "/dist_img.nii.gz");
+    }
+    itk::LinearInterpolateImageFunction<InternalImageType>::Pointer distanceMapInterpolator =
+      itk::LinearInterpolateImageFunction<InternalImageType>::New();
+    distanceMapInterpolator->SetInputImage(distanceMap);
+
+
+    // blur configx
+    //  const int    numSigmas = 2;
+    //  const double sigmas[numSigmas] = { 1.0, 1.1};
+    constexpr size_t numSigmas = 10;
+    // constexpr size_t lastSigmaIndex = numSigmas - 1;
+    constexpr double sigmas[numSigmas] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 };
+    //, 9.0, 10.0, 11.0, 12.0, 13.0  };
+
+    for (auto & curr_img : img_list)
+    {
+      // pre-compute different levels of gaussian blur
+      InternalImageType::Pointer                                      blurredImages[numSigmas];
+      itk::LinearInterpolateImageFunction<InternalImageType>::Pointer blurredImageInterpolators[numSigmas];
+      using BlurFilter = itk::SmoothingRecursiveGaussianImageFilter<FadeMapType, FadeMapType>;
+      for (size_t i = 0; i < numSigmas; ++i)
       {
-        const MaskImageType::PixelType mask_value = maskInterpolator->Evaluate(imgpnt);
-        if (mask_value == valid_inside_pixel)
+        BlurFilter::Pointer blur = BlurFilter::New();
+        blur->SetInput(curr_img);
+        blur->SetSigma(sigmas[i]);
+        blur->Update();
+        blurredImages[i] = blur->GetOutput();
+        blurredImageInterpolators[i] = itk::LinearInterpolateImageFunction<InternalImageType>::New();
+        blurredImageInterpolators[i]->SetInputImage(blurredImages[i]);
+        if (debugLevel >= 5)
         {
-          // Pass
+          itkUtil::WriteImage<InternalImageType>(blur->GetOutput(),
+                                                 outputDirectory + "/blur_img_" + std::to_string(i) + ".nii.gz");
         }
-        else if (mask_value == face_rm || mask_value == auto_roi_background || mask_value == eye_boxes_code)
+      }
+
+      InternalImageType::PointType                         imgpnt;
+      itk::ImageRegionIteratorWithIndex<InternalImageType> iit(curr_img, curr_img->GetLargestPossibleRegion());
+      while (!iit.IsAtEnd())
+      {
+        const auto & curr_index{ iit.GetIndex() };
+        curr_img->TransformIndexToPhysicalPoint<double>(curr_index, imgpnt);
+        if (maskInterpolator->IsInsideBuffer(imgpnt) && distanceMapInterpolator->IsInsideBuffer(imgpnt))
         {
-          const InternalImageType::PixelType distanceValue = distanceMapInterpolator->Evaluate(imgpnt);
-          // determine the correct blur value
-          int              sigmaIndex = 0;
-          constexpr double sigma_distance_ratio = 1.0; // Factor of sigma smoothing to distance ratio
-          for (size_t i = 0; i < numSigmas; ++i)
+          const MaskImageType::PixelType mask_value = maskInterpolator->Evaluate(imgpnt);
+          if (mask_value == valid_inside_pixel)
           {
-            if (sigmas[i] * sigma_distance_ratio < distanceValue)
-            {
-              sigmaIndex = i;
-            }
+            // Pass
           }
-          if (blurredImageInterpolators[sigmaIndex]->IsInsideBuffer(imgpnt))
+          else if (mask_value == face_rm || mask_value == auto_roi_background || mask_value == eye_boxes_code)
           {
-            const InternalImageType::PixelType blurredValue = blurredImageInterpolators[sigmaIndex]->Evaluate(imgpnt);
-            iit.Set(blurredValue);
-            // iit.Set(sigmas[sigmaIndex]* 100);
+            const InternalImageType::PixelType distanceValue = distanceMapInterpolator->Evaluate(imgpnt);
+            // determine the correct blur value
+            int              sigmaIndex = 0;
+            constexpr double sigma_distance_ratio = 1.0; // Factor of sigma smoothing to distance ratio
+            for (size_t i = 0; i < numSigmas; ++i)
+            {
+              if (sigmas[i] * sigma_distance_ratio < distanceValue)
+              {
+                sigmaIndex = i;
+              }
+            }
+            if (blurredImageInterpolators[sigmaIndex]->IsInsideBuffer(imgpnt))
+            {
+              const InternalImageType::PixelType blurredValue = blurredImageInterpolators[sigmaIndex]->Evaluate(imgpnt);
+              iit.Set(blurredValue);
+              // iit.Set(sigmas[sigmaIndex]* 100);
+            }
+            else
+            {
+              iit.Set(0);
+            }
           }
           else
           {
@@ -348,34 +379,31 @@ main(int argc, char * argv[])
         {
           iit.Set(0);
         }
+        ++iit;
       }
-      else
-      {
-        iit.Set(0);
-      }
-      ++iit;
+    }
+
+    // STEP 3 Generate intensity normalized images from the clippings.
+    for (size_t i = 0; i < inputVolume.size(); ++i)
+    {
+      const auto input_fn = itksys::SystemTools::GetFilenameName(inputVolume[i]);
+
+      const std::vector<std::string> output_fn_components{ outputDirectory, "/", input_fn };
+      const std::string              output_fn = itksys::SystemTools::JoinPath(output_fn_components);
+      using OutputImageType = itk::Image<unsigned short, 3>;
+      const bool clip = !no_clip;
+      const bool relative = !no_relative;
+
+      auto intensity_normalized_output = brains_intensity_normalize_quantiles<InternalImageType, OutputImageType>(
+        img_list[i], lowerPercentile, upperPercentile, lowerOutputIntensity, upperOutputIntensity, clip, relative);
+      std::cout << "Writing output filename: " << output_fn << std::endl;
+      itkUtil::WriteImage<OutputImageType>(intensity_normalized_output, output_fn);
     }
   }
 
-  // STEP 3 Generate intensity normalized images from the clippings.
-  for (size_t i = 0; i < inputVolume.size(); ++i)
-  {
-    const auto input_fn = itksys::SystemTools::GetFilenameName(inputVolume[i]);
-
-    const std::vector<std::string> output_fn_components{ outputDirectory, "/", input_fn };
-    const std::string              output_fn = itksys::SystemTools::JoinPath(output_fn_components);
-    using OutputImageType = itk::Image<unsigned short, 3>;
-    const bool clip = !no_clip;
-    const bool relative = !no_relative;
-
-    auto intensity_normalized_output = brains_intensity_normalize_quantiles<InternalImageType, OutputImageType>(
-      img_list[i], lowerPercentile, upperPercentile, lowerOutputIntensity, upperOutputIntensity, clip, relative);
-    std::cout << "Writing output filename: " << output_fn << std::endl;
-    itkUtil::WriteImage<OutputImageType>(intensity_normalized_output, output_fn);
-  }
   // Write out mask as the last element after used for images
   // If outputMask has path elements, then do not use outputDirectory.
-  if (! outputMask.empty() )
+  if (!outputMask.empty() && inputMask.empty())
   {
     if (outputMask.find('/') == std::string::npos)
     {

--- a/BRAINSDeface/BRAINSDeface.xml
+++ b/BRAINSDeface/BRAINSDeface.xml
@@ -38,6 +38,15 @@
             <label>Source Reference Image</label>
             <channel>input</channel>
         </image>
+        <image multiple="true">>
+            <name>passiveVolume</name>
+            <flag>p</flag>
+            <longflag>passiveVolume</longflag>
+            <description>Input images not used in generating masks, all images must be in the exact same physical space as inputVolumes, ACPC aligned and consistent with landmarks.</description>
+            <label>Source Passive Images Image</label>
+            <channel>input</channel>
+        </image>
+
 
         <image>
             <name>inputMask</name>
@@ -52,7 +61,7 @@
             <longflag>defaceMode</longflag>
             <element>zero</element>
             <element>blur</element>
-            <default>zero</default>
+            <default>blur</default>
         </string-enumeration>
     </parameters>
 

--- a/BRAINSDeface/BRAINSDeface.xml
+++ b/BRAINSDeface/BRAINSDeface.xml
@@ -39,6 +39,14 @@
             <channel>input</channel>
         </image>
 
+        <image>
+            <name>inputMask</name>
+            <longflag>inputMask</longflag>
+            <description>Optional pre-generated mask to use.</description>
+            <label>Optional Mask</label>
+            <channel>input</channel>
+        </image>
+
         <string-enumeration>
             <name>defaceMode</name>
             <longflag>defaceMode</longflag>
@@ -70,6 +78,19 @@
             <channel>output</channel>
             <default>/tmp</default>
         </directory>
+    </parameters>
+
+    <parameters>
+        <label>Run Mode</label>
+        <description>Modify the program to only generate a mask</description>
+
+        <boolean>
+            <name>noMaskApplication</name>
+            <longflag>noMaskApplication</longflag>
+            <description>Do not apply the mask to the input images used to generate the mask</description>
+            <label>No Mask Application</label>
+            <!-- The default for boolean parameters is always set to false.-->
+        </boolean>
     </parameters>
 
     <parameters>


### PR DESCRIPTION
This PR adds two flags that breaks BRAINSDeface into two phases that can be run independently. Phase one is mask generation, and phase two is mask application.

The two flags are:
- `--noMaskApplication` which will generate the mask but not apply it to the images that were used to generate the mask.
- `--inputMask` which is an input mask (skips mask generation)