### PR TITLE
ENH: Converted non-constant method parameters used in a constant context to constant, pass by reference parameters.

### DIFF
--- a/BRAINSABC/brainseg/BRAINSABC.cxx
+++ b/BRAINSABC/brainseg/BRAINSABC.cxx
@@ -89,7 +89,7 @@ using ShortImagePointer = ShortImageType::Pointer;
  * \return either the absolute path, or the prepended path
  */
 static std::string
-FindPathFromAtlasXML(const std::string & xmlCodedPath, std::string atlasDefinitionPath)
+FindPathFromAtlasXML(const std::string & xmlCodedPath, const std::string & atlasDefinitionPath)
 {
   if (xmlCodedPath[0] != '/') // If not an absolute path, assume relative path
   {

--- a/BRAINSABC/brainseg/EMSParameters.cxx
+++ b/BRAINSABC/brainseg/EMSParameters.cxx
@@ -54,7 +54,7 @@ EMSParameters ::EMSParameters()
 }
 
 void
-EMSParameters ::AddImage(std::string s, std::string orient)
+EMSParameters ::AddImage(const std::string & s, const std::string & orient)
 {
   m_Images.push_back(s);
   m_ImageOrientations.push_back(orient);

--- a/BRAINSABC/brainseg/EMSParameters.h
+++ b/BRAINSABC/brainseg/EMSParameters.h
@@ -65,7 +65,7 @@ public:
   itkSetMacro(OutputFormat, std::string);
 
   void
-  AddImage(std::string s, std::string orient);
+  AddImage(const std::string & s, const std::string & orient);
 
   void
   ClearImages();

--- a/BRAINSCommonLib/BRAINSFitHelper.cxx
+++ b/BRAINSCommonLib/BRAINSFitHelper.cxx
@@ -47,7 +47,7 @@ debug_catch()
 
 // convert spatial object to image
 itk::Image<unsigned char, 3>::ConstPointer
-ExtractConstPointerToImageMaskFromImageSpatialObject(SpatialObjectType::ConstPointer inputSpatialObject)
+ExtractConstPointerToImageMaskFromImageSpatialObject(const SpatialObjectType::ConstPointer & inputSpatialObject)
 {
   using MaskImageType = itk::Image<unsigned char, 3>;
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject<MaskImageType::ImageDimension>;
@@ -65,7 +65,7 @@ ExtractConstPointerToImageMaskFromImageSpatialObject(SpatialObjectType::ConstPoi
 
 // convert image to mask (spatial object)
 itk::ImageMaskSpatialObject<3>::ConstPointer
-ConvertMaskImageToSpatialMask(itk::Image<unsigned char, 3>::ConstPointer inputImage)
+ConvertMaskImageToSpatialMask(const itk::Image<unsigned char, 3>::ConstPointer & inputImage)
 {
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject<3>;
   ImageMaskSpatialObjectType::Pointer mask = ImageMaskSpatialObjectType::New();

--- a/BRAINSCommonLib/BRAINSFitHelper.h
+++ b/BRAINSCommonLib/BRAINSFitHelper.h
@@ -205,7 +205,7 @@ public:
   itkGetConstMacro(WriteOutputTransformInFloat, bool);
 
   void
-  SetSamplingStrategy(std::string strategy)
+  SetSamplingStrategy(const std::string & strategy)
   {
     if (strategy == "Random")
     {

--- a/BRAINSCommonLib/BRAINSFitSyN.h
+++ b/BRAINSCommonLib/BRAINSFitSyN.h
@@ -33,16 +33,16 @@ using CompositeTransformType = RegistrationHelperType::CompositeTransformType;
 
 template <typename FixedImageType, typename MovingimageType>
 typename SyN::CompositeTransformType::Pointer
-simpleSynReg(typename FixedImageType::Pointer &              infixedImage,
-             typename MovingimageType::Pointer &             inmovingImage,
-             typename SyN::CompositeTransformType::Pointer   compositeInitialTransform,
-             typename SyN::CompositeTransformType::Pointer & internalSavedState,
-             typename FixedImageType::Pointer &              infixedImage2 = NULL,
-             typename MovingimageType::Pointer &             inmovingImage2 = NULL,
-             SyN::RealType                                   samplingPercentage = 1.0,
-             std::string                                     whichMetric = "cc",
-             const bool                                      synFull = true,
-             typename SyN::CompositeTransformType::Pointer   restoreState = nullptr)
+simpleSynReg(typename FixedImageType::Pointer &                    infixedImage,
+             typename MovingimageType::Pointer &                   inmovingImage,
+             const typename SyN::CompositeTransformType::Pointer & compositeInitialTransform,
+             typename SyN::CompositeTransformType::Pointer &       internalSavedState,
+             typename FixedImageType::Pointer &                    infixedImage2 = NULL,
+             typename MovingimageType::Pointer &                   inmovingImage2 = NULL,
+             SyN::RealType                                         samplingPercentage = 1.0,
+             const std::string &                                   whichMetric = "cc",
+             const bool                                            synFull = true,
+             const typename SyN::CompositeTransformType::Pointer & restoreState = nullptr)
 {
   typename SyN::RegistrationHelperType::Pointer regHelper = SyN::RegistrationHelperType::New();
   {

--- a/BRAINSCommonLib/BRAINSFitUtils.h
+++ b/BRAINSCommonLib/BRAINSFitUtils.h
@@ -43,10 +43,10 @@
  * ImageMaskSpatialObjectType
  */
 extern itk::Image<unsigned char, 3>::ConstPointer
-ExtractConstPointerToImageMaskFromImageSpatialObject(SpatialObjectType::ConstPointer inputSpatialObject);
+ExtractConstPointerToImageMaskFromImageSpatialObject(const SpatialObjectType::ConstPointer & inputSpatialObject);
 
 extern itk::ImageMaskSpatialObject<3>::ConstPointer
-ConvertMaskImageToSpatialMask(itk::Image<unsigned char, 3>::ConstPointer inputImage);
+ConvertMaskImageToSpatialMask(const itk::Image<unsigned char, 3>::ConstPointer & inputImage);
 
 template <typename TransformType, unsigned int VImageDimension>
 void

--- a/BRAINSCommonLib/ExtractSingleLargestRegion.cxx
+++ b/BRAINSCommonLib/ExtractSingleLargestRegion.cxx
@@ -27,11 +27,11 @@
 #include "ExtractSingleLargestRegion.h"
 
 itk::Image<unsigned char, 3>::Pointer
-ExtractSingleLargestRegionFromMask(itk::Image<unsigned char, 3>::Pointer Mask,
-                                   const int                             openingSize,
-                                   const int                             closingSize,
-                                   const int                             safetySize,
-                                   itk::Image<unsigned char, 3>::Pointer inputLabelImage)
+ExtractSingleLargestRegionFromMask(const itk::Image<unsigned char, 3>::Pointer & Mask,
+                                   const int                                     openingSize,
+                                   const int                                     closingSize,
+                                   const int                                     safetySize,
+                                   const itk::Image<unsigned char, 3>::Pointer & inputLabelImage)
 {
   using ByteImageType = itk::Image<unsigned char, 3>;
   using CCImageType = itk::Image<unsigned int, 3>;
@@ -132,12 +132,12 @@ ExtractSingleLargestRegionFromMask(itk::Image<unsigned char, 3>::Pointer Mask,
 }
 
 itk::Image<unsigned char, 3>::Pointer
-ExtractSingleLargestRegion(const unsigned char                   threshold_low,
-                           const unsigned char                   threshold_high,
-                           const int                             openingSize,
-                           const int                             closingSize,
-                           const int                             safetySize,
-                           itk::Image<unsigned char, 3>::Pointer inputLabelImage)
+ExtractSingleLargestRegion(const unsigned char                           threshold_low,
+                           const unsigned char                           threshold_high,
+                           const int                                     openingSize,
+                           const int                                     closingSize,
+                           const int                                     safetySize,
+                           const itk::Image<unsigned char, 3>::Pointer & inputLabelImage)
 {
   using ByteImageType = itk::Image<unsigned char, 3>;
   using BinaryThresholdFilter = itk::BinaryThresholdImageFilter<ByteImageType, ByteImageType>;

--- a/BRAINSCommonLib/ExtractSingleLargestRegion.h
+++ b/BRAINSCommonLib/ExtractSingleLargestRegion.h
@@ -22,18 +22,18 @@
 #include "itkImage.h"
 
 extern itk::Image<unsigned char, 3>::Pointer
-ExtractSingleLargestRegionFromMask(itk::Image<unsigned char, 3>::Pointer Mask,
-                                   const int                             openingSize,
-                                   const int                             closingSize,
-                                   const int                             safetySize,
-                                   itk::Image<unsigned char, 3>::Pointer inputLabelImage);
+ExtractSingleLargestRegionFromMask(const itk::Image<unsigned char, 3>::Pointer & Mask,
+                                   const int                                     openingSize,
+                                   const int                                     closingSize,
+                                   const int                                     safetySize,
+                                   const itk::Image<unsigned char, 3>::Pointer & inputLabelImage);
 
 extern itk::Image<unsigned char, 3>::Pointer
-ExtractSingleLargestRegion(const unsigned char                   threshold_low,
-                           const unsigned char                   threshold_high,
-                           const int                             openingSize,
-                           const int                             closingSize,
-                           const int                             safetySize,
-                           itk::Image<unsigned char, 3>::Pointer inputLabelImage);
+ExtractSingleLargestRegion(const unsigned char                           threshold_low,
+                           const unsigned char                           threshold_high,
+                           const int                                     openingSize,
+                           const int                                     closingSize,
+                           const int                                     safetySize,
+                           const itk::Image<unsigned char, 3>::Pointer & inputLabelImage);
 
 #endif // ExtractSingleLargestRegion_h

--- a/BRAINSConstellationDetector/src/BRAINSAlignMSP.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSAlignMSP.cxx
@@ -56,16 +56,16 @@
 #include "GenericTransformImage.h"
 template <typename TInputImagePixelType>
 int
-DoIt(std::string      inputVolume,
-     std::string      LandmarkPoints,
-     std::string      resampleMSP,
-     std::string      resampleMSPLandmarkPoints,
-     int              mspQualityLevel,
-     bool             rescaleIntensities,
-     double           trimRescaledIntensities,
-     std::vector<int> rescaleIntensitiesOutputRange,
-     std::string      backgroundFillValueString,
-     std::string      interpolationMode)
+DoIt(std::string         inputVolume,
+     const std::string & LandmarkPoints,
+     std::string         resampleMSP,
+     const std::string & resampleMSPLandmarkPoints,
+     int                 mspQualityLevel,
+     bool                rescaleIntensities,
+     double              trimRescaledIntensities,
+     std::vector<int>    rescaleIntensitiesOutputRange,
+     const std::string & backgroundFillValueString,
+     std::string         interpolationMode)
 {
   // /////////////////////////////////////////////////////////////////////////////////////////////
   // read information from the setup file, allocate some memories, and

--- a/BRAINSConstellationDetector/src/BRAINSConstellationDetectorPrimary.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSConstellationDetectorPrimary.cxx
@@ -74,7 +74,7 @@ BRAINSConstellationDetectorPrimary::BRAINSConstellationDetectorPrimary()
 
 BRAINSConstellationDetectorPrimary::ImagePointType
 BRAINSConstellationDetectorPrimary ::localFindCenterHeadFunc(
-  BRAINSConstellationDetectorPrimary::ImageType::ConstPointer img)
+  const BRAINSConstellationDetectorPrimary::ImageType::ConstPointer & img)
 {
   // ------------------------------------
   // Find center of head mass

--- a/BRAINSConstellationDetector/src/BRAINSConstellationDetectorPrimary.h
+++ b/BRAINSConstellationDetector/src/BRAINSConstellationDetectorPrimary.h
@@ -328,7 +328,7 @@ public:
 
 private:
   static std::vector<float> &
-  RAS2LPS(std::vector<float> & RASlmk, std::string name)
+  RAS2LPS(std::vector<float> & RASlmk, const std::string & name)
   {
     if (!RASlmk.empty())
     {
@@ -350,7 +350,7 @@ private:
     return RASlmk;
   }
   static ImagePointType
-  localFindCenterHeadFunc(ImageType::ConstPointer img);
+  localFindCenterHeadFunc(const ImageType::ConstPointer & img);
 
   int          m_houghEyeDetectorMode;      // 1
   unsigned int m_mspQualityLevel;           // 2

--- a/BRAINSConstellationDetector/src/BRAINSConstellationModeler.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSConstellationModeler.cxx
@@ -288,7 +288,7 @@ main(int argc, char * argv[])
 
     RigidTransformType::Pointer eyeFixed2msp_lmk_tfm =
       ComputeMSP(image, orig_lmk_CenterOfHeadMass, mspQualityLevel, c_c);
-    const SImageType::PixelType minPixelValue = [](SImageType::Pointer im) -> SImageType::PixelType {
+    const SImageType::PixelType minPixelValue = [](const SImageType::Pointer & im) -> SImageType::PixelType {
       using StatisticsFilterType = itk::StatisticsImageFilter<SImageType>;
       StatisticsFilterType::Pointer statisticsFilter = StatisticsFilterType::New();
       statisticsFilter->SetInput(im);

--- a/BRAINSConstellationDetector/src/BRAINSHoughEyeDetector.hxx
+++ b/BRAINSConstellationDetector/src/BRAINSHoughEyeDetector.hxx
@@ -29,8 +29,8 @@ namespace itk
 
 template <typename TInputImage, typename TOutputImage>
 typename TOutputImage::Pointer
-RigidResampleInPlayByVersor3D(const typename TInputImage::ConstPointer & image,
-                              VersorRigid3DTransform<double>::Pointer    versorRigid3DTfm)
+RigidResampleInPlayByVersor3D(const typename TInputImage::ConstPointer &      image,
+                              const VersorRigid3DTransform<double>::Pointer & versorRigid3DTfm)
 {
   /** The output image will have exact the same index contents
    but with modified image info so that the index-to-physical mapping

--- a/BRAINSConstellationDetector/src/BRAINSLinearModelerEPCA.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSLinearModelerEPCA.cxx
@@ -47,7 +47,7 @@ main(int argc, char * argv[])
 }
 
 void
-CreateLmkDB(std::string filename, LmkDBType & baseLmkDB, LmkDBType & EPCALmkDB)
+CreateLmkDB(const std::string & filename, LmkDBType & baseLmkDB, LmkDBType & EPCALmkDB)
 {
   // Read in list of landmark list file
   std::ifstream myfile(filename.c_str());

--- a/BRAINSConstellationDetector/src/BRAINSLinearModelerEPCA.h
+++ b/BRAINSConstellationDetector/src/BRAINSLinearModelerEPCA.h
@@ -59,7 +59,7 @@ BRAINSLinearModelerEPCAPrimary(int argc, char * argv[]);
  * filename ...
  */
 void
-CreateLmkDB(std::string filename, LmkDBType & baseLmkDB, LmkDBType & EPCALmkDB);
+CreateLmkDB(const std::string & filename, LmkDBType & baseLmkDB, LmkDBType & EPCALmkDB);
 
 /*
  * Initialize X_i matrix from base landmarks

--- a/BRAINSConstellationDetector/src/BRAINSLmkTransform.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSLmkTransform.cxx
@@ -85,7 +85,7 @@ using ImageType = itk::Image<PixelType, ImageDimension>;
 using LandmarksVectorType = std::vector<ImageType::PointType>;
 
 LandmarksVectorType
-LoadLandmarks(std::string filename);
+LoadLandmarks(const std::string & filename);
 
 int
 main(int argc, char * argv[])
@@ -241,7 +241,7 @@ main(int argc, char * argv[])
 }
 
 LandmarksVectorType
-LoadLandmarks(std::string filename)
+LoadLandmarks(const std::string & filename)
 {
   LandmarksVectorType landmarks;
   std::string         line;

--- a/BRAINSConstellationDetector/src/PrepareOutputImages.cxx
+++ b/BRAINSConstellationDetector/src/PrepareOutputImages.cxx
@@ -42,16 +42,16 @@ GetNamedPointFromLandmarkList(const LandmarksMapType & landmarks, const std::str
 }
 
 void
-PrepareOutputImages(SImageType::Pointer &             lOutputResampledImage,
-                    SImageType::Pointer &             lOutputImage,
-                    SImageType::Pointer &             lOutputUntransformedClippedVolume,
-                    SImageType::ConstPointer          lImageToBeResampled,
-                    VersorTransformType::ConstPointer lVersorTransform,
-                    const double                      lACLowerBound,
-                    const short int                   BackgroundFillValue,
-                    const std::string &               lInterpolationMode,
-                    const bool                        lCutOutHeadInOutputVolume,
-                    const double                      lOtsuPercentileThreshold)
+PrepareOutputImages(SImageType::Pointer &                     lOutputResampledImage,
+                    SImageType::Pointer &                     lOutputImage,
+                    SImageType::Pointer &                     lOutputUntransformedClippedVolume,
+                    const SImageType::ConstPointer &          lImageToBeResampled,
+                    const VersorTransformType::ConstPointer & lVersorTransform,
+                    const double                              lACLowerBound,
+                    const short int                           BackgroundFillValue,
+                    const std::string &                       lInterpolationMode,
+                    const bool                                lCutOutHeadInOutputVolume,
+                    const double                              lOtsuPercentileThreshold)
 {
   using ResampleIPFilterType = ResampleInPlaceImageFilter<SImageType, SImageType>;
   using ResampleIPFilterPointer = ResampleIPFilterType::Pointer;
@@ -167,9 +167,9 @@ PrepareOutputImages(SImageType::Pointer &             lOutputResampledImage,
 }
 
 void
-ApplyInverseOfTransformToLandmarks(VersorTransformType::ConstPointer lVersorTransform,
-                                   const LandmarksMapType &          inputLmks,
-                                   LandmarksMapType &                outputLmks)
+ApplyInverseOfTransformToLandmarks(const VersorTransformType::ConstPointer & lVersorTransform,
+                                   const LandmarksMapType &                  inputLmks,
+                                   LandmarksMapType &                        outputLmks)
 {
   VersorTransformType::Pointer lInvVersorTransform = VersorTransformType::New();
   {

--- a/BRAINSConstellationDetector/src/PrepareOutputImages.h
+++ b/BRAINSConstellationDetector/src/PrepareOutputImages.h
@@ -29,20 +29,20 @@ extern SImageType::PointType
 GetNamedPointFromLandmarkList(const LandmarksMapType & landmarks, const std::string & NamedPoint);
 
 extern void
-PrepareOutputImages(SImageType::Pointer &             lOutputResampledImage,
-                    SImageType::Pointer &             lOutputImage,
-                    SImageType::Pointer &             lOutputUntransformedClippedVolume,
-                    SImageType::ConstPointer          lImageToBeResampled,
-                    VersorTransformType::ConstPointer lVersorTransform,
-                    const double                      lACLowerBound,
-                    const short int                   BackgroundFillValue,
-                    const std::string &               lInterpolationMode,
-                    const bool                        lCutOutHeadInOutputVolume,
-                    const double                      lOtsuPercentileThreshold);
+PrepareOutputImages(SImageType::Pointer &                     lOutputResampledImage,
+                    SImageType::Pointer &                     lOutputImage,
+                    SImageType::Pointer &                     lOutputUntransformedClippedVolume,
+                    const SImageType::ConstPointer &          lImageToBeResampled,
+                    const VersorTransformType::ConstPointer & lVersorTransform,
+                    const double                              lACLowerBound,
+                    const short int                           BackgroundFillValue,
+                    const std::string &                       lInterpolationMode,
+                    const bool                                lCutOutHeadInOutputVolume,
+                    const double                              lOtsuPercentileThreshold);
 
 extern void
-ApplyInverseOfTransformToLandmarks(VersorTransformType::ConstPointer lVersorTransform,
-                                   const LandmarksMapType &          inputLmks,
-                                   LandmarksMapType &                outputLmks);
+ApplyInverseOfTransformToLandmarks(const VersorTransformType::ConstPointer & lVersorTransform,
+                                   const LandmarksMapType &                  inputLmks,
+                                   LandmarksMapType &                        outputLmks);
 } // namespace itk
 #endif // __PrepareOutputImages_h__

--- a/BRAINSConstellationDetector/src/landmarkIO.cxx
+++ b/BRAINSConstellationDetector/src/landmarkIO.cxx
@@ -28,7 +28,7 @@
 #include "itkNumberToString.h"
 
 RGBImageType::Pointer
-ReturnOrientedRGBImage(SImageType::Pointer inputImage)
+ReturnOrientedRGBImage(const SImageType::Pointer & inputImage)
 {
   RGBImageType::Pointer orientedImage;
 
@@ -79,7 +79,7 @@ ReturnOrientedRGBImage(SImageType::Pointer inputImage)
 }
 
 RGB2DImageType::Pointer
-GenerateRGB2DImage(RGBImageType::Pointer orientedImage)
+GenerateRGB2DImage(const RGBImageType::Pointer & orientedImage)
 {
   // Alocate 2DImage
   RGB2DImageType::Pointer   TwoDImage = RGB2DImageType::New();
@@ -420,15 +420,15 @@ MakeBranded2DImage(SImageType::ConstPointer         in,
 // INFO:  Determine what the interface for WriteMRMLFile really needs to produce
 // a useful file, and then limit the interface to just that.
 extern void
-WriteMRMLFile(std::string                                   outputMRML,
-              std::string                                   outputLandmarksInInputSpace,
-              std::string                                   outputLandmarksInOutputSpace,
-              std::string                                   inputVolume,
-              std::string                                   outputVolume,
-              std::string                                   outputTransform,
-              const LandmarksMapType &                      outputLandmarksInInputSpaceMap,
-              const LandmarksMapType &                      outputLandmarksInOutputSpaceMap,
-              LandmarkIO::VersorTransformType::ConstPointer versorTransform)
+WriteMRMLFile(const std::string &                                   outputMRML,
+              std::string                                           outputLandmarksInInputSpace,
+              std::string                                           outputLandmarksInOutputSpace,
+              const std::string &                                   inputVolume,
+              const std::string &                                   outputVolume,
+              const std::string &                                   outputTransform,
+              const LandmarksMapType &                              outputLandmarksInInputSpaceMap,
+              const LandmarksMapType &                              outputLandmarksInOutputSpaceMap,
+              const LandmarkIO::VersorTransformType::ConstPointer & versorTransform)
 {
   constexpr unsigned int      LocalImageDimension = 3;
   itk::NumberToString<double> doubleToString;
@@ -730,7 +730,7 @@ WriteMRMLFile(std::string                                   outputMRML,
 }
 
 void
-loadLLSModel(std::string                                     llsModelFilename,
+loadLLSModel(const std::string &                             llsModelFilename,
              std::map<std::string, std::vector<double>> &    llsMeans,
              std::map<std::string, LandmarkIO::MatrixType> & llsMatrices,
              std::map<std::string, double> &                 searchRadii)
@@ -833,9 +833,9 @@ loadLLSModel(std::string                                     llsModelFilename,
 }
 
 void
-writeVerificationScript(std::string outputVerificationScriptFilename,
-                        std::string outputVolume,
-                        std::string saveOutputLandmarksFilename)
+writeVerificationScript(const std::string & outputVerificationScriptFilename,
+                        const std::string & outputVolume,
+                        const std::string & saveOutputLandmarksFilename)
 {
   std::ofstream ScriptFile;
 

--- a/BRAINSConstellationDetector/src/landmarkIO.h
+++ b/BRAINSConstellationDetector/src/landmarkIO.h
@@ -73,20 +73,20 @@ MakeBranded2DImage(SImageType::ConstPointer         in,
 
 // Write Slicer scene file (.mrml)
 extern void
-WriteMRMLFile(std::string                                   outputMRML,
-              std::string                                   outputLandmarksInInputSpace,
-              std::string                                   outputLandmarksInOutputSpace,
-              std::string                                   inputVolume,
-              std::string                                   outputVolume,
-              std::string                                   outputTransform,
-              const LandmarksMapType &                      outputLandmarksInInputSpaceMap,
-              const LandmarksMapType &                      outputLandmarksInOutputSpaceMap,
-              LandmarkIO::VersorTransformType::ConstPointer versorTransform);
+WriteMRMLFile(const std::string &                                   outputMRML,
+              std::string                                           outputLandmarksInInputSpace,
+              std::string                                           outputLandmarksInOutputSpace,
+              const std::string &                                   inputVolume,
+              const std::string &                                   outputVolume,
+              const std::string &                                   outputTransform,
+              const LandmarksMapType &                              outputLandmarksInInputSpaceMap,
+              const LandmarksMapType &                              outputLandmarksInOutputSpaceMap,
+              const LandmarkIO::VersorTransformType::ConstPointer & versorTransform);
 
 // load linear least squares model for selected landmarks
 // .load from txt file
 extern void
-loadLLSModel(std::string                                     llsModelFilename,
+loadLLSModel(const std::string &                             llsModelFilename,
              std::map<std::string, std::vector<double>> &    llsMeans,
              std::map<std::string, LandmarkIO::MatrixType> & llsMatrices,
              std::map<std::string, double> &                 searchRadii);
@@ -114,8 +114,8 @@ readLLSModel(const std::string &                             modelName,
 
 // write out verification script
 extern void
-writeVerificationScript(std::string outputVerificationScriptFilename,
-                        std::string outputVolume,
-                        std::string saveOutputLandmarksFilename);
+writeVerificationScript(const std::string & outputVerificationScriptFilename,
+                        const std::string & outputVolume,
+                        const std::string & saveOutputLandmarksFilename);
 
 #endif // __landmarkIO__h

--- a/BRAINSConstellationDetector/src/landmarksConstellationCommon.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationCommon.cxx
@@ -249,7 +249,7 @@ CreatedebugPlaneImage(SImageType::Pointer                 referenceImage,
 
 
 PyramidFilterType::Pointer
-MakeThreeLevelPyramid(SImageType::Pointer refImage)
+MakeThreeLevelPyramid(const SImageType::Pointer & refImage)
 {
   PyramidFilterType::ScheduleType pyramidSchedule;
 
@@ -279,7 +279,7 @@ MakeThreeLevelPyramid(SImageType::Pointer refImage)
 }
 
 PyramidFilterType::Pointer
-MakeOneLevelPyramid(SImageType::Pointer refImage)
+MakeOneLevelPyramid(const SImageType::Pointer & refImage)
 {
   PyramidFilterType::ScheduleType pyramidSchedule;
 
@@ -375,7 +375,7 @@ computeSymmetricScale(const std::vector<itk::Point<double, 3>> & fixedPoints,
 } // namespace
 
 SimilarityTransformType::Pointer
-DoIt_Similarity(PointList fixedPoints, PointList movingPoints)
+DoIt_Similarity(const PointList & fixedPoints, const PointList & movingPoints)
 {
   // Our input into landmark based initialize will be of this form
   // The format for saving to slicer is defined later
@@ -408,7 +408,7 @@ DoIt_Similarity(PointList fixedPoints, PointList movingPoints)
 
 
 VersorRigidTransformType::Pointer
-DoIt_Rigid(PointList fixedPoints, PointList movingPoints)
+DoIt_Rigid(const PointList & fixedPoints, const PointList & movingPoints)
 {
   // Our input into landmark based initialize will be of this form
   // The format for saving to slicer is defined later
@@ -592,7 +592,7 @@ decomposeRPAC(const SImageType::PointType & RP,
 
 
 void
-extractArray(LinearInterpolatorType::Pointer                                imInterp,
+extractArray(const LinearInterpolatorType::Pointer &                        imInterp,
              const SImageType::PointType &                                  CenterPoint,
              const landmarksConstellationModelIO::IndexLocationVectorType & model,
              std::vector<float> &                                           result_array)
@@ -657,7 +657,7 @@ CreateTestCenteredRotatedImage2(const RigidTransformType::Pointer & ACPC_MSP_Ali
 // using PointType = landmarksDataSet::PointType;
 
 void
-MakeLabelImage(SImageType::Pointer           in,
+MakeLabelImage(const SImageType::Pointer &   in,
                const SImageType::PointType & RP,
                const SImageType::PointType & AC,
                const SImageType::PointType & PC,

--- a/BRAINSConstellationDetector/src/landmarksConstellationCommon.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationCommon.h
@@ -108,10 +108,10 @@ using LinearInterpolatorType = itk::LinearInterpolateImageFunction<SImageType, d
 extern std::string globalResultsDir;
 extern int         globalImagedebugLevel;
 extern PyramidFilterType::Pointer
-MakeThreeLevelPyramid(SImageType::Pointer refImage);
+MakeThreeLevelPyramid(const SImageType::Pointer & refImage);
 
 extern PyramidFilterType::Pointer
-MakeOneLevelPyramid(SImageType::Pointer refImage);
+MakeOneLevelPyramid(const SImageType::Pointer & refImage);
 
 extern SImageType::PointType
 GetImageCenterPhysicalPoint(SImageType::Pointer & image);
@@ -136,7 +136,7 @@ decomposeRPAC(const SImageType::PointType & RP,
               double * const                RPAC_over_RPPC);
 
 extern void
-MakeLabelImage(SImageType::Pointer           in,
+MakeLabelImage(const SImageType::Pointer &   in,
                const SImageType::PointType & RP,
                const SImageType::PointType & AC,
                const SImageType::PointType & PC,
@@ -287,7 +287,7 @@ removeVectorMean(std::vector<ValuesType> & x)
  * @param result_array
  */
 extern void
-extractArray(LinearInterpolatorType::Pointer                                imInterp,
+extractArray(const LinearInterpolatorType::Pointer &                        imInterp,
              const SImageType::PointType &                                  CenterPoint,
              const landmarksConstellationModelIO::IndexLocationVectorType & model,
              std::vector<float> &                                           result_array);
@@ -368,9 +368,9 @@ using VersorRigidTransformType = itk::VersorRigid3DTransform<double>;
 using SimilarityTransformType = itk::Similarity3DTransform<double>;
 
 extern SimilarityTransformType::Pointer
-DoIt_Similarity(PointList fixedPoints, PointList movingPoints);
+DoIt_Similarity(const PointList & fixedPoints, const PointList & movingPoints);
 
 extern VersorRigidTransformType::Pointer
-DoIt_Rigid(PointList fixedPoints, PointList movingPoints);
+DoIt_Rigid(const PointList & fixedPoints, const PointList & movingPoints);
 
 #endif //__landmarksConstellationCommon_h

--- a/BRAINSConstellationDetector/src/landmarksConstellationDetector.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationDetector.cxx
@@ -47,7 +47,7 @@ local_to_string(unsigned int i)
 
 VersorTransformType::Pointer
 landmarksConstellationDetector::GetLandmarkTransformFromImageTransform(
-  VersorTransformType::ConstPointer orig2msp_img_tfm)
+  const VersorTransformType::ConstPointer & orig2msp_img_tfm)
 {
   VersorTransformType::Pointer orig2msp_lmk_tfm = VersorTransformType::New();
   SImageType::PointType        centerPoint = orig2msp_img_tfm->GetCenter();
@@ -81,8 +81,9 @@ landmarksConstellationDetector::Compute_orig2msp_img_tfm(const SImagePointType &
 }
 
 void
-landmarksConstellationDetector::ComputeFinalRefinedACPCAlignedTransform(SImageType::Pointer      original_space_image,
-                                                                        const LandmarksMapType & updated_orig_lmks)
+landmarksConstellationDetector::ComputeFinalRefinedACPCAlignedTransform(
+  const SImageType::Pointer & original_space_image,
+  const LandmarksMapType &    updated_orig_lmks)
 {
   ////////////////////////////
   // START BRAINSFit alternative
@@ -280,11 +281,11 @@ landmarksConstellationDetector::GetImageOrigToACPCVersorTransform() const
 
 SImageType::PointType
 landmarksConstellationDetector::FindCandidatePoints(
-  SImageType::Pointer volumeMSP,
-  SImageType::Pointer mask_LR,
-  const double        LR_restrictions,
-  const double        PA_restrictions,
-  const double        SI_restrictions,
+  const SImageType::Pointer & volumeMSP,
+  const SImageType::Pointer & mask_LR,
+  const double                LR_restrictions,
+  const double                PA_restrictions,
+  const double                SI_restrictions,
   // INFO: restrictions should really be ellipsoidal values
   const SImageType::PointType::VectorType &                      CenterOfSearchArea,
   const std::vector<std::vector<float>> &                        TemplateMean,

--- a/BRAINSConstellationDetector/src/landmarksConstellationDetector.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationDetector.h
@@ -101,7 +101,7 @@ public:
   }
 
   double
-  GetModelRadius(std::string PointName)
+  GetModelRadius(const std::string & PointName)
   {
     return m_InputTemplateModel.GetRadius(PointName);
   }
@@ -157,7 +157,7 @@ public:
   Compute(SImageType::Pointer orig_space_image);
 
   SImageType::Pointer
-  GetTaggedImage(SImageType::Pointer original_space_image) const
+  GetTaggedImage(const SImageType::Pointer & original_space_image) const
   {
     itk::ImageDuplicator<SImageType>::Pointer duplicator = itk::ImageDuplicator<SImageType>::New();
 
@@ -204,8 +204,8 @@ public:
   VersorTransformType::Pointer
   GetImageOrigToACPCVersorTransform() const;
   void
-  ComputeFinalRefinedACPCAlignedTransform(SImageType::Pointer      original_space_image,
-                                          const LandmarksMapType & updated_orig_lmks);
+  ComputeFinalRefinedACPCAlignedTransform(const SImageType::Pointer & original_space_image,
+                                          const LandmarksMapType &    updated_orig_lmks);
 
 protected:
 private:
@@ -225,7 +225,7 @@ private:
   }
 
   static VersorTransformType::Pointer
-  GetLandmarkTransformFromImageTransform(VersorTransformType::ConstPointer orig2msp_img_tfm);
+  GetLandmarkTransformFromImageTransform(const VersorTransformType::ConstPointer & orig2msp_img_tfm);
   // Linear model estimation using EPCA
   void
   LinearEstimation(LandmarksMapType &               msp_lmks_linearly_estimated,
@@ -253,11 +253,11 @@ private:
                                 int                               sign);
 
   SImageType::PointType
-  FindCandidatePoints(SImageType::Pointer volumeMSP,
-                      SImageType::Pointer mask_LR,
-                      const double        LR_restrictions,
-                      const double        PA_restrictions,
-                      const double        SI_restrictions,
+  FindCandidatePoints(const SImageType::Pointer & volumeMSP,
+                      const SImageType::Pointer & mask_LR,
+                      const double                LR_restrictions,
+                      const double                PA_restrictions,
+                      const double                SI_restrictions,
                       // INFO: restrictions should really be ellipsoidal values
                       const SImageType::PointType::VectorType &                      CenterOfSearchArea,
                       const std::vector<std::vector<float>> &                        TemplateMean,

--- a/BRAINSConstellationDetector/src/landmarksConstellationDetectorCompute.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationDetectorCompute.cxx
@@ -23,7 +23,7 @@ static bool
 lmk_check_differences(const LandmarksMapType & ref,
                       const LandmarksMapType & cmp,
                       const bool               backward_compare,
-                      std::string              filename,
+                      const std::string &      filename,
                       int                      lineno)
 {
   std::cerr << "===" << lineno << " " << filename << std::endl;
@@ -82,7 +82,7 @@ landmarksConstellationDetector::Compute(SImageType::Pointer orig_space_image)
   this->m_eyeFixed2msp_img_tfm =
     ComputeMSP(this->m_eyeFixed_img, eyeFixed_lmk_CenterOfHeadMass, this->m_mspQualityLevel, c_c);
   {
-    const SImageType::PixelType minPixelValue = [](SImageType::Pointer im) -> SImageType::PixelType {
+    const SImageType::PixelType minPixelValue = [](const SImageType::Pointer & im) -> SImageType::PixelType {
       using StatisticsFilterType = itk::StatisticsImageFilter<SImageType>;
       StatisticsFilterType::Pointer statisticsFilter = StatisticsFilterType::New();
       statisticsFilter->SetInput(im);

--- a/BRAINSConstellationDetector/src/landmarksConstellationModelIO.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationModelIO.h
@@ -120,7 +120,7 @@ public:
   }
 
   void
-  SetRPtoXMean(std::string name, const SImageType::PointType::VectorType & RPtoXMean)
+  SetRPtoXMean(const std::string & name, const SImageType::PointType::VectorType & RPtoXMean)
   {
     this->m_RPtoXMean[name] = RPtoXMean;
   }
@@ -150,7 +150,7 @@ public:
   }
 
   const SImageType::PointType::VectorType &
-  GetRPtoXMean(std::string name)
+  GetRPtoXMean(const std::string & name)
   {
     return this->m_RPtoXMean[name];
   }
@@ -227,7 +227,7 @@ public:
 
   // Access the internal memory locations for modification.
   FloatVectorType &
-  AccessTemplate(std::string name, const unsigned int indexDataSet, const unsigned int indexAngle)
+  AccessTemplate(const std::string & name, const unsigned int indexDataSet, const unsigned int indexAngle)
   {
     if (this->m_Templates.find(name) == this->m_Templates.end())
     {
@@ -238,7 +238,7 @@ public:
 
   // Access the mean vectors of templates
   const FloatVectorType &
-  AccessTemplateMean(std::string name, const unsigned int indexAngle)
+  AccessTemplateMean(const std::string & name, const unsigned int indexAngle)
   {
     if (this->m_TemplateMeansComputed.find(name) == this->m_TemplateMeansComputed.end() ||
         this->m_Templates.find(name) == this->m_Templates.end())
@@ -250,7 +250,7 @@ public:
   }
 
   const Float2DVectorType &
-  AccessAllTemplateMeans(std::string name)
+  AccessAllTemplateMeans(const std::string & name)
   {
     if (this->m_TemplateMeansComputed.find(name) == this->m_TemplateMeansComputed.end() &&
         this->m_Templates.find(name) == this->m_Templates.end())
@@ -532,7 +532,7 @@ public:
   };
 
   void
-  WritedebugMeanImages(std::string name)
+  WritedebugMeanImages(const std::string & name)
   {
     debugImageDescriptor DID(this->m_TemplateMeans[name], this->GetRadius(name), this->GetHeight(name), "");
 

--- a/BRAINSLabelStats/BRAINSLabelStats.cxx
+++ b/BRAINSLabelStats/BRAINSLabelStats.cxx
@@ -46,7 +46,7 @@ PURPOSE.  See the above copyright notices for more information.
 
 
 std::string
-GetXmlLabelName(std::string fileName, int label)
+GetXmlLabelName(const std::string & fileName, int label)
 {
   // Set default return value
   std::string labelName = "Error";
@@ -90,7 +90,7 @@ GetXmlLabelName(std::string fileName, int label)
 }
 
 std::string
-GetAntsLabelName(std::string fileName, int label)
+GetAntsLabelName(const std::string & fileName, int label)
 {
   // Set default return value
   std::string labelName = "Error";
@@ -138,7 +138,7 @@ GetAntsLabelName(std::string fileName, int label)
 }
 
 std::string
-GetLabelName(int mode, std::string fileName, int label)
+GetLabelName(int mode, const std::string & fileName, int label)
 {
   switch (mode)
   {

--- a/BRAINSLandmarkInitializer/BRAINSLandmarkInitializer.cxx
+++ b/BRAINSLandmarkInitializer/BRAINSLandmarkInitializer.cxx
@@ -102,9 +102,9 @@ ComputeIsotropicScaleFactor(const LandmarkPointContainer & fixedLmks,
 }
 
 void
-PreProcessLandmarkFiles(std::string              inputFixedLandmarkFilename,
-                        std::string              inputMovingLandmarkFilename,
-                        std::string              inputWeightFilename,
+PreProcessLandmarkFiles(const std::string &      inputFixedLandmarkFilename,
+                        const std::string &      inputMovingLandmarkFilename,
+                        const std::string &      inputWeightFilename,
                         LandmarkPointContainer & fixedLmks,
                         LandmarkPointContainer & movingLmks,
                         LandmarkWeightType &     landmarkWgts)

--- a/BRAINSSnapShotWriter/BRAINSSnapShotWriter.cxx
+++ b/BRAINSSnapShotWriter/BRAINSSnapShotWriter.cxx
@@ -50,7 +50,7 @@ template <typename TImageType>
 ExtractIndexType
 GetSliceIndexToExtract(typename TImageType::Pointer referenceImage,
                        std::vector<int>             planes,
-                       IndexType                    inputSliceToExtractInIndex,
+                       const IndexType &            inputSliceToExtractInIndex,
                        PercentIndexType             inputSliceToExtractInPercent,
                        PhysicalPointIndexType       inputSliceToExtractInPhysicalPoint)
 {

--- a/ConvertBetweenFileFormats/castconverthelpers.h
+++ b/ConvertBetweenFileFormats/castconverthelpers.h
@@ -120,7 +120,7 @@ PrintInfo(ReaderType reader, WriterType writer)
  */
 template <typename InputImageType, typename OutputImageType>
 void
-ReadDicomSeriesCastWriteImage(std::string inputDirectoryName, std::string outputFileName)
+ReadDicomSeriesCastWriteImage(const std::string & inputDirectoryName, const std::string & outputFileName)
 {
   /** Typedef the correct reader, caster and writer. */
   using SeriesReaderType = typename itk::ImageSeriesReader<InputImageType>;
@@ -194,7 +194,7 @@ ReadDicomSeriesCastWriteImage(std::string inputDirectoryName, std::string output
  */
 template <typename InputImageType, typename OutputImageType>
 void
-ReadCastWriteImage(std::string inputFileName, std::string outputFileName)
+ReadCastWriteImage(const std::string & inputFileName, const std::string & outputFileName)
 {
   /**  Typedef the correct reader, caster and writer. */
   using ImageReaderType = typename itk::ImageFileReader<InputImageType>;
@@ -333,7 +333,7 @@ ReadVTICastWriteImage(std::string inputFileName, std::string outputFileName, int
 #else
 template <typename TOuptutPixelType>
 int
-ReadVTICastWriteImage(std::string, std::string, int)
+ReadVTICastWriteImage(const std::string &, const std::string &, int)
 {
   return 0;
 }

--- a/DWIConvert/DWIConvertLib.cxx
+++ b/DWIConvert/DWIConvertLib.cxx
@@ -274,7 +274,7 @@ DWIConvert::CreateDicomConverter(const std::string & inputDicomDirectory,
 
 
 void
-DWIConvert::SetInputFileName(std::string inputFilePath)
+DWIConvert::SetInputFileName(const std::string & inputFilePath)
 {
 
   const auto isDirectory = itksys::SystemTools::FileIsDirectory(inputFilePath);
@@ -324,7 +324,7 @@ DWIConvert::SetInputFileName(std::string inputFilePath)
 
 
 void
-DWIConvert::SetOutputFileName(std::string outputFilePath)
+DWIConvert::SetOutputFileName(const std::string & outputFilePath)
 {
   m_outputVolume = outputFilePath;
   m_outputFileType = detectOuputVolumeType(outputFilePath);

--- a/DWIConvert/DWIConvertLib.h
+++ b/DWIConvert/DWIConvertLib.h
@@ -49,9 +49,9 @@ public:
 
   // currently supported file types: { ".nii", ".nii.gz", ".nhdr", ".nrrd"}
   void
-  SetInputFileName(std::string inputFilePath);
+  SetInputFileName(const std::string & inputFilePath);
   void
-  SetOutputFileName(std::string outputFilePath);
+  SetOutputFileName(const std::string & outputFilePath);
 
   const std::string &
   getInputVolume() const;

--- a/DWIConvert/DWIConverter.cxx
+++ b/DWIConvert/DWIConverter.cxx
@@ -505,7 +505,7 @@ DWIConverter::ManualWriteNRRDFile(const std::string & outputVolumeHeaderName, co
 }
 
 Volume4DType::Pointer
-DWIConverter::ThreeDToFourDImage(Volume3DUnwrappedType::Pointer img) const
+DWIConverter::ThreeDToFourDImage(const Volume3DUnwrappedType::Pointer & img) const
 {
   const int nVolumes = this->GetNVolume();
 
@@ -573,7 +573,7 @@ DWIConverter::ThreeDToFourDImage(Volume3DUnwrappedType::Pointer img) const
 }
 
 DWIConverter::Volume3DUnwrappedType::Pointer
-DWIConverter::FourDToThreeDImage(Volume4DType::Pointer img4D) const
+DWIConverter::FourDToThreeDImage(const Volume4DType::Pointer & img4D) const
 {
   Volume4DType::SizeType      size4D(img4D->GetLargestPossibleRegion().GetSize());
   Volume4DType::DirectionType direction4D(img4D->GetDirection());
@@ -639,10 +639,10 @@ DWIConverter::FourDToThreeDImage(Volume4DType::Pointer img4D) const
 }
 
 void
-DWIConverter::WriteFSLFormattedFileSet(const std::string &   outputVolumeHeaderName,
-                                       const std::string &   outputBValues,
-                                       const std::string &   outputBVectors,
-                                       Volume4DType::Pointer img4D) const
+DWIConverter::WriteFSLFormattedFileSet(const std::string &           outputVolumeHeaderName,
+                                       const std::string &           outputBValues,
+                                       const std::string &           outputBVectors,
+                                       const Volume4DType::Pointer & img4D) const
 {
   const double trace = this->m_MeasurementFrame[0][0] * this->m_MeasurementFrame[1][1] * this->m_MeasurementFrame[2][2];
   if (std::abs(trace - 1.0) > 1e-4)
@@ -726,7 +726,7 @@ DWIConverter::ComputeMaxBvalue(const std::vector<double> & bValues) const
 }
 
 size_t
-DWIConverter::has_valid_nifti_extension(std::string outputVolumeHeaderName) const
+DWIConverter::has_valid_nifti_extension(const std::string & outputVolumeHeaderName) const
 {
   constexpr size_t   NUMEXT = 2;
   const char * const extList[NUMEXT] = { ".nii.gz", ".nii" };

--- a/DWIConvert/DWIConverter.h
+++ b/DWIConvert/DWIConverter.h
@@ -202,19 +202,19 @@ public:
   void
   ManualWriteNRRDFile(const std::string & outputVolumeHeaderName, const std::string & commentstring) const;
   Volume4DType::Pointer
-  ThreeDToFourDImage(Volume3DUnwrappedType::Pointer img) const;
+  ThreeDToFourDImage(const Volume3DUnwrappedType::Pointer & img) const;
 
   Volume3DUnwrappedType::Pointer
-  FourDToThreeDImage(Volume4DType::Pointer img4D) const;
+  FourDToThreeDImage(const Volume4DType::Pointer & img4D) const;
 
   /** the DICOM datasets are read as 3D volumes, but they need to be
    *  written as 4D volumes for image types other than NRRD.
    */
   void
-  WriteFSLFormattedFileSet(const std::string &   outputVolumeHeaderName,
-                           const std::string &   outputBValues,
-                           const std::string &   outputBVectors,
-                           Volume4DType::Pointer img4D) const;
+  WriteFSLFormattedFileSet(const std::string &           outputVolumeHeaderName,
+                           const std::string &           outputBValues,
+                           const std::string &           outputBVectors,
+                           const Volume4DType::Pointer & img4D) const;
 
 
   /**
@@ -236,7 +236,7 @@ protected:
   double
   ComputeMaxBvalue(const std::vector<double> & bValues) const;
   size_t
-  has_valid_nifti_extension(std::string outputVolumeHeaderName) const;
+  has_valid_nifti_extension(const std::string & outputVolumeHeaderName) const;
 
   /** add vendor-specific flags; */
   virtual void

--- a/DWIConvert/TestSuite/DWICompare.cxx
+++ b/DWIConvert/TestSuite/DWICompare.cxx
@@ -202,7 +202,7 @@ DoIt(int argc, char * argv[], PixelType)
 }
 
 void
-GetImageType(std::string                         fileName,
+GetImageType(const std::string &                 fileName,
              itk::ImageIOBase::IOPixelType &     pixelType,
              itk::ImageIOBase::IOComponentType & componentType)
 {

--- a/DWIConvert/TestSuite/DWISimpleCompare.cxx
+++ b/DWIConvert/TestSuite/DWISimpleCompare.cxx
@@ -233,7 +233,7 @@ DoIt(const std::string & inputVolume1, const std::string & inputVolume2, PixelTy
 }
 
 void
-GetImageType(std::string                         fileName,
+GetImageType(const std::string &                 fileName,
              itk::ImageIOBase::IOPixelType &     pixelType,
              itk::ImageIOBase::IOComponentType & componentType)
 {

--- a/GTRACT/Cmdline/gtractAverageBvalues.cxx
+++ b/GTRACT/Cmdline/gtractAverageBvalues.cxx
@@ -56,15 +56,18 @@
 #include "DWIConvertLib.h"
 
 int
-buildDirectionLut(itk::Array<int> &       lut,
-                  itk::Array<int> &       count,
-                  itk::MetaDataDictionary meta,
-                  int                     numImages,
-                  double                  directionsTolerance,
-                  bool                    averageB0only);
+buildDirectionLut(itk::Array<int> &               lut,
+                  itk::Array<int> &               count,
+                  const itk::MetaDataDictionary & meta,
+                  int                             numImages,
+                  double                          directionsTolerance,
+                  bool                            averageB0only);
 
 bool
-areDirectionsEqual(std::string direction1, std::string direction2, double directionsTolerance, bool averageB0only);
+areDirectionsEqual(const std::string & direction1,
+                   const std::string & direction2,
+                   double              directionsTolerance,
+                   bool                averageB0only);
 
 int
 main(int argc, char * argv[])
@@ -257,12 +260,12 @@ main(int argc, char * argv[])
 }
 
 int
-buildDirectionLut(itk::Array<int> &       lut,
-                  itk::Array<int> &       count,
-                  itk::MetaDataDictionary meta,
-                  int                     numImages,
-                  double                  directionsTolerance,
-                  bool                    averageB0only)
+buildDirectionLut(itk::Array<int> &               lut,
+                  itk::Array<int> &               count,
+                  const itk::MetaDataDictionary & meta,
+                  int                             numImages,
+                  double                          directionsTolerance,
+                  bool                            averageB0only)
 {
   int numElements = 0;
 
@@ -321,7 +324,10 @@ buildDirectionLut(itk::Array<int> &       lut,
 }
 
 bool
-areDirectionsEqual(std::string direction1, std::string direction2, double directionsTolerance, bool averageB0only)
+areDirectionsEqual(const std::string & direction1,
+                   const std::string & direction2,
+                   double              directionsTolerance,
+                   bool                averageB0only)
 {
   constexpr unsigned int MAXSTR = 256;
   char                   tmpDir1[MAXSTR];

--- a/GTRACT/Cmdline/gtractResampleDWIInPlace.cxx
+++ b/GTRACT/Cmdline/gtractResampleDWIInPlace.cxx
@@ -66,8 +66,8 @@
  */
 template <typename IOImageType>
 typename IOImageType::Pointer
-SetVectorImageRigidTransformInPlace(typename itk::VersorRigid3DTransform<double>::ConstPointer RigidTransform,
-                                    const IOImageType *                                        InputImage)
+SetVectorImageRigidTransformInPlace(const typename itk::VersorRigid3DTransform<double>::ConstPointer & RigidTransform,
+                                    const IOImageType *                                                InputImage)
 {
   using ResampleIPFilterType = itk::ResampleInPlaceImageFilter<IOImageType, IOImageType>;
   using ResampleIPFilterPointer = typename ResampleIPFilterType::Pointer;

--- a/GTRACT/Common/algo.cxx
+++ b/GTRACT/Common/algo.cxx
@@ -37,7 +37,7 @@
 #include "algo.h"
 
 TMatrix
-Matrix_Inverse(TMatrix M)
+Matrix_Inverse(const TMatrix & M)
 {
   //  const int NumberOfDirections=M.rows();
   TMatrix M_T = M.transpose();
@@ -74,7 +74,7 @@ My_lsf(TVector x, TVector y)
 }
 
 TVector
-Eigen_Value(TMatrix M)
+Eigen_Value(const TMatrix & M)
 {
   vnl_symmetric_eigensystem<float> eig(M);
   TVector                          result(3);
@@ -177,7 +177,7 @@ CI(TVector ADC1, TVector ADC2)
 }
 
 float
-LI(TVector ADC1, TVector ADC2)
+LI(const TVector & ADC1, const TVector & ADC2)
 {
   TVector t0 = DD(ADC1, ADC2);
 

--- a/GTRACT/Common/algo.h
+++ b/GTRACT/Common/algo.h
@@ -54,13 +54,13 @@
 #include "gtractCommonWin32.h"
 
 extern GTRACT_COMMON_EXPORT TMatrix
-                            Matrix_Inverse(TMatrix M);
+                            Matrix_Inverse(const TMatrix & M);
 
 extern GTRACT_COMMON_EXPORT float
 My_lsf(TVector x, TVector y);
 
 extern GTRACT_COMMON_EXPORT TVector
-                            Eigen_Value(TMatrix M);
+                            Eigen_Value(const TMatrix & M);
 
 extern GTRACT_COMMON_EXPORT TMatrix
                             Tensor2Matrix(TVector ADCe);
@@ -87,7 +87,7 @@ extern GTRACT_COMMON_EXPORT float
 CI(TVector ADC1, TVector ADC2);
 
 extern GTRACT_COMMON_EXPORT float
-LI(TVector ADC1, TVector ADC2);
+LI(const TVector & ADC1, const TVector & ADC2);
 
 extern GTRACT_COMMON_EXPORT TVector
                             TensorShape(TVector eigV);


### PR DESCRIPTION
These parameters are used solely as constant values. By converting them to constant, pass by reference values we save time by not copying and achieve the same effect.
This implements a portion of the 'performance-unnecessary-value-parm' clang-tidy check.
        -"The parameter 'LandmarkPoints' is copied for each invocation but only used as a const reference; consider making it a const reference"
