### PR TITLE
ENH: Replaced single character string literals within find operations with characters.

### DIFF
--- a/BRAINSCommonLib/Slicer3LandmarkIO.cxx
+++ b/BRAINSCommonLib/Slicer3LandmarkIO.cxx
@@ -260,11 +260,11 @@ ReadSlicer3toITKLmkOldSlicer(const std::string & landmarksFilename)
         {
           coordinate_str = match.str(1);
         }
-        if (coordinate_str.find("LPS") != std::string::npos || coordinate_str.find("1") != std::string::npos)
+        if (coordinate_str.find("LPS") != std::string::npos || coordinate_str.find('1') != std::string::npos)
         {
           useLPS = true;
         }
-        else if (coordinate_str.find("RAS") != std::string::npos || coordinate_str.find("0") != std::string::npos)
+        else if (coordinate_str.find("RAS") != std::string::npos || coordinate_str.find('0') != std::string::npos)
         {
           useLPS = false;
         }
@@ -356,11 +356,11 @@ ReadSlicer3toITKLmkSlicer4(const std::string & landmarksFilename)
         {
           coordinate_str = match.str(1);
         }
-        if (coordinate_str.find("LPS") != std::string::npos || coordinate_str.find("1") != std::string::npos)
+        if (coordinate_str.find("LPS") != std::string::npos || coordinate_str.find('1') != std::string::npos)
         {
           useLPS = true;
         }
-        else if (coordinate_str.find("RAS") != std::string::npos || coordinate_str.find("0") != std::string::npos)
+        else if (coordinate_str.find("RAS") != std::string::npos || coordinate_str.find('0') != std::string::npos)
         {
           useLPS = false;
         }

--- a/BRAINSCommonLib/itkBRAINSToolsTestMain.h
+++ b/BRAINSCommonLib/itkBRAINSToolsTestMain.h
@@ -500,7 +500,7 @@ RegressionTestBaselines(char * baselineFilename)
   std::string originalBaseline(baselineFilename);
 
   int                    x = 0;
-  std::string::size_type suffixPos = originalBaseline.rfind(".");
+  std::string::size_type suffixPos = originalBaseline.rfind('.');
   std::string            suffix;
   if (suffixPos != std::string::npos)
   {

--- a/BRAINSConstellationDetector/src/fcsv_to_hdf5.cxx
+++ b/BRAINSConstellationDetector/src/fcsv_to_hdf5.cxx
@@ -362,9 +362,9 @@ main(int argc, char * argv[])
   }
 
   std::string cleanedGlobPattern = landmarkGlobPattern;
-  while (cleanedGlobPattern.find("\\") != std::string::npos)
+  while (cleanedGlobPattern.find('\\') != std::string::npos)
   {
-    cleanedGlobPattern.replace(cleanedGlobPattern.find("\\"), 1, ""); // Replace
+    cleanedGlobPattern.replace(cleanedGlobPattern.find('\\'), 1, ""); // Replace
                                                                       // escape
                                                                       // characters
   }

--- a/ConvertBetweenFileFormats/castconvert.cxx
+++ b/ConvertBetweenFileFormats/castconvert.cxx
@@ -135,7 +135,7 @@ main(int argc, char * argv[])
     /** Make sure last character of input != "/".
      * Otherwise FileIsDirectory() won't work.
      */
-    if (input.rfind("/") == input.size() - 1)
+    if (input.rfind('/') == input.size() - 1)
     {
       input.erase(input.size() - 1, 1);
     }
@@ -273,13 +273,13 @@ main(int argc, char * argv[])
     }
 
     /** Get rid of the "_" in inputPixelComponentType and outputPixelComponentType. */
-    std::basic_string<char>::size_type              pos = inputPixelComponentType.find("_");
+    std::basic_string<char>::size_type              pos = inputPixelComponentType.find('_');
     static const std::basic_string<char>::size_type npos = std::basic_string<char>::npos;
     if (pos != npos)
     {
       inputPixelComponentType.replace(pos, 1, " ");
     }
-    pos = outputPixelComponentType.find("_");
+    pos = outputPixelComponentType.find('_');
     if (pos != npos)
     {
       outputPixelComponentType.replace(pos, 1, " ");

--- a/DWIConvert/DWIConvertLib.cxx
+++ b/DWIConvert/DWIConvertLib.cxx
@@ -151,7 +151,7 @@ DWIConvert::write(const std::string & outputVolume)
 
   std::string outputVolumeHeaderName(m_outputVolume);
   { // concatenate with outputDirectory
-    if (m_outputVolume.find("/") == std::string::npos && m_outputVolume.find("\\") == std::string::npos)
+    if (m_outputVolume.find('/') == std::string::npos && m_outputVolume.find('\\') == std::string::npos)
     {
       if (!outputVolumeHeaderName.empty())
       {


### PR DESCRIPTION
In several locations, a length 1 string is passed to `std::string::find()` or others.
The character literal overload is more efficient so these values have been converted.
This implements the 'performance-faster-string-find' clang-tidy check.
	-"'find' called with a string literal consisting of a single character; consider using the more effective overload accepting a character."
