### PR TITLE
ENH: Removed unnecessary <cmath> and "math.h" include statements.

### DIFF
--- a/BRAINSABC/brainseg/EMSegmentationFilter.hxx
+++ b/BRAINSABC/brainseg/EMSegmentationFilter.hxx
@@ -24,7 +24,6 @@
 #include <sstream>
 #include <iomanip>
 
-#include <cmath>
 #include <cstdlib>
 #include <algorithm>
 

--- a/BRAINSABC/brainseg/LLSBiasCorrector.hxx
+++ b/BRAINSABC/brainseg/LLSBiasCorrector.hxx
@@ -20,8 +20,6 @@
 #define __LLSBiasCorrector_hxx
 
 #include <cfloat>
-#include <cmath>
-#include <cmath>
 #include <iostream>
 
 #include "Log.h"

--- a/BRAINSCommonLib/ConvertToRigidAffine.h
+++ b/BRAINSCommonLib/ConvertToRigidAffine.h
@@ -33,7 +33,6 @@
 #include <vnl/algo/vnl_svd.h>
 #include <vcl_compiler.h>
 #include <iostream>
-#include <cmath>
 
 // INFO:  Need to make return types an input template type.
 namespace AssignRigid

--- a/BRAINSCommonLib/CrossOverAffineSystem.h
+++ b/BRAINSCommonLib/CrossOverAffineSystem.h
@@ -35,7 +35,6 @@
 #include <vnl/algo/vnl_svd.h>
 #include <vcl_compiler.h>
 #include <iostream>
-#include <cmath>
 #include <cstdio>
 
 /*

--- a/BRAINSCommonLib/Imgmath.h
+++ b/BRAINSCommonLib/Imgmath.h
@@ -42,7 +42,6 @@
 #include "itkLogImageFilter.h"
 #include <vcl_compiler.h>
 #include <iostream>
-#include <cmath>
 
 /* Iadd adds 2 images at every pixel location and outputs the resulting image.*/
 template <typename ImageType>

--- a/BRAINSCommonLib/Slicer3LandmarkWeightIO.cxx
+++ b/BRAINSCommonLib/Slicer3LandmarkWeightIO.cxx
@@ -24,7 +24,6 @@
 
 #include "Slicer3LandmarkWeightIO.h"
 #include "itkNumberToString.h"
-#include "math.h"
 
 void
 WriteITKtoSlicer3LmkWts(const std::string & landmarksWeightFilename, const LandmarksWeightMapType & landmarks)

--- a/BRAINSCommonLib/TestSuite/DWIMetaDataDictionaryValidatorTest.cxx
+++ b/BRAINSCommonLib/TestSuite/DWIMetaDataDictionaryValidatorTest.cxx
@@ -6,7 +6,6 @@
 
 #include <itkMetaDataObject.h>
 
-#include <cmath>
 #include <cstdio>
 #include <itkImage.h>
 #include <itkImageFileWriter.h>

--- a/BRAINSCommonLib/itkInverseConsistentLandmarks.hxx
+++ b/BRAINSCommonLib/itkInverseConsistentLandmarks.hxx
@@ -35,7 +35,6 @@
 #include "itkInverseConsistentLandmarks.h"
 #include <cstdio>
 #include <ctime>
-#include <cmath>
 #include <string>
 #include <iostream>
 #include "itkNumberToString.h"

--- a/BRAINSConstellationDetector/TestSuite/VersorTester.cxx
+++ b/BRAINSConstellationDetector/TestSuite/VersorTester.cxx
@@ -17,7 +17,6 @@
  *
  *=========================================================================*/
 #include <sstream>
-#include <cmath>
 
 #include <itkMath.h>
 #include <itkPoint.h>

--- a/BRAINSConstellationDetector/gui/QVTKInteractionCallback.cxx
+++ b/BRAINSConstellationDetector/gui/QVTKInteractionCallback.cxx
@@ -32,7 +32,6 @@
 #include "vtkRenderWindow.h"
 #include "vtkInteractorStyleImage.h"
 #include "vtkVersion.h"
-#include <cmath>
 
 // The mouse motion callback, to turn "Slicing" on and off
 void

--- a/BRAINSConstellationDetector/gui/include/QVTKInteractionCallback.h
+++ b/BRAINSConstellationDetector/gui/include/QVTKInteractionCallback.h
@@ -32,8 +32,6 @@
 #include <QObject>
 #include <QString>
 
-#include <cmath>
-
 #include <QDebug>
 
 #include "itkMacro.h" //Needed for nullptr

