### PR TITLE
ENH: Converted intervision to float division when used in a float context.

### DIFF
--- a/BRAINSABC/brainseg/EMSegmentationFilter.hxx
+++ b/BRAINSABC/brainseg/EMSegmentationFilter.hxx
@@ -2561,7 +2561,7 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>::EMLoop()
                 || ((deltaLogLikelihood < m_LikelihoodTolerance) && (biasdegree == m_MaxBiasDegree));
 
     CurrentEMIteration++;
-    const float biasIncrementInterval = (m_MaximumIterations / (m_MaxBiasDegree + 1));
+    const float biasIncrementInterval = ((float)m_MaximumIterations / (m_MaxBiasDegree + 1));
     CHECK_NAN(biasIncrementInterval,
               __FILE__,
               __LINE__,


### PR DESCRIPTION
In one case, the result of an integer division is stored into a floating-point variable.
This has been changed to float division to preserve precision.
This implements the bugprone-integer-division clang-tidy check.
	-"Result of integer division used in a floating point context; possible loss of precision"