### PR TITLE
ENH: Replaced instances of the `throw()` specifier with `noexcept` or removed them entirely.

### DIFF
--- a/BRAINSABC/common/muException.h
+++ b/BRAINSABC/common/muException.h
@@ -33,11 +33,11 @@ namespace mu
 class Exception : public std::exception
 {
 public:
-  Exception() throw()
+  Exception() noexcept
     : m_Message("")
   {}
 
-  ~Exception() throw() override = default;
+  ~Exception() noexcept override = default;
 
   void
   SetMessage(const char * s)
@@ -52,7 +52,7 @@ public:
   }
 
   const char *
-  what() const throw() override
+  what() const noexcept override
   {
     return m_Message.c_str();
   }

--- a/BRAINSConstellationDetector/src/itkReflectiveCorrelationCenterToImageMetric.h
+++ b/BRAINSConstellationDetector/src/itkReflectiveCorrelationCenterToImageMetric.h
@@ -83,7 +83,7 @@ public:
   ////////////////////////
   // Mandatory metric functions
   void
-  Initialize() throw(itk::ExceptionObject) override
+  Initialize() override
   {
     ParametersType params;
     params.set_size(SpaceDimension);


### PR DESCRIPTION
The throw specifier from C++ 11 is now considered to be poorly implemented and can be indeterministic.
The specifier `noexcept` is a modernized version that solves earlier pitfalls.
However, it does not include an option to permit specific exceptions.
Thus, empty `throw()` specifiers have been replaced with `noexcept` and
non-empty `throw(...)` specifiers were removed.
This implements the modernize-use-noexcept clang-tidy check.
	-"Dynamic exception specification 'throw()' is deprecated; consider using 'noexcept' instead"