--- a/BRAINSConstellationDetector/landmarkStatistics/GenerateAverageLmkFile.cxx
+++ b/BRAINSConstellationDetector/landmarkStatistics/GenerateAverageLmkFile.cxx
@@ -35,7 +35,6 @@
 */
 
 #include "itkImage.h"
-#include <cmath>
 #include <fstream>
 #include "Slicer3LandmarkIO.h"
 

--- a/BRAINSConstellationDetector/landmarkStatistics/LmkStatistics.cxx
+++ b/BRAINSConstellationDetector/landmarkStatistics/LmkStatistics.cxx
@@ -52,8 +52,6 @@ case n:     PCn1         PCn2
 
 #include "Slicer3LandmarkIO.h"
 #include "itkImage.h"
-#include "math.h"
-#include <cmath>
 
 
 int

--- a/BRAINSConstellationDetector/src/BRAINSAlignMSP.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSAlignMSP.cxx
@@ -46,7 +46,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <sstream>
-#include <cmath>
 #include <itkIntensityWindowingImageFilter.h>
 #include "BRAINSThreadControl.h"
 #include "landmarksConstellationCommon.h"

--- a/BRAINSConstellationDetector/src/BRAINSConstellationModeler.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSConstellationModeler.cxx
@@ -48,7 +48,6 @@
 
 #include <fstream>
 #include <cstring>
-#include <cmath>
 #include <map>
 
 #include "BRAINSThreadControl.h"
@@ -62,7 +61,6 @@
 #include "GenericTransformImage.h"
 
 #include "itkOrthogonalize3DRotationMatrix.h"
-#include "math.h"
 
 
 // //////////////////////////////////////////////////////////////

--- a/BRAINSConstellationDetector/src/LLSModel.cxx
+++ b/BRAINSConstellationDetector/src/LLSModel.cxx
@@ -19,7 +19,6 @@
 #include "LLSModel.h"
 
 #include "BRAINSConstellationDetectorVersion.h"
-#include "math.h"
 
 
 LLSModel ::LLSModel() = default;

--- a/BRAINSConstellationDetector/src/insertMidACPCpoint.cxx
+++ b/BRAINSConstellationDetector/src/insertMidACPCpoint.cxx
@@ -32,7 +32,6 @@
 // {NameOfoutputlandmarkFile}.fcsv
 
 #include "itkImage.h"
-#include <cmath>
 #include "Slicer3LandmarkIO.h"
 #include "insertMidACPCpointCLP.h"
 #include <BRAINSCommonLib.h>

--- a/BRAINSConstellationDetector/src/landmarksConstellationCommon.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationCommon.h
@@ -31,7 +31,6 @@
 
 #include <cstdio>
 #include <cstdlib>
-#include <cmath>
 #include <ctime>
 
 #include <numeric>

--- a/BRAINSConstellationDetector/src/landmarksConstellationDetector.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationDetector.cxx
@@ -31,7 +31,6 @@
 #include "BRAINSHoughEyeDetector.h"
 
 #include "itkLandmarkBasedTransformInitializer.h"
-#include "math.h"
 #include <BRAINSFitHelper.h>
 
 

--- a/BRAINSConstellationDetector/src/landmarksConstellationModelIO.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationModelIO.h
@@ -35,7 +35,6 @@
 #include <vector>
 #include <fstream>
 #include <iostream>
-#include <cmath>
 #include <cstring>
 #include <map>
 

--- a/BRAINSConstellationDetector/src/landmarksConstellationWeights.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationWeights.cxx
@@ -44,7 +44,6 @@
 #include "landmarksConstellationCommon.h"
 #include "landmarksConstellationTrainingDefinitionIO.h"
 #include "landmarksConstellationWeightsCLP.h"
-#include "math.h"
 
 
 // D E F I N E S //////////////////////////////////////////////////////////////

--- a/BRAINSFit/PerformMetricTest.cxx
+++ b/BRAINSFit/PerformMetricTest.cxx
@@ -30,7 +30,6 @@
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkTransformFileReader.h"
-#include "math.h"
 
 
 #define CHECK_PARAMETER_IS_SET(parameter, message)                                                                     \

--- a/BRAINSFit/TestSuite/makexfrmedImage.cxx
+++ b/BRAINSFit/TestSuite/makexfrmedImage.cxx
@@ -28,7 +28,6 @@
 #include <itkTransformFileWriter.h>
 #include "itkIO.h"
 #include "ReadMask.h"
-#include <cmath>
 
 #ifndef M_PI
 #  define M_PI 3.1415926

--- a/BRAINSLabelStats/BRAINSLabelStats.cxx
+++ b/BRAINSLabelStats/BRAINSLabelStats.cxx
@@ -28,7 +28,6 @@ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.  See the above copyright notices for more information.
 =========================================================================*/
 
