### PR TITLE
ENH: Surrounded macro replacement arguments with parenthesis.

### DIFF
--- a/BRAINSABC/common/muMacros.h
+++ b/BRAINSABC/common/muMacros.h
@@ -25,19 +25,19 @@
 #include <sstream>
 #include <string>
 
-#define muEcho(varname) std::cout << #varname << " = " << varname << std::flush << std::endl;
+#define muEcho(varname) std::cout << #varname << " = " << (varname) << std::flush << std::endl;
 
 #define muStringMacro(strname, s)                                                                                      \
   std::string strname;                                                                                                 \
   {                                                                                                                    \
     std::ostringstream outss;                                                                                          \
     outss << "" s << std::ends;                                                                                        \
-    strname = outss.str();                                                                                             \
+    (strname) = outss.str();                                                                                           \
   }
 
 #define muSelfFilterMacro(filter, obj)                                                                                 \
   {                                                                                                                    \
-    filter->SetInput(obj);                                                                                             \
+    (filter)->SetInput(obj);                                                                                           \
     iterator copy                                                                                                      \
   }
 
@@ -47,7 +47,7 @@
     typename ReaderType::Pointer reader = ReaderType::New();                                                           \
     reader->SetFileName(filename);                                                                                     \
     reader->Update();                                                                                                  \
-    image = reader->GetOutput();                                                                                       \
+    (image) = reader->GetOutput();                                                                                     \
   }
 
 #define muWriteMacro(type, filename, image)                                                                            \

--- a/BRAINSFit/PerformMetricTest.cxx
+++ b/BRAINSFit/PerformMetricTest.cxx
@@ -33,9 +33,9 @@
 
 
 #define CHECK_PARAMETER_IS_SET(parameter, message)                                                                     \
-  if (parameter == "")                                                                                                 \
+  if ((parameter) == "")                                                                                               \
   {                                                                                                                    \
-    std::cerr << message << std::endl;                                                                                 \
+    std::cerr << (message) << std::endl;                                                                               \
     return EXIT_FAILURE;                                                                                               \
   }
 

--- a/BRAINSTransformConvert/BRAINSTransformConvert.cxx
+++ b/BRAINSTransformConvert/BRAINSTransformConvert.cxx
@@ -205,9 +205,9 @@ ExtractTransform(typename itk::ScaleSkewVersor3DTransform<TScalarType>::Pointer 
 }
 
 #define CHECK_PARAMETER_IS_SET(parameter, message)                                                                     \
-  if (parameter == "")                                                                                                 \
+  if ((parameter) == "")                                                                                               \
   {                                                                                                                    \
-    std::cerr << message << std::endl;                                                                                 \
+    std::cerr << (message) << std::endl;                                                                               \
     return EXIT_FAILURE;                                                                                               \
   }
 

--- a/ConvertBetweenFileFormats/castconverthelpers.h
+++ b/ConvertBetweenFileFormats/castconverthelpers.h
@@ -359,7 +359,7 @@ ReadVTICastWriteImage(const std::string &, const std::string &, int)
  */
 
 #define callCorrectReadWriterMacro(typeIn, typeOut, dim)                                                               \
-  if (inputPixelComponentType == #typeIn && outputPixelComponentType == #typeOut && inputDimension == dim)             \
+  if (inputPixelComponentType == #typeIn && outputPixelComponentType == #typeOut && inputDimension == (dim))           \
   {                                                                                                                    \
     if (!ReadVTICastWriteImage<typeOut>(inputFileName, outputFileName, dim))                                           \
     {                                                                                                                  \


### PR DESCRIPTION
It is recommended to surround macro arguments in the replacement list with parenthesis.
This ensures that the argument value is calculated properly.
This implements the bugprone-macro-parentheses clang-tidy check.
	-”Macro argument should be enclosed in parentheses"