### PR TITLE
ENH: Changed access level of deleted copy constructors and copy assignment operators.

### DIFF
--- a/BRAINSCommonLib/itkScalarImagePortionToHistogramGenerator.h
+++ b/BRAINSCommonLib/itkScalarImagePortionToHistogramGenerator.h
@@ -118,6 +118,15 @@ public:
   void
   SetHistogramMax(RealPixelType maximumValue);
 
+  /** Delete the copy constructor */
+  ScalarImagePortionToHistogramGenerator(const Self &) = delete; // purposely not
+                                                                 // implemented
+
+  /** Delete the copy assignment operator */
+  void
+  operator=(const Self &) = delete; // purposely not
+                                    // implemented
+
 protected:
   ScalarImagePortionToHistogramGenerator();
   ~ScalarImagePortionToHistogramGenerator() override = default;
@@ -130,13 +139,6 @@ private:
 
   HistogramPointer m_Histogram;
   GeneratorPointer m_HistogramGenerator;
-
-  ScalarImagePortionToHistogramGenerator(const Self &) = delete; // purposely not
-                                                                 // implemented
-  void
-  operator=(const Self &) = delete; // purposely not
-
-  // implemented
 };
 } // end of namespace Statistics
 } // end of namespace itk

--- a/GTRACT/Common/itkGtractInverseDisplacementFieldImageFilter.h
+++ b/GTRACT/Common/itkGtractInverseDisplacementFieldImageFilter.h
@@ -178,6 +178,15 @@ public:
   unsigned long
   GetMTime() const override;
 
+  /** Delete the copy constructor */
+  GtractInverseDisplacementFieldImageFilter(const Self &) = delete; // purposely not
+                                                                    // implemented
+
+  /** Delete the copy assignment operator */
+  void
+  operator=(const Self &) = delete; // purposely not
+                                    // implemented
+
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
   itkConceptMacro(OutputHasNumericTraitsCheck, (Concept::HasNumericTraits<OutputPixelComponentType>));
@@ -204,13 +213,6 @@ protected:
   PrepareKernelBaseSpline();
 
 private:
-  GtractInverseDisplacementFieldImageFilter(const Self &) = delete; // purposely not
-                                                                    // implemented
-  void
-  operator=(const Self &) = delete; // purposely not
-
-  // implemented
-
   SizeType                   m_Size;            // Size of the output image
   KernelTransformPointerType m_KernelTransform; // Coordinate transform to
                                                 // use


### PR DESCRIPTION
By switching the access level from private to public, programmers will be informed that the operation has been deleted
instead of simply being denied access.
This implements the modernize-use-equals-delete clang-tidy check.
	-"Deleted member function should be public"