### PR TITLE
STYLE: converted some `for(...; ...; ...)` loops to use the new range-based loops in C++11.

### DIFF
--- a/BRAINSCommonLib/TestSuite/DWIMetaDataDictionaryValidatorTest.cxx
+++ b/BRAINSCommonLib/TestSuite/DWIMetaDataDictionaryValidatorTest.cxx
@@ -67,9 +67,9 @@ PrintDictionaryHelper(const itk::MetaDataDictionary & dictPrint)
       for (const auto & i : outMsr)
       {
         std::cout << "  ";
-        for (size_t j = 0; j < i.size(); ++j)
+        for (const auto & j : i)
         {
-          std::cout << i[j] << " ";
+          std::cout << j << " ";
         }
         std::cout << std::endl;
       }
@@ -334,9 +334,9 @@ main(int argc, char * argv[])
         std::cout << "ERROR: outGT not preserved! Output outGT:" << std::endl;
         for (const auto & i : outGT)
         {
-          for (size_t j = 0; j < i.size(); ++j)
+          for (const auto & j : i)
           {
-            std::cout << i[j] << " ";
+            std::cout << j << " ";
           }
           std::cout << std::endl;
         }

--- a/BRAINSConstellationDetector/src/landmarksConstellationModelIO.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationModelIO.h
@@ -190,9 +190,9 @@ public:
     for (auto & q : output)
     {
       q.resize(input[0][0].size());
-      for (auto oit = q.begin(); oit != q.end(); ++oit)
+      for (float & oit : q)
       {
-        *oit = 0;
+        oit = 0;
       }
     }
     for (const auto & curr_dataset : input)
@@ -218,9 +218,9 @@ public:
     const float inv_size = 1.0 / input.size();
     for (auto & q : output)
     {
-      for (auto oit = q.begin(); oit != q.end(); ++oit)
+      for (float & oit : q)
       {
-        *oit *= inv_size;
+        oit *= inv_size;
       }
     }
   }
@@ -768,9 +768,9 @@ private:
   {
     for (const auto & it1 : vec)
     {
-      for (auto it2 = it1.begin(); it2 != it1.end(); ++it2)
+      for (float it2 : it1)
       {
-        this->Write<float>(f, *it2);
+        this->Write<float>(f, it2);
       }
     }
   }
@@ -780,9 +780,9 @@ private:
   {
     for (auto & it1 : vec)
     {
-      for (auto it2 = it1.begin(); it2 != it1.end(); ++it2)
+      for (float & it2 : it1)
       {
-        this->Read<float>(f, *it2);
+        this->Read<float>(f, it2);
       }
     }
   }


### PR DESCRIPTION
This change was made to modernize the codebase.
Only non-risky for loops were modified.
A risky loop is a loop where the container expression is more complex than just a reference to a declared expression,
and some part of it appears elsewhere in the loop.
This implements the modernize-loop-convert clang-tidy check.
	-"Use range-based for loop instead"