### PR TITLE
BUG: Fixed the `DWIMetaDataDictionaryValidator` segfault error.

### DIFF
--- a/BRAINSCommonLib/DWIMetaDataDictionaryValidator.cxx
+++ b/BRAINSCommonLib/DWIMetaDataDictionaryValidator.cxx
@@ -197,12 +197,12 @@ DWIMetaDataDictionaryValidator::SetGradientTable(GradientTableType & myGradientT
 void
 DWIMetaDataDictionaryValidator::DeleteGradientTable()
 {
-  for (auto it = m_dict.Begin(); it != m_dict.End(); ++it)
+  DWIMetaDataDictionaryValidator::StringVectorType keys = m_dict.GetKeys();
+  for (auto & key : keys)
   {
-    // http://stackoverflow.com/questions/8234779/how-to-remove-from-a-map-while-iterating-it
-    if ((*it).first.find("DWMRI_gradient_") != std::string::npos)
+    if (key.find("DWMRI_gradient_") != std::string::npos)
     {
-      m_dict.Erase((*it).first);
+      m_dict.Erase(key);
     }
   }
 }


### PR DESCRIPTION
The `DeleteGradientTable()` method was deleting its iterator value before incrementing to the next element.
This has been fixed by using a `foreach` loop over the map's keys instead.