### PR TITLE
ENH: Replaced integer cast rounding methods with built in rounding functions.

### DIFF
--- a/BRAINSCommonLib/itkComputeHistogramQuantileThresholds.hxx
+++ b/BRAINSCommonLib/itkComputeHistogramQuantileThresholds.hxx
@@ -117,11 +117,11 @@ ComputeHistogramQuantileThresholds<TInputImage, TMaskImage>::Calculate()
       if (histIt.GetFrequency() != 0)
       {
         ++m_NumberOfValidHistogramsEntries;
-        m_UpperIntensityThresholdValue = static_cast<int>(measurement + 0.5);
+        m_UpperIntensityThresholdValue = lround(measurement);
         // rounding by chopping
         if (!saw_lowest)
         {
-          m_LowerIntensityThresholdValue = static_cast<int>(measurement + 0.5);
+          m_LowerIntensityThresholdValue = lround(measurement);
           // rounding by chopping
           saw_lowest = true;
         }


### PR DESCRIPTION
Using `(int)(double_expression + 0.5)` to round can be inaccurate and slow.
Similar usages have been replaced with `lround`.
This implements the bugprone-incorrect-roundings clang-tidy check.
	-"Casting (double + 0.5) to integer leads to incorrect rounding; consider using lround (#include <cmath>) instead"