### PR TITLE
STYLE: Swapped copied const-references constructor parameters with pass-by-value parameters that are then moved with `std::move()`.

### DIFF
--- a/DWIConvert/DWIConverterFactory.cxx
+++ b/DWIConvert/DWIConverterFactory.cxx
@@ -2,12 +2,14 @@
 // Created by Hui Xie on 12/19/16.
 //
 
+#include <utility>
+
 #include "DWIConverterFactory.h"
 
-DWIConverterFactory::DWIConverterFactory(const std::string & DicomDirectory,
-                                         const bool          UseBMatrixGradientDirections,
-                                         const double        smallGradientThreshold)
-  : m_DicomDirectory(DicomDirectory)
+DWIConverterFactory::DWIConverterFactory(std::string  DicomDirectory,
+                                         const bool   UseBMatrixGradientDirections,
+                                         const double smallGradientThreshold)
+  : m_DicomDirectory(std::move(DicomDirectory))
   , m_UseBMatrixGradientDirections(UseBMatrixGradientDirections)
   , m_SmallGradientThreshold(smallGradientThreshold)
 {}

--- a/DWIConvert/DWIConverterFactory.h
+++ b/DWIConvert/DWIConverterFactory.h
@@ -37,9 +37,9 @@
 class DWIConverterFactory
 {
 public:
-  DWIConverterFactory(const std::string & DicomDirectory,
-                      const bool          UseBMatrixGradientDirections,
-                      const double        smallGradientThreshold);
+  DWIConverterFactory(std::string  DicomDirectory,
+                      const bool   UseBMatrixGradientDirections,
+                      const double smallGradientThreshold);
 
   ~DWIConverterFactory();
 

--- a/DWIConvert/FSLDWIConverter.cxx
+++ b/DWIConvert/FSLDWIConverter.cxx
@@ -2,14 +2,16 @@
 // Created by Johnson, Hans J on 11/25/16.
 //
 
+#include <utility>
+
 #include "FSLDWIConverter.h"
 
 FSLDWIConverter::FSLDWIConverter(const DWIConverter::FileNamesContainer & inputFileNames,
-                                 const std::string &                      inputBValues,
-                                 const std::string &                      inputBVectors)
+                                 std::string                              inputBValues,
+                                 std::string                              inputBVectors)
   : DWIConverter(inputFileNames)
-  , m_inputBValues(inputBValues)
-  , m_inputBVectors(inputBVectors)
+  , m_inputBValues(std::move(inputBValues))
+  , m_inputBVectors(std::move(inputBVectors))
 {}
 
 FSLDWIConverter::CommonDicomFieldMapType

--- a/DWIConvert/FSLDWIConverter.h
+++ b/DWIConvert/FSLDWIConverter.h
@@ -26,8 +26,8 @@ class FSLDWIConverter : public DWIConverter
 {
 public:
   FSLDWIConverter(const DWIConverter::FileNamesContainer & inputFileNames,
-                  const std::string &                      inputBValues,
-                  const std::string &                      inputBVectors);
+                  std::string                              inputBValues,
+                  std::string                              inputBVectors);
 
   ~FSLDWIConverter() override = default;
 


### PR DESCRIPTION
Instead of passing construction parameters by reference and then copying to member variables, the parameters are passed by value (therefore copied) and then moved to the member variable.
This is a modernized effect that has the same efficiency.
This implements the modernize-pass-by-value clang-tidy check.
        -"Pass by value and use std::move"

