### PR TITLE
BUG: Updated VTK utility names.

### DIFF
--- a/BRAINSConstellationDetector/CMakeLists.txt
+++ b/BRAINSConstellationDetector/CMakeLists.txt
@@ -43,24 +43,24 @@ if(BUILD_WITH_GUI OR BRAINS3_USE_QT OR BRAINSTools_USE_QT)
     ITKVTK
     ITKVtkGlue
   )
-  set(LOCAL_VTKQT vtkGUISupportQt)
+  set(LOCAL_VTKQT GUISupportQt) #vtkGUISupportQt)
 
 FindVTKUtil(
-  vtkCommonColor
-  vtkCommonComputationalGeometry
-  vtkCommonCore
-  vtkCommonDataModel
-  vtkCommonExecutionModel
-  vtkCommonMath
-  vtkCommonMisc
-  vtkCommonSystem
-  vtkCommonTransforms
-  vtkFiltersCore
-  vtkFiltersGeneral
-  vtkFiltersSources
-  vtkImagingCore
-  vtkInteractionStyle
-  vtkRenderingCore
+  CommonColor #vtkCommonColor
+  CommonComputationalGeometry #vtkCommonComputationalGeometry
+  CommonCore #vtkCommonCore
+  CommonDataModel #vtkCommonDataModel
+  CommonExecutionModel #vtkCommonExecutionModel
+  CommonMath #vtkCommonMath
+  CommonMisc #vtkCommonMisc
+  CommonSystem #vtkCommonSystem
+  CommonTransforms #vtkCommonTransforms
+  FiltersCore #vtkFiltersCore
+  FiltersGeneral #vtkFiltersGeneral
+  FiltersSources #vtkFiltersSources
+  ImagingCore #vtkImagingCore
+  InteractionStyle #vtkInteractionStyle
+  RenderingCore #vtkRenderingCore
   ${LOCAL_VTKQT})
 endif()
 

--- a/CMake/FindVTKUtil.cmake
+++ b/CMake/FindVTKUtil.cmake
@@ -11,12 +11,12 @@ macro(FindVTKUtil)
 
   #  message("VTK_DIR:${VTK_DIR}")
   set(VTK_COMMON_COMPONENTS
-    vtkCommonSystem
-    vtkCommonCore
-    vtkCommonSystem
-    vtkCommonMath
-    vtkCommonMisc
-    vtkCommonTransforms
+    CommonSystem #vtkCommonSystem
+    CommonCore #vtkCommonCore
+    CommonSystem #vtkCommonSystem
+    CommonMath #vtkCommonMath
+    CommonMisc #vtkCommonMisc
+    CommonTransforms #vtkCommonTransforms
     ${ARGN}
   )
   find_package(VTK ${VTK_VERSION_MIN} COMPONENTS ${VTK_COMMON_COMPONENTS} REQUIRED)
@@ -39,7 +39,11 @@ macro(FindVTKUtil)
 #  set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS ${VTK_DEFINITIONS})
 
   find_package(VTK ${VTK_VERSION_MIN} REQUIRED) ## HACK: VTK should be minimized.  This is maximizing it's use to all modules.
-  include(${VTK_USE_FILE})
+
+  # No longer needed; warns or errors depending on the version requested when
+  # finding VTK.
+  #include(${VTK_USE_FILE})
+
   #  message("VTK_USE_FILE:${VTK_USE_FILE}")
   #  message("VTK_INCLUDE_DIRS:${VTK_INCLUDE_DIRS}")
   include_directories(${VTK_INCLUDE_DIRS})

--- a/ConvertBetweenFileFormats/CMakeLists.txt
+++ b/ConvertBetweenFileFormats/CMakeLists.txt
@@ -9,9 +9,12 @@ FindITKUtil(ConvertBetweenFileFormats_ITK
 
 if(BUILD_WITH_GUI OR BRAINS3_USE_QT OR BRAINSTools_USE_QT)
   FINDITKUtil(ITKVtkGlue)
-  set(LOCAL_VTKQT vtkGUISupportQt)
-  FindVTKUtil(vtkInteractionStyle
-    vtkRenderingCore  vtkImagingSources ${LOCAL_VTKQT})
+  set(LOCAL_VTKQT GUISupportQt) #vtkGUISupportQt)
+  FindVTKUtil(
+    InteractionStyle #vtkInteractionStyle
+    RenderingCore #vtkRenderingCore
+    ImagingSources #vtkImagingSources
+    ${LOCAL_VTKQT})
 endif()
 
 # This project is intended to be built outside the Insight source tree


### PR DESCRIPTION
Some VTK utility names were not changed after the recent External package update.
This does not affect functionality but does cause CMake to throw an error in debug mode.
These names have now been updated.
