### PR TITLE
ENH: Converted method parameters to pass by refrence.

### DIFF
--- a/BRAINSABC/brainseg/BRAINSABC.cxx
+++ b/BRAINSABC/brainseg/BRAINSABC.cxx
@@ -89,7 +89,7 @@ using ShortImagePointer = ShortImageType::Pointer;
  * \return either the absolute path, or the prepended path
  */
 static std::string
-FindPathFromAtlasXML(const std::string xmlCodedPath, std::string atlasDefinitionPath)
+FindPathFromAtlasXML(const std::string & xmlCodedPath, std::string atlasDefinitionPath)
 {
   if (xmlCodedPath[0] != '/') // If not an absolute path, assume relative path
   {

--- a/BRAINSABC/brainseg/EMSegmentationFilter.h
+++ b/BRAINSABC/brainseg/EMSegmentationFilter.h
@@ -366,7 +366,7 @@ private:
   typename TProbabilityImage::Pointer
   ComputeOnePosterior(const FloatingPrecision                   priorScale,
                       const typename TProbabilityImage::Pointer prior,
-                      const vnl_matrix<FloatingPrecision>       currCovariance,
+                      const vnl_matrix<FloatingPrecision> &     currCovariance,
                       typename RegionStats::MeanMapType &       currMeans,
                       const MapOfInputImageVectors &            intensityImages);
 
@@ -414,8 +414,8 @@ private:
               const unsigned int                 CurrentEMIteration,
               const ByteImageVectorType &        CandidateRegions,
               MapOfInputImageVectors &           inputImages,
-              const ByteImageType::Pointer       currentBrainMask,
-              const ByteImageType::Pointer       currentForegroundMask,
+              const ByteImageType::Pointer &     currentBrainMask,
+              const ByteImageType::Pointer &     currentForegroundMask,
               const ProbabilityImageVectorType & probImages,
               const BoolVectorType &             probUseForBias,
               const int                          DebugLevel,

--- a/BRAINSABC/common/Log.cxx
+++ b/BRAINSABC/common/Log.cxx
@@ -60,7 +60,7 @@ Log ::CloseFile()
 
 
 void
-Log ::SetOutputFileName(const std::string s)
+Log ::SetOutputFileName(const std::string & s)
 {
   if (m_Output.is_open())
   {

--- a/BRAINSABC/common/Log.h
+++ b/BRAINSABC/common/Log.h
@@ -61,7 +61,7 @@ public:
   //  }
 
   void
-  SetOutputFileName(std::string s);
+  SetOutputFileName(const std::string & s);
 
   void
   WriteString(const char * s);

--- a/BRAINSCommonLib/ConvertToRigidAffine.h
+++ b/BRAINSCommonLib/ConvertToRigidAffine.h
@@ -70,7 +70,7 @@ using Similarity3DParametersType = Similarity3DTransformType::ParametersType;
  * AffineTransformPointer  :=  AffineTransformPointer
  */
 inline void
-AssignConvertedTransform(AffineTransformPointer & result, const AffineTransformType::ConstPointer affine)
+AssignConvertedTransform(AffineTransformPointer & result, const AffineTransformType::ConstPointer & affine)
 {
   if (result.IsNotNull())
   {
@@ -121,7 +121,7 @@ AssignConvertedTransform(AffineTransformPointer & result, const VnlTransformMatr
  * VnlTransformMatrixType44  :=  AffineTransformPointer
  */
 inline void
-AssignConvertedTransform(VnlTransformMatrixType44 & result, const AffineTransformType::ConstPointer affine)
+AssignConvertedTransform(VnlTransformMatrixType44 & result, const AffineTransformType::ConstPointer & affine)
 {
   if (affine.IsNotNull())
   {
@@ -150,7 +150,7 @@ AssignConvertedTransform(VnlTransformMatrixType44 & result, const AffineTransfor
  * AffineTransformPointer  :=  ScaleSkewVersor3DTransformPointer
  */
 inline void
-AssignConvertedTransform(AffineTransformPointer & result, const ScaleSkewVersor3DTransformType::ConstPointer scale)
+AssignConvertedTransform(AffineTransformPointer & result, const ScaleSkewVersor3DTransformType::ConstPointer & scale)
 {
   if (result.IsNotNull() && scale.IsNotNull())
   {
@@ -171,8 +171,8 @@ AssignConvertedTransform(AffineTransformPointer & result, const ScaleSkewVersor3
  * ScaleSkewVersor3DTransformPointer  :=  ScaleSkewVersor3DTransformPointer
  */
 inline void
-AssignConvertedTransform(ScaleSkewVersor3DTransformPointer &                result,
-                         const ScaleSkewVersor3DTransformType::ConstPointer scale)
+AssignConvertedTransform(ScaleSkewVersor3DTransformPointer &                  result,
+                         const ScaleSkewVersor3DTransformType::ConstPointer & scale)
 {
   if (result.IsNotNull() && scale.IsNotNull())
   {
@@ -192,7 +192,7 @@ AssignConvertedTransform(ScaleSkewVersor3DTransformPointer &                resu
  */
 
 inline void
-AssignConvertedTransform(AffineTransformPointer & result, const ScaleVersor3DTransformType::ConstPointer scale)
+AssignConvertedTransform(AffineTransformPointer & result, const ScaleVersor3DTransformType::ConstPointer & scale)
 {
   if (result.IsNotNull() && scale.IsNotNull())
   {
@@ -216,7 +216,7 @@ AssignConvertedTransform(AffineTransformPointer & result, const ScaleVersor3DTra
  */
 
 inline void
-AssignConvertedTransform(ScaleVersor3DTransformPointer & result, const ScaleVersor3DTransformType::ConstPointer scale)
+AssignConvertedTransform(ScaleVersor3DTransformPointer & result, const ScaleVersor3DTransformType::ConstPointer & scale)
 {
   if (result.IsNotNull() && scale.IsNotNull())
   {
@@ -235,8 +235,8 @@ AssignConvertedTransform(ScaleVersor3DTransformPointer & result, const ScaleVers
  * AffineTransformPointer  :=  VersorRigid3DTransformPointer
  */
 inline void
-AssignConvertedTransform(AffineTransformPointer &                       result,
-                         const VersorRigid3DTransformType::ConstPointer versorTransform)
+AssignConvertedTransform(AffineTransformPointer &                         result,
+                         const VersorRigid3DTransformType::ConstPointer & versorTransform)
 {
   if (result.IsNotNull() && versorTransform.IsNotNull())
   {
@@ -262,8 +262,8 @@ AssignConvertedTransform(AffineTransformPointer &                       result,
  */
 
 inline void
-AssignConvertedTransform(VersorRigid3DTransformPointer &                result,
-                         const VersorRigid3DTransformType::ConstPointer versorRigid)
+AssignConvertedTransform(VersorRigid3DTransformPointer &                  result,
+                         const VersorRigid3DTransformType::ConstPointer & versorRigid)
 {
   if (result.IsNotNull() && versorRigid.IsNotNull())
   {
@@ -282,8 +282,8 @@ AssignConvertedTransform(VersorRigid3DTransformPointer &                result,
  * ScaleSkewVersor3DTransformPointer  :=  ScaleVersor3DTransformPointer
  */
 inline void
-AssignConvertedTransform(ScaleSkewVersor3DTransformPointer &            result,
-                         const ScaleVersor3DTransformType::ConstPointer scale)
+AssignConvertedTransform(ScaleSkewVersor3DTransformPointer &              result,
+                         const ScaleVersor3DTransformType::ConstPointer & scale)
 {
   if (result.IsNotNull() && scale.IsNotNull())
   {
@@ -305,8 +305,8 @@ AssignConvertedTransform(ScaleSkewVersor3DTransformPointer &            result,
  * ScaleSkewVersor3DTransformPointer  :=  VersorRigid3DTransformPointer
  */
 inline void
-AssignConvertedTransform(ScaleSkewVersor3DTransformPointer &            result,
-                         const VersorRigid3DTransformType::ConstPointer versorRigid)
+AssignConvertedTransform(ScaleSkewVersor3DTransformPointer &              result,
+                         const VersorRigid3DTransformType::ConstPointer & versorRigid)
 {
   if (result.IsNotNull() && versorRigid.IsNotNull())
   {
@@ -328,8 +328,8 @@ AssignConvertedTransform(ScaleSkewVersor3DTransformPointer &            result,
  */
 
 inline void
-AssignConvertedTransform(Similarity3DTransformPointer &                result,
-                         const Similarity3DTransformType::ConstPointer similarity3D)
+AssignConvertedTransform(Similarity3DTransformPointer &                  result,
+                         const Similarity3DTransformType::ConstPointer & similarity3D)
 {
   if (result.IsNotNull() && similarity3D.IsNotNull())
   {
@@ -348,8 +348,8 @@ AssignConvertedTransform(Similarity3DTransformPointer &                result,
  * ScaleVersor3DTransformPointer  :=  VersorRigid3DTransformPointer
  */
 inline void
-AssignConvertedTransform(ScaleVersor3DTransformPointer &                result,
-                         const VersorRigid3DTransformType::ConstPointer versorRigid)
+AssignConvertedTransform(ScaleVersor3DTransformPointer &                  result,
+                         const VersorRigid3DTransformType::ConstPointer & versorRigid)
 {
   if (result.IsNotNull() && versorRigid.IsNotNull())
   {
@@ -367,8 +367,8 @@ AssignConvertedTransform(ScaleVersor3DTransformPointer &                result,
 }
 
 inline void
-ExtractVersorRigid3DTransform(VersorRigid3DTransformPointer &                result,
-                              const ScaleVersor3DTransformType::ConstPointer scaleVersorRigid)
+ExtractVersorRigid3DTransform(VersorRigid3DTransformPointer &                  result,
+                              const ScaleVersor3DTransformType::ConstPointer & scaleVersorRigid)
 {
   if (result.IsNotNull() && scaleVersorRigid.IsNotNull())
   {
@@ -386,8 +386,8 @@ ExtractVersorRigid3DTransform(VersorRigid3DTransformPointer &                res
 }
 
 inline void
-ExtractVersorRigid3DTransform(VersorRigid3DTransformPointer &                    result,
-                              const ScaleSkewVersor3DTransformType::ConstPointer scaleSkewVersorRigid)
+ExtractVersorRigid3DTransform(VersorRigid3DTransformPointer &                      result,
+                              const ScaleSkewVersor3DTransformType::ConstPointer & scaleSkewVersorRigid)
 {
   if (result.IsNotNull() && scaleSkewVersorRigid.IsNotNull())
   {
@@ -405,8 +405,8 @@ ExtractVersorRigid3DTransform(VersorRigid3DTransformPointer &                   
 }
 
 inline void
-ExtractVersorRigid3DTransform(VersorRigid3DTransformPointer &                result,
-                              const VersorRigid3DTransformType::ConstPointer versorRigid)
+ExtractVersorRigid3DTransform(VersorRigid3DTransformPointer &                  result,
+                              const VersorRigid3DTransformType::ConstPointer & versorRigid)
 {
   if (result.IsNotNull() && versorRigid.IsNotNull())
   {
@@ -431,7 +431,7 @@ ExtractVersorRigid3DTransform(VersorRigid3DTransformPointer &                res
  * must clip out the null subspace, if any.
  */
 inline Matrix3D
-orthogonalize(const Matrix3D rotator)
+orthogonalize(const Matrix3D & rotator)
 {
   vnl_svd<double>                             decomposition(rotator.GetVnlMatrix().as_matrix(), -1E-6);
   vnl_diag_matrix<vnl_svd<double>::singval_t> Winverse(decomposition.Winverse());
@@ -457,7 +457,7 @@ orthogonalize(const Matrix3D rotator)
 }
 
 inline void
-ExtractVersorRigid3DTransform(VersorRigid3DTransformPointer & result, const AffineTransformType::ConstPointer affine)
+ExtractVersorRigid3DTransform(VersorRigid3DTransformPointer & result, const AffineTransformType::ConstPointer & affine)
 {
   if (result.IsNotNull() && affine.IsNotNull())
   {

--- a/BRAINSCommonLib/DWIMetaDataDictionaryValidator.cxx
+++ b/BRAINSCommonLib/DWIMetaDataDictionaryValidator.cxx
@@ -47,7 +47,7 @@ DWIMetaDataDictionaryValidator::GetGradientKeyString(int index) const
 
 
 void
-DWIMetaDataDictionaryValidator::SetStringDictObject(const std::string key, const std::string value)
+DWIMetaDataDictionaryValidator::SetStringDictObject(const std::string & key, const std::string & value)
 {
   itk::EncapsulateMetaData<std::string>(m_dict, key, value);
 }
@@ -229,7 +229,7 @@ DWIMetaDataDictionaryValidator::SetBValue(const double bvalue)
 }
 
 std::string
-DWIMetaDataDictionaryValidator::GetIndexedKeyString(const std::string base_key_name, const size_t index) const
+DWIMetaDataDictionaryValidator::GetIndexedKeyString(const std::string & base_key_name, const size_t index) const
 {
   std::ostringstream itos;
   itos << index;
@@ -279,7 +279,7 @@ DWIMetaDataDictionaryValidator::GenericSetDoubleVector(const std::vector<double>
 std::vector<std::string>
 DWIMetaDataDictionaryValidator::GenericGetStringVector(const std::string & KeyBaseName,
                                                        const size_t        numElements,
-                                                       const std::string   defaultValue) const
+                                                       const std::string & defaultValue) const
 {
   std::vector<std::string> values(numElements);
   for (size_t index = 0; index < values.size(); ++index)

--- a/BRAINSCommonLib/DWIMetaDataDictionaryValidator.h
+++ b/BRAINSCommonLib/DWIMetaDataDictionaryValidator.h
@@ -69,13 +69,13 @@ class DWIMetaDataDictionaryValidator
 private:
   itk::MetaDataDictionary m_dict;
   void
-  SetStringDictObject(const std::string, const std::string);
+  SetStringDictObject(const std::string &, const std::string &);
 
 protected:
   std::string
   GetGradientKeyString(int) const;
   std::string
-  GetIndexedKeyString(const std::string base_key_name, const size_t index) const;
+  GetIndexedKeyString(const std::string & base_key_name, const size_t index) const;
 
   void
   GenericSetStringVector(const std::vector<std::string> & values, const std::string & KeyBaseName);
@@ -85,7 +85,7 @@ protected:
   std::vector<std::string>
   GenericGetStringVector(const std::string & KeyBaseName,
                          const size_t        numElements,
-                         const std::string   defaultValue) const;
+                         const std::string & defaultValue) const;
 
   std::vector<double>
   GenericGetDoubleVector(const std::string & KeyBaseName, const size_t numElements, const double defaultValue) const;

--- a/BRAINSCommonLib/GenericTransformImage.cxx
+++ b/BRAINSCommonLib/GenericTransformImage.cxx
@@ -53,7 +53,7 @@
 namespace itk
 {
 itk::VersorRigid3DTransform<double>::Pointer
-ComputeRigidTransformFromGeneric(const itk::Transform<double, 3, 3>::ConstPointer genericTransformToWrite)
+ComputeRigidTransformFromGeneric(const itk::Transform<double, 3, 3>::ConstPointer & genericTransformToWrite)
 {
   using VersorRigid3DTransformType = itk::VersorRigid3DTransform<double>;
   using ScaleVersor3DTransformType = itk::ScaleVersor3DTransform<double>;

--- a/BRAINSCommonLib/GenericTransformImage.h
+++ b/BRAINSCommonLib/GenericTransformImage.h
@@ -69,14 +69,12 @@ namespace itk
  * \endcode
  */
 template <typename TInputScalarType, typename TWriteScalarType>
-extern void
-WriteTransformToDisk(itk::Transform<TInputScalarType, 3, 3> const * const MyTransform,
-                     const std::string &                                  TransformFilename);
+extern void WriteTransformToDisk(itk::Transform<TInputScalarType, 3, 3> const * const MyTransform,
+                                 const std::string &                                  TransformFilename);
 
 template <typename TScalarType>
-extern void
-WriteTransformToDisk(itk::Transform<TScalarType, 3, 3> const * const MyTransform,
-                     const std::string &                             TransformFilename);
+extern void WriteTransformToDisk(itk::Transform<TScalarType, 3, 3> const * const MyTransform,
+                                 const std::string &                             TransformFilename);
 
 /**
  * \author Hans J. Johnson
@@ -137,7 +135,7 @@ ReadTransformFromDisk(const std::string & initialTransform);
  * \endcode
  */
 extern itk::VersorRigid3DTransform<double>::Pointer
-ComputeRigidTransformFromGeneric(const itk::Transform<double, 3, 3>::ConstPointer genericTransformToWrite);
+ComputeRigidTransformFromGeneric(const itk::Transform<double, 3, 3>::ConstPointer & genericTransformToWrite);
 
 /**
  * \author Hans J. Johnson

--- a/BRAINSCommonLib/itkOtsuHistogramMatchingImageFilter.h
+++ b/BRAINSCommonLib/itkOtsuHistogramMatchingImageFilter.h
@@ -207,11 +207,11 @@ protected:
 
   /** Construct a histogram from an image. */
   void
-  ConstructHistogram(const InputImageType *                    image,
-                     const typename SpatialObjectType::Pointer mask,
-                     HistogramType *                           histogram,
-                     const THistogramMeasurement               minValue,
-                     const THistogramMeasurement               maxValue);
+  ConstructHistogram(const InputImageType *                      image,
+                     const typename SpatialObjectType::Pointer & mask,
+                     HistogramType *                             histogram,
+                     const THistogramMeasurement                 minValue,
+                     const THistogramMeasurement                 maxValue);
 
 private:
   unsigned long m_NumberOfHistogramLevels{ 256 };

--- a/BRAINSCommonLib/itkOtsuHistogramMatchingImageFilter.hxx
+++ b/BRAINSCommonLib/itkOtsuHistogramMatchingImageFilter.hxx
@@ -347,11 +347,11 @@ OtsuHistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasuremen
 template <typename TInputImage, typename TOutputImage, typename THistogramMeasurement>
 void
 OtsuHistogramMatchingImageFilter<TInputImage, TOutputImage, THistogramMeasurement>::ConstructHistogram(
-  const InputImageType *           image,
-  const SpatialObjectType::Pointer mask,
-  HistogramType *                  histogram,
-  const THistogramMeasurement      minValue,
-  const THistogramMeasurement      maxValue)
+  const InputImageType *             image,
+  const SpatialObjectType::Pointer & mask,
+  HistogramType *                    histogram,
+  const THistogramMeasurement        minValue,
+  const THistogramMeasurement        maxValue)
 {
   {
     // allocate memory for the histogram

--- a/BRAINSConstellationDetector/src/landmarksConstellationCommon.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationCommon.cxx
@@ -154,9 +154,9 @@ CreatedebugPlaneImage(SImageType::Pointer referenceImage, const std::string & de
 }
 
 SImageType::Pointer
-CreatedebugPlaneImage(SImageType::Pointer               referenceImage,
-                      const RigidTransformType::Pointer MSPTransform,
-                      const std::string &               debugfilename)
+CreatedebugPlaneImage(SImageType::Pointer                 referenceImage,
+                      const RigidTransformType::Pointer & MSPTransform,
+                      const std::string &                 debugfilename)
 {
   SImageType::PixelType low = 0;
 
@@ -448,9 +448,9 @@ computeTmspFromPoints(SImageType::PointType RP,
   orig.emplace_back(AC);
   orig.emplace_back(PC);
   SImagePointType NEWAC = DesiredCenter;
-//  NEWAC[0] = 0.0;
-//  NEWAC[1] = 0.0;
-//  NEWAC[2] = 0.0;
+  //  NEWAC[0] = 0.0;
+  //  NEWAC[1] = 0.0;
+  //  NEWAC[2] = 0.0;
   SImagePointType NEWPC;
   NEWPC[0] = 0.0;
   SImageType::PointType::VectorType ACPC = PC - AC;
@@ -468,7 +468,7 @@ computeTmspFromPoints(SImageType::PointType RP,
   // double theta = ACPC/
   const auto a = ACPC.GetVnlVector();
   const auto b = ACRP.GetVnlVector();
-  const auto rej = a - ( (dot_product(a, b) / dot_product(b, b)) * b);
+  const auto rej = a - ((dot_product(a, b) / dot_product(b, b)) * b);
   NEWRP[2] = -rej.magnitude();
 
   PointList final;
@@ -476,8 +476,8 @@ computeTmspFromPoints(SImageType::PointType RP,
   final.emplace_back(NEWAC);
   final.emplace_back(NEWPC);
 
-  //Now convert the result to a Euler Transform.
-  auto versorBaseTransform =  DoIt_Rigid(final, orig);
+  // Now convert the result to a Euler Transform.
+  auto                        versorBaseTransform = DoIt_Rigid(final, orig);
   RigidTransformType::Pointer result = RigidTransformType::New();
   result->SetIdentity();
   result->SetCenter(versorBaseTransform->GetCenter());
@@ -625,7 +625,7 @@ ShortToUChar(short in, short min, short max)
 }
 
 SImageType::Pointer
-CreateTestCenteredRotatedImage2(const RigidTransformType::Pointer ACPC_MSP_AlignedTransform,
+CreateTestCenteredRotatedImage2(const RigidTransformType::Pointer & ACPC_MSP_AlignedTransform,
                                 /* const
                                   SImageType::PointType
                                   finalPoint_MSP, */

--- a/BRAINSConstellationDetector/src/landmarksConstellationCommon.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationCommon.h
@@ -120,7 +120,7 @@ extern unsigned char
 ShortToUChar(short in, short min, short max);
 
 extern SImageType::Pointer
-CreateTestCenteredRotatedImage2(const RigidTransformType::Pointer ACPC_MSP_AlignedTransform,
+CreateTestCenteredRotatedImage2(const RigidTransformType::Pointer & ACPC_MSP_AlignedTransform,
                                 /* const
                                   SImageType::PointType
                                   finalPoint, */
@@ -150,9 +150,9 @@ ComputeMSP(SImageType::Pointer           input_image,
            double &                      cc);
 
 extern SImageType::Pointer
-CreatedebugPlaneImage(SImageType::Pointer               referenceImage,
-                      const RigidTransformType::Pointer MSPTransform,
-                      const std::string &               debugfilename);
+CreatedebugPlaneImage(SImageType::Pointer                 referenceImage,
+                      const RigidTransformType::Pointer & MSPTransform,
+                      const std::string &                 debugfilename);
 
 extern void
 CreatedebugPlaneImage(SImageType::Pointer referenceImage, const std::string & debugfilename);

--- a/BRAINSConstellationDetector/src/landmarksConstellationDetector.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationDetector.cxx
@@ -552,24 +552,21 @@ landmarksConstellationDetector::FindCandidatePoints(
 
       LandmarksMapType msp_lmks_algo_found; // named points in EMSP space
       msp_lmks_algo_found["CenterOfSearchArea"] = CenterOfSearchArea;
-      msp_lmks_algo_found["LPS_BEGIN"] =  LPS_BEGIN;
-      msp_lmks_algo_found["LPS_END"] =  LPS_END;
-      const std::string pointsName(this->m_ResultsDir + "/NCCOutput_" +
-                                      itksys::SystemTools::GetFilenameName(mapID) + "_" +
-                                      local_to_string(curr_rotationAngle_index) + "_markers.fcsv");
+      msp_lmks_algo_found["LPS_BEGIN"] = LPS_BEGIN;
+      msp_lmks_algo_found["LPS_END"] = LPS_END;
+      const std::string pointsName(this->m_ResultsDir + "/NCCOutput_" + itksys::SystemTools::GetFilenameName(mapID) +
+                                   "_" + local_to_string(curr_rotationAngle_index) + "_markers.fcsv");
       WriteITKtoSlicer3Lmk(pointsName, msp_lmks_algo_found);
 
       // Print the name of the file that is the master volume, the fixed image sample should
       // be aligned with this!
-      const std::string volumeMSPName(this->m_ResultsDir + "/NCCOutput_" +
-                                              itksys::SystemTools::GetFilenameName(mapID) + "_" +
-                                              local_to_string(curr_rotationAngle_index) + "_volumeMSP.nii.gz");
+      const std::string volumeMSPName(this->m_ResultsDir + "/NCCOutput_" + itksys::SystemTools::GetFilenameName(mapID) +
+                                      "_" + local_to_string(curr_rotationAngle_index) + "_volumeMSP.nii.gz");
       itkUtil::WriteImage<SImageType>(volumeMSP, volumeMSPName);
 
 
-      const std::string mask_LRName(this->m_ResultsDir + "/NCCOutput_" +
-                                      itksys::SystemTools::GetFilenameName(mapID) + "_" +
-                                      local_to_string(curr_rotationAngle_index) + "_mask_LRName.nii.gz");
+      const std::string mask_LRName(this->m_ResultsDir + "/NCCOutput_" + itksys::SystemTools::GetFilenameName(mapID) +
+                                    "_" + local_to_string(curr_rotationAngle_index) + "_mask_LRName.nii.gz");
       itkUtil::WriteImage<SImageType>(mask_LR, mask_LRName);
 
       const std::string ncc_output_name_fixed(this->m_ResultsDir + "/NCCOutput_" +
@@ -626,8 +623,8 @@ landmarksConstellationDetector::FindCandidatePoints(
 }
 
 void
-landmarksConstellationDetector::EulerToVersorRigid(VersorTransformType::Pointer &         result,
-                                                   const RigidTransformType::ConstPointer eulerRigid)
+landmarksConstellationDetector::EulerToVersorRigid(VersorTransformType::Pointer &           result,
+                                                   const RigidTransformType::ConstPointer & eulerRigid)
 {
   if (result.IsNotNull() && eulerRigid.IsNotNull())
   {
@@ -648,9 +645,9 @@ landmarksConstellationDetector::EulerToVersorRigid(VersorTransformType::Pointer 
 
 
 void
-landmarksConstellationDetector::DoResampleInPlace(const SImageType::ConstPointer         inputImg,
-                                                  const RigidTransformType::ConstPointer rigidTx,
-                                                  SImageType::Pointer &                  inPlaceResampledImg)
+landmarksConstellationDetector::DoResampleInPlace(const SImageType::ConstPointer &         inputImg,
+                                                  const RigidTransformType::ConstPointer & rigidTx,
+                                                  SImageType::Pointer &                    inPlaceResampledImg)
 {
   VersorTransformType::Pointer versorRigidTx = VersorTransformType::New();
   EulerToVersorRigid(versorRigidTx, rigidTx.GetPointer());

--- a/BRAINSConstellationDetector/src/landmarksConstellationDetector.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationDetector.h
@@ -123,7 +123,7 @@ public:
   }
 
   void
-  Setorig2eyeFixed_img_tfm(const VersorTransformType::Pointer houghEyeTransform)
+  Setorig2eyeFixed_img_tfm(const VersorTransformType::Pointer & houghEyeTransform)
   {
     this->m_orig2eyeFixed_img_tfm = houghEyeTransform;
   }
@@ -210,16 +210,16 @@ public:
 protected:
 private:
   void
-  EulerToVersorRigid(VersorTransformType::Pointer &, const RigidTransformType::ConstPointer);
+  EulerToVersorRigid(VersorTransformType::Pointer &, const RigidTransformType::ConstPointer &);
 
   void
-  DoResampleInPlace(const SImageType::ConstPointer, const RigidTransformType::ConstPointer, SImageType::Pointer &);
+  DoResampleInPlace(const SImageType::ConstPointer &, const RigidTransformType::ConstPointer &, SImageType::Pointer &);
 
   static VersorTransformType::Pointer
   Compute_orig2msp_img_tfm(const SImagePointType & RP, const SImagePointType & AC, const SImagePointType & PC);
 
   static bool
-  mapHasKey(const LandmarksMapType & map, const std::string key)
+  mapHasKey(const LandmarksMapType & map, const std::string & key)
   {
     return map.find(key) != map.cend();
   }

--- a/DWIConvert/DWIConvertLib.cxx
+++ b/DWIConvert/DWIConvertLib.cxx
@@ -208,10 +208,10 @@ DWIConvert::write()
 }
 
 DWIConverter *
-DWIConvert::CreateDicomConverter(const std::string inputDicomDirectory,
-                                 const bool        useBMatrixGradientDirections,
-                                 const double      smallGradientThreshold,
-                                 const bool        allowLossyConversion)
+DWIConvert::CreateDicomConverter(const std::string & inputDicomDirectory,
+                                 const bool          useBMatrixGradientDirections,
+                                 const double        smallGradientThreshold,
+                                 const bool          allowLossyConversion)
 {
   // check for required parameters
   if (inputDicomDirectory == emptyString)

--- a/DWIConvert/DWIConvertLib.h
+++ b/DWIConvert/DWIConvertLib.h
@@ -139,10 +139,10 @@ public:
 
 private:
   DWIConverter *
-  CreateDicomConverter(const std::string inputDicomDirectory,
-                       const bool        useBMatrixGradientDirections,
-                       const double      smallGradientThreshold,
-                       const bool        allowLossyConversion);
+  CreateDicomConverter(const std::string & inputDicomDirectory,
+                       const bool          useBMatrixGradientDirections,
+                       const double        smallGradientThreshold,
+                       const bool          allowLossyConversion);
 
   std::string m_inputFileType;
   std::string m_outputFileType;

--- a/DWIConvert/DWIConverter.cxx
+++ b/DWIConvert/DWIConverter.cxx
@@ -348,7 +348,7 @@ DWIConverter::MakeFileComment(const std::string & version,
                               bool                useBMatrixGradientDirections,
                               bool                useIdentityMeaseurementFrame,
                               double              smallGradientThreshold,
-                              const std::string   inputFileType) const
+                              const std::string & inputFileType) const
 {
   std::stringstream commentSection;
   {
@@ -375,7 +375,7 @@ DWIConverter::MakeFileComment(const std::string & version,
 }
 
 void
-DWIConverter::ManualWriteNRRDFile(const std::string & outputVolumeHeaderName, const std::string commentstring) const
+DWIConverter::ManualWriteNRRDFile(const std::string & outputVolumeHeaderName, const std::string & commentstring) const
 {
   const size_t extensionPos = outputVolumeHeaderName.find(".nhdr");
   const bool   nrrdSingleFileFormat = (extensionPos != std::string::npos) ? false : true;
@@ -640,8 +640,8 @@ DWIConverter::FourDToThreeDImage(Volume4DType::Pointer img4D) const
 
 void
 DWIConverter::WriteFSLFormattedFileSet(const std::string &   outputVolumeHeaderName,
-                                       const std::string     outputBValues,
-                                       const std::string     outputBVectors,
+                                       const std::string &   outputBValues,
+                                       const std::string &   outputBVectors,
                                        Volume4DType::Pointer img4D) const
 {
   const double trace = this->m_MeasurementFrame[0][0] * this->m_MeasurementFrame[1][1] * this->m_MeasurementFrame[2][2];

--- a/DWIConvert/DWIConverter.h
+++ b/DWIConvert/DWIConverter.h
@@ -197,10 +197,10 @@ public:
                   bool                useBMatrixGradientDirections,
                   bool                useIdentityMeaseurementFrame,
                   double              smallGradientThreshold,
-                  const std::string   inputFileType) const;
+                  const std::string & inputFileType) const;
 
   void
-  ManualWriteNRRDFile(const std::string & outputVolumeHeaderName, const std::string commentstring) const;
+  ManualWriteNRRDFile(const std::string & outputVolumeHeaderName, const std::string & commentstring) const;
   Volume4DType::Pointer
   ThreeDToFourDImage(Volume3DUnwrappedType::Pointer img) const;
 
@@ -212,8 +212,8 @@ public:
    */
   void
   WriteFSLFormattedFileSet(const std::string &   outputVolumeHeaderName,
-                           const std::string     outputBValues,
-                           const std::string     outputBVectors,
+                           const std::string &   outputBValues,
+                           const std::string &   outputBVectors,
                            Volume4DType::Pointer img4D) const;
 
 

--- a/DWIConvert/DWIConverterFactory.cxx
+++ b/DWIConvert/DWIConverterFactory.cxx
@@ -4,9 +4,9 @@
 
 #include "DWIConverterFactory.h"
 
-DWIConverterFactory::DWIConverterFactory(const std::string DicomDirectory,
-                                         const bool        UseBMatrixGradientDirections,
-                                         const double      smallGradientThreshold)
+DWIConverterFactory::DWIConverterFactory(const std::string & DicomDirectory,
+                                         const bool          UseBMatrixGradientDirections,
+                                         const double        smallGradientThreshold)
   : m_DicomDirectory(DicomDirectory)
   , m_UseBMatrixGradientDirections(UseBMatrixGradientDirections)
   , m_SmallGradientThreshold(smallGradientThreshold)

--- a/DWIConvert/DWIConverterFactory.h
+++ b/DWIConvert/DWIConverterFactory.h
@@ -37,9 +37,9 @@
 class DWIConverterFactory
 {
 public:
-  DWIConverterFactory(const std::string DicomDirectory,
-                      const bool        UseBMatrixGradientDirections,
-                      const double      smallGradientThreshold);
+  DWIConverterFactory(const std::string & DicomDirectory,
+                      const bool          UseBMatrixGradientDirections,
+                      const double        smallGradientThreshold);
 
   ~DWIConverterFactory();
 

--- a/DWIConvert/DWIDICOMConverterBase.cxx
+++ b/DWIConvert/DWIDICOMConverterBase.cxx
@@ -245,10 +245,10 @@ DWIDICOMConverterBase::LoadFromDisk()
  * @param vr "DCM_DS" for enumeration as indicated by vr in example above
  */
 void
-DWIDICOMConverterBase::_addToStringDictionary(const std::string dcm_primary_name,
-                                              const std::string dcm_seconary_name,
-                                              const std::string dcm_human_readable_name,
-                                              const enum VRType vr)
+DWIDICOMConverterBase::_addToStringDictionary(const std::string & dcm_primary_name,
+                                              const std::string & dcm_seconary_name,
+                                              const std::string & dcm_human_readable_name,
+                                              const enum VRType   vr)
 {
   int dcm_primary_code;
   {

--- a/DWIConvert/DWIDICOMConverterBase.h
+++ b/DWIConvert/DWIDICOMConverterBase.h
@@ -61,10 +61,10 @@ protected:
    * @param vr "DCM_DS" for enumeration as indicated by vr in example above
    */
   void
-  _addToStringDictionary(const std::string dcm_primary_name,
-                         const std::string dcm_seconary_name,
-                         const std::string dcm_human_readable_name,
-                         const enum VRType vr);
+  _addToStringDictionary(const std::string & dcm_primary_name,
+                         const std::string & dcm_seconary_name,
+                         const std::string & dcm_human_readable_name,
+                         const enum VRType   vr);
 
   /** the SliceOrderIS flag can be computed (as above) but if it's
    *  invariant, the derived classes can just set the flag. This method

--- a/DWIConvert/FSLDWIConverter.cxx
+++ b/DWIConvert/FSLDWIConverter.cxx
@@ -5,8 +5,8 @@
 #include "FSLDWIConverter.h"
 
 FSLDWIConverter::FSLDWIConverter(const DWIConverter::FileNamesContainer & inputFileNames,
-                                 const std::string                        inputBValues,
-                                 const std::string                        inputBVectors)
+                                 const std::string &                      inputBValues,
+                                 const std::string &                      inputBVectors)
   : DWIConverter(inputFileNames)
   , m_inputBValues(inputBValues)
   , m_inputBVectors(inputBVectors)

--- a/DWIConvert/FSLDWIConverter.h
+++ b/DWIConvert/FSLDWIConverter.h
@@ -26,8 +26,8 @@ class FSLDWIConverter : public DWIConverter
 {
 public:
   FSLDWIConverter(const DWIConverter::FileNamesContainer & inputFileNames,
-                  const std::string                        inputBValues,
-                  const std::string                        inputBVectors);
+                  const std::string &                      inputBValues,
+                  const std::string &                      inputBVectors);
 
   ~FSLDWIConverter() override = default;
 


### PR DESCRIPTION
Constant method parameters are copied during each method invocation. These parameters have been changed to pass-by-reference to avoid unnecessary, expensive copies.
This implements a portion of the 'performance-unnecessary-value-parm' clang-tidy check.
	The const qualified parameter 's' is copied for each invocation; consider making it a reference
