### PR TITLE
DOC: Update documentation URLs in XML files

### DIFF
--- a/BRAINSDWICleanup/BRAINSDWICleanup.xml
+++ b/BRAINSDWICleanup/BRAINSDWICleanup.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
   <category>Diffusion.Utilities</category>
-  <title>BRAINSDWICleanup</title>
+  <title>DWI Cleanup (BRAINS)</title>
 
   <description>Remove bad gradients/volumes from DWI NRRD file.</description>
   <acknowledgements></acknowledgements>
   <version>5.4.0</version>
-  <documentation-url></documentation-url>
+  <documentation-url>https://slicer.readthedocs.io/en/latest/user_guide/modules/brainsdwicleanup.html</documentation-url>
   <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt</license>
   <contributor>This tool was developed by Kent Williams.</contributor>
 

--- a/BRAINSDeface/BRAINSDeface.xml
+++ b/BRAINSDeface/BRAINSDeface.xml
@@ -2,18 +2,12 @@
 <executable>
     <category>Utilities.BRAINS</category>
     <title>Brain Deface from T1/T2 image (BRAINS)</title>
-    <description>
-        This program: 1) will deface images from a set of images.  Inputs must be ACPC aligned, and AC, PC, LE, RE provided.
-    </description>
+    <description>This program: 1) will deface images from a set of images.  Inputs must be ACPC aligned, and AC, PC, LE, RE provided.</description>
     <version>5.4.0</version>
-    <documentation-url></documentation-url>
+    <documentation-url>https://slicer.readthedocs.io/en/latest/user_guide/modules/brainsdeface.html</documentation-url>
     <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt</license>
-    <contributor>
-        This tool is created by Hans J. Johnson.
-    </contributor>
-    <acknowledgements>
-        This work was developed by the University of Iowa Department of Electrical and Computer Engineering.
-    </acknowledgements>
+    <contributor>This tool is created by Hans J. Johnson.</contributor>
+    <acknowledgements>This work was developed by the University of Iowa Department of Electrical and Computer Engineering.</acknowledgements>
 
     <parameters>
         <label>Input Images</label>

--- a/BRAINSFit/BRAINSFit.xml
+++ b/BRAINSFit/BRAINSFit.xml
@@ -2,8 +2,8 @@
 <executable>
   <category>Registration</category>
   <title>General Registration (BRAINS)</title>
