### PR TITLE
ENH: Swapped safe-to-replace local variable copies with a constant reference.

### DIFF
--- a/BRAINSABC/brainseg/BRAINSABC.cxx
+++ b/BRAINSABC/brainseg/BRAINSABC.cxx
@@ -1268,7 +1268,7 @@ main(int argc, char ** argv)
       // so there is no need to overwrite that.
       if (!atlasToSubjectTransform.empty() && !itksys::SystemTools::FileExists(atlasToSubjectTransform.c_str()))
       {
-        const std::string postSegmentationTransformFileName = atlasToSubjectTransform;
+        const std::string & postSegmentationTransformFileName = atlasToSubjectTransform;
         // NOTE:  Aliasing of smart-pointers up the polymorphic tree OK here
         // because
         // the primary

--- a/BRAINSCommonLib/TestSuite/DWIMetaDataDictionaryValidatorTest.cxx
+++ b/BRAINSCommonLib/TestSuite/DWIMetaDataDictionaryValidatorTest.cxx
@@ -63,7 +63,7 @@ PrintDictionaryHelper(const itk::MetaDataDictionary & dictPrint)
       using msrFrameType = std::vector<std::vector<double>>;
       const auto * msrFrameMetaDataObject =
         dynamic_cast<const itk::MetaDataObject<msrFrameType> *>(it->second.GetPointer());
-      const msrFrameType outMsr = msrFrameMetaDataObject->GetMetaDataObjectValue();
+      const msrFrameType & outMsr = msrFrameMetaDataObject->GetMetaDataObjectValue();
       for (const auto & i : outMsr)
       {
         std::cout << "  ";

--- a/BRAINSConstellationDetector/src/LLSModel.cxx
+++ b/BRAINSConstellationDetector/src/LLSModel.cxx
@@ -96,8 +96,8 @@ LLSModel ::WriteScalar(const std::string & path, const double & value)
 void
 LLSModel ::WriteString(const std::string & path, const std::string & strname)
 {
-  const H5std_string SET_NAME(path);
-  const H5std_string SET_DATA(strname);
+  const H5std_string & SET_NAME(path);
+  const H5std_string & SET_DATA(strname);
 
   hsize_t       numStrings(1);
   H5::DataSpace strSpace(1, &numStrings);

--- a/BRAINSConstellationDetector/src/fcsv_to_hdf5.cxx
+++ b/BRAINSConstellationDetector/src/fcsv_to_hdf5.cxx
@@ -626,9 +626,9 @@ main(int argc, char * argv[])
     vnl_matrix<double> Yi =
       (byClassLandmarkMatrix["newLandmarks"][i].second) - (byClassLandmarkMatrix["baseLandmarks"][0].second);
 
-    const vnl_matrix<double> tmp = vnl_matrix_inverse<double>(Zi * Zi.transpose().as_ref()).as_matrix();
-    const vnl_matrix<double> Zinv{ tmp };
-    const vnl_matrix<double> Ci{ Zinv * (Zi * Yi) };
+    const vnl_matrix<double>   tmp = vnl_matrix_inverse<double>(Zi * Zi.transpose().as_ref()).as_matrix();
+    const vnl_matrix<double> & Zinv{ tmp };
+    const vnl_matrix<double>   Ci{ Zinv * (Zi * Yi) };
     M.push_back(W[i] * Ci);
 
     // Compute the estimation errors for training datasets

--- a/GTRACT/Cmdline/gtractResampleDWIInPlace.cxx
+++ b/GTRACT/Cmdline/gtractResampleDWIInPlace.cxx
@@ -210,9 +210,9 @@ main(int argc, char * argv[])
   resampleImageValidator.SetMetaDataDictionary(resampleImage->GetMetaDataDictionary());
 
   // Get measurement frame and its inverse from DWI scan
-  DWIMetaDataDictionaryValidator::RotationMatrixType msrFrame = resampleImageValidator.GetMeasurementFrame();
-  DWIMetaDataDictionaryValidator::RotationMatrixType DWIMeasurementFrame = msrFrame;
-  DWIMetaDataDictionaryValidator::RotationMatrixType DWIInverseMeasurementFrame;
+  DWIMetaDataDictionaryValidator::RotationMatrixType         msrFrame = resampleImageValidator.GetMeasurementFrame();
+  const DWIMetaDataDictionaryValidator::RotationMatrixType & DWIMeasurementFrame = msrFrame;
+  DWIMetaDataDictionaryValidator::RotationMatrixType         DWIInverseMeasurementFrame;
   DWIInverseMeasurementFrame = DWIMeasurementFrame.GetInverse();
 
   // Resample DWI in place


### PR DESCRIPTION
In some code locations, local variables are created that simply represent a copy of another variable.
For expensive to copy values, this can be inefficient.
This commit converts such local variables whose contents are not modified to constant references.
This implements a portion of the 'performance-unnecessary-copy-initialization' clang-tidy check.
	-"Local copy 'SET_DATA' of the variable 'strname' is never modified; consider avoiding the copy"
