### PR TITLE
ENH: Combined the logic of identical `if/else` and `switch` statements into one.

### DIFF
--- a/BRAINSCommonLib/GenericTransformImage.cxx
+++ b/BRAINSCommonLib/GenericTransformImage.cxx
@@ -162,7 +162,8 @@ WriteBothTransformsToDisk(const typename itk::Transform<TInputScalarType, 3, 3>:
     {
       const std::string transformFileType = genericComponent->GetNameOfClass();
       if (transformFileType == "VersorRigid3DTransform" || transformFileType == "ScaleVersor3DTransform" ||
-          transformFileType == "ScaleSkewVersor3DTransform" || transformFileType == "AffineTransform")
+          transformFileType == "ScaleSkewVersor3DTransform" || transformFileType == "AffineTransform" ||
+          transformFileType == "displacementFieldTransform")
       {
         if (!outputTransform.empty()) // Write out the transform
         {
@@ -182,13 +183,6 @@ WriteBothTransformsToDisk(const typename itk::Transform<TInputScalarType, 3, 3>:
         if (!outputTransform.empty())
         {
           itk::WriteTransformToDisk<TInputScalarType, TWriteScalarType>(tempInitializerITKTransform, outputTransform);
-        }
-      }
-      else if (transformFileType == "displacementFieldTransform")
-      {
-        if (!outputTransform.empty()) // Write out the transform
-        {
-          itk::WriteTransformToDisk<TInputScalarType, TWriteScalarType>(genericComponent, outputTransform);
         }
       }
       else //  NO SUCH CASE!!

--- a/BRAINSCommonLib/Slicer3LandmarkIO.cxx
+++ b/BRAINSCommonLib/Slicer3LandmarkIO.cxx
@@ -264,11 +264,8 @@ ReadSlicer3toITKLmkOldSlicer(const std::string & landmarksFilename)
         {
           useLPS = true;
         }
-        else if (coordinate_str.find("RAS") != std::string::npos || coordinate_str.find('0') != std::string::npos)
-        {
-          useLPS = false;
-        }
-        else // Unkonwn coordinate stsystem
+        else if (coordinate_str.find("RAS") != std::string::npos || coordinate_str.find('0') != std::string::npos ||
+                 true) // also serves as default for an unknown coordinate system
         {
           useLPS = false;
         }
@@ -360,11 +357,8 @@ ReadSlicer3toITKLmkSlicer4(const std::string & landmarksFilename)
         {
           useLPS = true;
         }
-        else if (coordinate_str.find("RAS") != std::string::npos || coordinate_str.find('0') != std::string::npos)
-        {
-          useLPS = false;
-        }
-        else // Unkonwn coordinate system
+        else if (coordinate_str.find("RAS") != std::string::npos || coordinate_str.find('0') != std::string::npos ||
+                 true) // also serves as default for an unknown coordinate system
         {
           useLPS = false;
         }

--- a/BRAINSConstellationDetector/src/BRAINSTransformFromFiducials.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSTransformFromFiducials.cxx
@@ -155,15 +155,12 @@ main(int argc, char * argv[])
     SimilarityTransformType::Pointer similarityTransform = DoIt_Similarity(fixedPoints, movingPoints);
     genericTransform = similarityTransform.GetPointer();
   }
-  else if (transformType == "Affine")
+  /*else if (transformType == "Affine")
   {
-    // itk::Matrix<double, 3> a =
-    //   computeAffineTransform(fixedPoints, movingPoints,
-    //                          fixedCenter, movingCenter);
-    std::cerr << "Unsupported transform type: " << transformType << std::endl;
-    genericTransform = nullptr;
-    return EXIT_FAILURE;
-  }
+     itk::Matrix<double, 3> a =
+       computeAffineTransform(fixedPoints, movingPoints,
+                              fixedCenter, movingCenter);
+  }*/
   else
   {
     std::cerr << "Unsupported transform type: " << transformType << std::endl;

--- a/BRAINSConstellationDetector/src/BinaryMaskEditorBasedOnLandmarks.cxx
+++ b/BRAINSConstellationDetector/src/BinaryMaskEditorBasedOnLandmarks.cxx
@@ -119,11 +119,8 @@ CutBinaryVolumeByPlaneWithDirection(typename TImageType::Pointer * _imageVolume,
     LandmarkPointType currentPhysicalLocation;
     (*_imageVolume)->TransformIndexToPhysicalPoint(it.GetIndex(), currentPhysicalLocation);
 
-    if (direction == "true" && currentPlane->GetRelativeLocationToPlane(currentPhysicalLocation) > 0.0F)
-    {
-      it.Set(0.0F);
-    }
-    else if (direction == "false" && currentPlane->GetRelativeLocationToPlane(currentPhysicalLocation) < 0.0F)
+    if ((direction == "true" && (*currentPlane).GetRelativeLocationToPlane(currentPhysicalLocation) > 0.0F) ||
+        (direction == "false" && (*currentPlane).GetRelativeLocationToPlane(currentPhysicalLocation) < 0.0F))
     {
       it.Set(0.0F);
     }

--- a/BRAINSDeface/BRAINSDeface.cxx
+++ b/BRAINSDeface/BRAINSDeface.cxx
@@ -166,18 +166,12 @@ main(int argc, char * argv[])
             {
               mit.Set(below_ac);
             }
-            // blur nose region
+            // blur nose region / blur Cheak region
             else if ((maskpnt[PA] < RE_pnt[PA] || maskpnt[PA] < LE_pnt[PA]) &&
                      (maskpnt[SI] < (RE_pnt[SI]) || (maskpnt[SI] < LE_pnt[SI])))
             {
               mit.Set(face_rm);
             }
-//            // blur Cheek region
-//            else if ((maskpnt[PA] < RE_pnt[PA] || maskpnt[PA] < LE_pnt[PA]) &&
-//                     (maskpnt[SI] < (RE_pnt[SI]) || (maskpnt[SI] < LE_pnt[SI])))
-//            {
-//              mit.Set(face_rm);
-//            }
             else if ((
                        // Now remove RE eye boxes
                        (maskpnt[PA] < (RE_pnt[PA] + approx_eye_radius)) && // anterior to back of eye

--- a/DWIConvert/DWIDICOMConverterBase.cxx
+++ b/DWIConvert/DWIDICOMConverterBase.cxx
@@ -268,8 +268,6 @@ DWIDICOMConverterBase::_addToStringDictionary(const std::string & dcm_primary_na
       this->m_Headers[0]->GetElementCS(dcm_primary_code, dcm_secondary_code, stringValue, throwException);
       break;
     case DCM_LO:
-      this->m_Headers[0]->GetElementLO(dcm_primary_code, dcm_secondary_code, stringValue, throwException);
-      break;
     case DCM_SH:
       this->m_Headers[0]->GetElementLO(dcm_primary_code, dcm_secondary_code, stringValue, throwException);
       break;

--- a/DWIConvert/PhilipsDWIConverter.cxx
+++ b/DWIConvert/PhilipsDWIConverter.cxx
@@ -139,15 +139,10 @@ PhilipsDWIConverter::ExtractDWIData()
       {
         continue;
       }
-      else if (!B0FieldFound || b < zeroBValueTolerance)
-      { // Deal with b0 images
-        this->m_BValues.push_back(b);
-        this->m_DiffusionVectors.push_back(vect3d);
-      }
-      else if (StringContains(DiffusionDirectionality, "DIRECTIONAL") ||
+      else if (!B0FieldFound || b < zeroBValueTolerance || StringContains(DiffusionDirectionality, "DIRECTIONAL") ||
                (DiffusionDirectionality == "NONE") // Some new Philips data does not specify "DIRECTIONAL"
                || (DiffusionDirectionality.empty()))
-      { // Deal with gradient direction images
+      { // Deal with b0 images and Deal with gradient direction images
         this->m_BValues.push_back(b);
         this->m_DiffusionVectors.push_back(vect3d);
       }


### PR DESCRIPTION
There are code locations where the value of a `switch` or logic for an `if/else` is different, but the contents are the same.
These have now been combined so the body is only written once.
This reduces redundant code but may negatively affect readability.
This implements the bugprone-branch-clone clang-tidy check.
	-”Repeated branch in conditional chain"