### PR TITLE
STYLE: Replaced default bodies of special member functions with `- default;`

### DIFF
--- a/BRAINSCommonLib/CrossOverAffineSystem.hxx
+++ b/BRAINSCommonLib/CrossOverAffineSystem.hxx
@@ -47,8 +47,7 @@ CrossOverAffineSystem<TCoordinateType, NDimensions>::CrossOverAffineSystem()
  * Destructor
  */
 template <typename TCoordinateType, unsigned int NDimensions>
-CrossOverAffineSystem<TCoordinateType, NDimensions>::~CrossOverAffineSystem()
-{}
+CrossOverAffineSystem<TCoordinateType, NDimensions>::~CrossOverAffineSystem() = default;
 
 /**
  * Utility function not provided in general vector implementations.


### PR DESCRIPTION
The explicitly defaulted function declarations enable more opportunities in optimization,
because the compiler might treat explicitly defaulted functions as trivial.
This implements the modernize-use-equals-default clang-tidy check.
	-"Use '= default' to define a trivial destructor"