-  <description>Register a three-dimensional volume to a reference volume (Mattes Mutual Information by default). Full documentation avalable here: http://wiki.slicer.org/slicerWiki/index.php/Documentation/4.1/Modules/BRAINSFit. Method described in BRAINSFit: Mutual Information Registrations of Whole-Brain 3D Images, Using the Insight Toolkit, Johnson H.J., Harris G., Williams K., The Insight Journal, 2007. http://hdl.handle.net/1926/1291</description>
-  <documentation-url>http://www.slicer.org/slicerWiki/index.php/Documentation/4.1/Modules/BRAINSFit</documentation-url>
+  <description>Register a three-dimensional volume to a reference volume (Mattes Mutual Information by default). Method described in BRAINSFit: Mutual Information Registrations of Whole-Brain 3D Images, Using the Insight Toolkit, Johnson H.J., Harris G., Williams K., The Insight Journal, 2007. http://hdl.handle.net/1926/1291</description>
+  <documentation-url>https://slicer.readthedocs.io/en/latest/user_guide/modules/brainsfit.html</documentation-url>
   <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt</license>
   <contributor>Hans J. Johnson (hans-johnson -at- uiowa.edu, http://www.psychiatry.uiowa.edu), Ali Ghayoor</contributor>
   <acknowledgements><![CDATA[Hans Johnson(1,3,4); Kent Williams(1); Gregory Harris(1), Vincent Magnotta(1,2,3);  Andriy Fedorov(5); Ali Ghayoor(4) 1=University of Iowa Department of Psychiatry, 2=University of Iowa Department of Radiology, 3=University of Iowa Department of Biomedical Engineering, 4=University of Iowa Department of Electrical and Computer Engineering, 5=Surgical Planning Lab, Harvard]]>  </acknowledgements>
@@ -135,7 +135,7 @@
     <boolean>
        <name>useBSpline</name>
        <longflag>useBSpline</longflag>
-       <label>BSpline (>27 DOF) </label>
+       <label>BSpline (>27 DOF)</label>
        <description>Perform a BSpline registration as part of the sequential registration steps.  This family of options overrides the use of transformType if any of them are set.</description>
        <default>false</default>
     </boolean>
@@ -149,7 +149,7 @@
     <boolean>
        <name>useComposite</name>
        <longflag>useComposite</longflag>
-       <label>Composite (many DOF) </label>
+       <label>Composite (many DOF)</label>
        <description>Perform a Composite registration as part of the sequential registration steps.  This family of options overrides the use of transformType if any of them are set.</description>
        <default>false</default>
     </boolean>
@@ -198,7 +198,7 @@
     <boolean>
        <name>useROIBSpline</name>
        <longflag>useROIBSpline</longflag>
-       <label>Define BSpline grid over the ROI bounding box </label>
+       <label>Define BSpline grid over the ROI bounding box</label>
        <description>If enabled then the bounding box of the input ROIs defines the BSpline grid support region. Otherwise the BSpline grid support region is the whole fixed image.</description>
        <default>false</default>
     </boolean>
@@ -403,14 +403,14 @@
     <double>
       <name>ROIAutoDilateSize</name>
       <longflag>ROIAutoDilateSize</longflag>
-      <label> ROIAuto Dilate Size</label>
+      <label>ROIAuto Dilate Size</label>
       <description>This flag is only relevant when using ROIAUTO mode for initializing masks.  It defines the final dilation size to capture a bit of background outside the tissue region.  A setting of 10mm has been shown to help regularize a BSpline registration type so that there is some background constraints to match the edges of the head better.</description>
       <default>0.0</default>
     </double>
     <double>
       <name>ROIAutoClosingSize</name>
       <longflag>ROIAutoClosingSize</longflag>
-      <label> ROIAuto Closing Size</label>
+      <label>ROIAuto Closing Size</label>
       <description>This flag is only relevant when using ROIAUTO mode for initializing masks.  It defines the hole closing size in mm.  It is rounded up to the nearest whole pixel size in each direction. The default is to use a closing size of 9mm.  For mouse data this value may need to be reset to 0.9 or smaller.</description>
       <default>9.0</default>
     </double>

--- a/BRAINSFit/PerformMetricTest.xml
+++ b/BRAINSFit/PerformMetricTest.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
   <category>Registration</category>
-  <title>Metric Test</title>
-  <description>
-    Compare Mattes/MSQ metric value for two input images and a possible input BSpline transform.
-  </description>
+  <title>Registration Metric Test (BRAINS)</title>
+  <description>Compare Mattes/MSQ metric value for two input images and a possible input BSpline transform.</description>
   <version>5.4.0</version>
-  <documentation-url>A utility to compare metric value between two input images.</documentation-url>
+  <documentation-url>https://slicer.readthedocs.io/en/latest/user_guide/modules/performmetrictest.html</documentation-url>
   <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt</license>
   <contributor>Ali Ghayoor</contributor>
   <acknowledgements>
@@ -20,9 +18,7 @@
       <channel>input</channel>
       <name>inputBSplineTransform</name>
       <label>Transform File Name</label>
-      <description>
-        Input transform that is use to warp moving image before metric comparison.
-      </description>
+      <description>Input transform that is use to warp moving image before metric comparison.</description>
       <longflag>inputBSplineTransform</longflag>
     </transform>
 

--- a/BRAINSLabelStats/BRAINSLabelStats.xml
+++ b/BRAINSLabelStats/BRAINSLabelStats.xml
@@ -4,7 +4,7 @@
   <title>Label Statistics (BRAINS)</title>
   <description>Compute image statistics within each label of a label map. </description>
   <version>5.4.0</version>
-  <documentation-url>http://www.nitrc.org/plugins/mwiki/index.php/brains:BRAINSClassify</documentation-url>
+  <documentation-url>https://slicer.readthedocs.io/en/latest/user_guide/modules/brainslabelstats.html</documentation-url>
   <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt</license>
   <contributor>Vincent A. Magnotta</contributor>
   <acknowledgements>Funding for this work was provided by the Dana Foundation</acknowledgements>

--- a/BRAINSROIAuto/BRAINSROIAuto.xml
+++ b/BRAINSROIAuto/BRAINSROIAuto.xml
@@ -2,10 +2,10 @@
 <executable>
   <category>Segmentation.Specialized</category>
   <title>Foreground masking (BRAINS)</title>
-  <description>This program is used to create a mask over the most prominant forground region in an image.  This is accomplished via a combination of otsu thresholding and a closing operation.  More documentation is available here: http://wiki.slicer.org/slicerWiki/index.php/Documentation/4.1/Modules/ForegroundMasking.
+  <description>This program is used to create a mask over the most prominant forground region in an image.  This is accomplished via a combination of otsu thresholding and a closing operation.
   </description>
   <version>5.4.0</version>
-  <documentation-url></documentation-url>
+  <documentation-url>https://slicer.readthedocs.io/en/latest/user_guide/modules/brainsroiauto.html</documentation-url>
   <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt</license>
   <contributor>Hans J. Johnson, hans-johnson -at- uiowa.edu, http://www.psychiatry.uiowa.edu</contributor>
   <acknowledgements>Hans Johnson(1,3,4); Kent Williams(1); Gregory Harris(1), Vincent Magnotta(1,2,3);  Andriy Fedorov(5), fedorov -at- bwh.harvard.edu (Slicer integration); (1=University of Iowa Department of Psychiatry, 2=University of Iowa Department of Radiology, 3=University of Iowa Department of Biomedical Engineering, 4=University of Iowa Department of Electrical and Computer Engineering, 5=Surgical Planning Lab, Harvard)  </acknowledgements>
@@ -79,7 +79,7 @@
     <double>
       <name>ROIAutoDilateSize</name>
       <longflag>ROIAutoDilateSize</longflag>
-      <label> ROIAuto Dilate Size</label>
+      <label>ROIAuto Dilate Size</label>
       <description>This flag is only relavent when using ROIAUTO mode for initializing masks.  It defines the final dilation size to capture a bit of background outside the tissue region.  At setting of 10mm has been shown to help regularize a BSpline registration type so that there is some background constraints to match the edges of the head better.</description>
       <default>0.0</default>
     </double>

--- a/BRAINSResample/BRAINSResample.xml
+++ b/BRAINSResample/BRAINSResample.xml
@@ -4,10 +4,10 @@
   <title>Resample Image (BRAINS)</title>
 
   <description>
-    This program collects together three common image processing tasks that all involve resampling an image volume: Resampling to a new resolution and spacing, applying a transformation (using an ITK transform IO mechanisms) and Warping (using a vector image deformation field).  Full documentation available here: http://wiki.slicer.org/slicerWiki/index.php/Documentation/4.1/Modules/BRAINSResample.
+    This program collects together three common image processing tasks that all involve resampling an image volume: Resampling to a new resolution and spacing, applying a transformation (using an ITK transform IO mechanisms) and Warping (using a vector image deformation field).
   </description>
   <version>5.4.0</version>
-  <documentation-url>http://www.slicer.org/slicerWiki/index.php/Documentation/4.1/Modules/BRAINSResample</documentation-url>
+  <documentation-url>https://slicer.readthedocs.io/en/latest/user_guide/modules/brainsresample.html</documentation-url>
   <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt</license>
   <contributor>This tool was developed by Vincent Magnotta, Greg Harris, and Hans Johnson.</contributor>
   <acknowledgements>The development of this tool was supported by funding from grants NS050568 and NS40068 from the National Institute of Neurological Disorders and Stroke and grants MH31593, MH40856, from the National Institute of Mental Health.  </acknowledgements>

--- a/BRAINSResample/BRAINSResize.xml
+++ b/BRAINSResample/BRAINSResize.xml
@@ -7,7 +7,7 @@
 This program is useful for downsampling an image by a constant scale factor.
   </description>
   <version>5.4.0</version>
-  <documentation-url></documentation-url>
+  <documentation-url>https://slicer.readthedocs.io/en/latest/user_guide/modules/brainsresize.html</documentation-url>
   <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt</license>
   <contributor>This tool was developed by Hans Johnson.</contributor>
   <acknowledgements>The development of this tool was supported by funding from grants NS050568 and NS40068 from the National Institute of Neurological Disorders and Stroke and grants MH31593, MH40856, from the National Institute of Mental Health.  </acknowledgements>

--- a/BRAINSStripRotation/BRAINSStripRotation.xml
+++ b/BRAINSStripRotation/BRAINSStripRotation.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
   <category>Utilities</category>
-  <title>BRAINS Strip Rotation</title>
+  <title>Strip Rotation (BRAINS)</title>
   <description>Read an Image, write out same image with identity rotation matrix plus an ITK transform file</description>
   <version>5.4.0</version>
-  <documentation-url></documentation-url>
+  <documentation-url>https://slicer.readthedocs.io/en/latest/user_guide/modules/brainsstriprotation.html</documentation-url>
   <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt</license>
-  <contributor>Kent WIlliams</contributor>
+  <contributor>Kent Williams</contributor>
   <acknowledgements></acknowledgements>
   <parameters>
+    <label>Input Parameters</label>
     <image>
       <name>inputVolume</name>
       <longflag alias="fixedVolume">inputVolume</longflag>

--- a/BRAINSTransformConvert/BRAINSTransformConvert.xml
+++ b/BRAINSTransformConvert/BRAINSTransformConvert.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
   <category>Utilities.BRAINS</category>
-  <title>BRAINS Transform Convert</title>
+  <title>Transform Convert (BRAINS)</title>
   <description>Convert ITK transforms to higher order transforms</description>
   <version>5.4.0</version>
-  <documentation-url>A utility to convert between transform file formats.</documentation-url>
+  <documentation-url>https://slicer.readthedocs.io/en/latest/user_guide/modules/brainstransformconvert.html</documentation-url>
   <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt</license>
   <contributor>Hans J. Johnson,Kent Williams, Ali Ghayoor</contributor>
   <acknowledgements>

--- a/DWIConvert/DWIConvert.xml
+++ b/DWIConvert/DWIConvert.xml
@@ -4,7 +4,7 @@
   <title>Diffusion-weighted DICOM Import (DWIConvert)</title>
   <description><![CDATA[Converts diffusion weighted MR images in DICOM series into NRRD format for analysis in Slicer. This program has been tested on only a limited subset of DTI DICOM formats available from Siemens, GE, and Philips scanners. Work in progress to support DICOM multi-frame data. The program parses DICOM header to extract necessary information about measurement frame, diffusion weighting directions, b-values, etc, and write out a NRRD image. For non-diffusion weighted DICOM images, it loads in an entire DICOM series and writes out a single dicom volume in a .nhdr/.raw pair.]]></description>
   <version>5.4.0</version>
-  <documentation-url>http://wiki.slicer.org/slicerWiki/index.php/Documentation/4.5/Modules/DWIConverter</documentation-url>
+  <documentation-url>https://slicer.readthedocs.io/en/latest/user_guide/modules/dwiconvert.html</documentation-url>
   <license>Apache License Version 2.0</license>
   <contributor>Hans Johnson (UIowa), Vince Magnotta (UIowa) Joy Matsui (UIowa), Kent Williams (UIowa), Mark Scully (Uiowa), Xiaodong Tao (GE)</contributor>
   <acknowledgements><![CDATA[This work is part of the National Alliance for Medical Image Computing (NAMIC), funded by the National Institutes of Health through the NIH Roadmap for Medical Research, Grant U54 EB005149.  Additional support for DTI data produced on Philips scanners was contributed by Vincent Magnotta and Hans Johnson at the University of Iowa.]]></acknowledgements>


### PR DESCRIPTION
Slicer module documentation is being moved from Slicer wiki to slicer.readthedocs.io. CLI module descriptor files are updated accordingly (along with some typo fixes).

@hjmjohnson