-#include <cmath>
 #include <sstream>
 #include <iostream>
 #include <fstream>
@@ -42,7 +41,6 @@ PURPOSE.  See the above copyright notices for more information.
 #include "itkDOMNode.h"
 
 #include "BRAINSLabelStatsCLP.h"
-#include "math.h"
 
 
 std::string

--- a/BRAINSMush/BRAINSMush.cxx
+++ b/BRAINSMush/BRAINSMush.cxx
@@ -44,7 +44,6 @@ Minimal Input Example:
 #include "itkLargestForegroundFilledMaskImageFilter.h"
 
 #include <fstream>
-#include <cmath>
 #include <string>
 #include <BRAINSCommonLib.h>
 

--- a/DWIConvert/DWIConvertUtils.h
+++ b/DWIConvert/DWIConvertUtils.h
@@ -38,7 +38,6 @@
 #include "itkNumberToString.h"
 #include "DWIMetaDataDictionaryValidator.h"
 
-#include <cmath>
 
 using PixelValueType = short;
 /*

--- a/DWIConvert/TestSuite/BFileCompareTool.cpp
+++ b/DWIConvert/TestSuite/BFileCompareTool.cpp
@@ -1,7 +1,6 @@
 #include <cstdio>
 #include <iostream>
 #include <vector>
-#include <cmath>
 #include <cstring>
 #include <cstdlib>
 using namespace std;

--- a/GTRACT/Cmdline/gtractAverageBvalues.cxx
+++ b/GTRACT/Cmdline/gtractAverageBvalues.cxx
@@ -37,8 +37,6 @@
 #include <iostream>
 #include <fstream>
 
-#include <cmath>
-
 #include <itkArray.h>
 #include <itkImage.h>
 #include <itkVectorImage.h>

--- a/GTRACT/Cmdline/gtractClipAnisotropy.cxx
+++ b/GTRACT/Cmdline/gtractClipAnisotropy.cxx
@@ -37,8 +37,6 @@
 #include <iostream>
 #include <fstream>
 
-#include <cmath>
-
 #include <itkImage.h>
 #include <itkImageFileWriter.h>
 #include <itkImageFileReader.h>

--- a/GTRACT/Cmdline/gtractResampleDWIInPlace.cxx
+++ b/GTRACT/Cmdline/gtractResampleDWIInPlace.cxx
@@ -31,7 +31,6 @@
 =========================================================================*/
 #include <iostream>
 #include <fstream>
-#include <cmath>
 
 #include <itkImage.h>
 #include <itkVectorImage.h>

--- a/GTRACT/Common/algo.h
+++ b/GTRACT/Common/algo.h
@@ -41,8 +41,6 @@
 #ifndef __algo_H_
 #define __algo_H_
 
-#include <cmath>
-
 #include <vnl/vnl_matrix.h>
 #include <vnl/vnl_vector.h>
 #include <vnl/vnl_transpose.h>

--- a/GTRACT/Common/itkDtiStreamlineTrackingFilter.hxx
+++ b/GTRACT/Common/itkDtiStreamlineTrackingFilter.hxx
@@ -37,8 +37,6 @@
 #ifndef __itkDtiStreamlineTrackingFilter_hxx
 #define __itkDtiStreamlineTrackingFilter_hxx
 
-#include <cmath>
-
 #include "vtkFloatArray.h"
 #include "vtkPolyLine.h"
 

--- a/ImageCalculator/ImageCalculatorTemplates.h
+++ b/ImageCalculator/ImageCalculatorTemplates.h
@@ -38,7 +38,6 @@
 #  include <sstream>
 #  include <vcl_compiler.h>
 #  include <iostream>
-#  include <cmath>
 #  include "ImageCalculatorUtils.h"
 #  include <metaCommand.h>
 #  include <itkIdentityTransform.h>

--- a/ImageCalculator/ImageCalculatorUtils.cxx
+++ b/ImageCalculator/ImageCalculatorUtils.cxx
@@ -23,7 +23,6 @@
 #include <cstring>
 #include <vcl_compiler.h>
 #include <iostream>
-#include <cmath>
 #include <iostream>
 #include <metaCommand.h>
 #include <iostream>


### PR DESCRIPTION
These redundant or unnecessary include statements that existed throughout the BRAINSTools repository.
By removing them we avoid including unneeded code.
All references to "math.h" have removed to comply with the modernize-deprecated-headers clang-tidy check.
	-"Inclusion of deprecated C++ header 'math.h'; consider using 'cmath' instead"


