### PR TITLE
STYLE: Replace (*p).member with p->member in library code

### DIFF
--- a/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
+++ b/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
@@ -153,14 +153,14 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>::RegisterIntraSubjectIm
       // NEED A "USE_CACHED_VAULES commandline flag
 #ifdef QUICK_FALLTHROUGH_IF_EXISTS // PROVIDES a fall through to avoid estimating transforms, only useful for repeat
                                    // runs
-      std::cerr << "FILENAME  " << (*isNamesIt).c_str() << std::flush << std::endl;
-      if (itksys::SystemTools::FileExists((*isNamesIt).c_str()))
+      std::cerr << "FILENAME  " << isNamesIt->c_str() << std::flush << std::endl;
+      if (itksys::SystemTools::FileExists(isNamesIt->c_str()))
       {
         try
         {
-          muLogMacro(<< "Reading transform from file: " << (*isNamesIt).c_str() << "." << std::endl);
+          muLogMacro(<< "Reading transform from file: " << isNamesIt->c_str() << "." << std::endl);
           m_IntraSubjectTransforms[mapOfModalImageListsIt->first].push_back(
-            itk::ReadTransformFromDisk((*isNamesIt).c_str()));
+            itk::ReadTransformFromDisk(isNamesIt->c_str()));
         }
         catch (...)
         {
@@ -175,7 +175,7 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>::RegisterIntraSubjectIm
         muLogMacro(<< "Registering (Identity) image to key image." << std::endl);
         m_IntraSubjectTransforms[mapOfModalImageListsIt->first].push_back(MakeRigidIdentity());
       }
-      else if ((*intraImIt).GetPointer() == this->m_KeySubjectImage.GetPointer())
+      else if (intraImIt->GetPointer() == this->m_KeySubjectImage.GetPointer())
       {
         muLogMacro(<< "Key image registered to itself with Identity transform." << std::endl);
         m_IntraSubjectTransforms[mapOfModalImageListsIt->first].push_back(MakeRigidIdentity());
@@ -201,7 +201,7 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>::RegisterIntraSubjectIm
         // INFO: Find way to turn on histogram equalization for same mode images
         constexpr int dilateSize = 15;
         constexpr int closingSize = 15;
-        intraSubjectRegistrationHelper->SetMovingVolume((*intraImIt).GetPointer());
+        intraSubjectRegistrationHelper->SetMovingVolume(intraImIt->GetPointer());
         muLogMacro(<< "Generating MovingImage Mask (Intrasubject  " << i << ")" << std::endl);
         using ROIAutoType = itk::BRAINSROIAutoImageFilter<InternalImageType, itk::Image<unsigned char, 3>>;
         typename ROIAutoType::Pointer ROIFilter = ROIAutoType::New();
@@ -364,7 +364,7 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>::AverageIntraSubjectReg
     {
       auto intraImIt = this->m_RegisteredIntraSubjectImagesList[mapOfRegisteredModalImageListsIt->first]
                          .begin(); // each intra subject image
-      this->m_ModalityAveragedOfIntraSubjectImages.push_back((*intraImIt).GetPointer());
+      this->m_ModalityAveragedOfIntraSubjectImages.push_back(intraImIt->GetPointer());
     }
     else
     {

--- a/BRAINSABC/brainseg/BRAINSABC.cxx
+++ b/BRAINSABC/brainseg/BRAINSABC.cxx
@@ -583,7 +583,7 @@ main(int argc, char ** argv)
                          << ": " << (*imIt) << "...\n");
 
               LocalReaderPointer imgreader = LocalReaderType::New();
-              imgreader->SetFileName((*imIt).c_str());
+              imgreader->SetFileName(imIt->c_str());
 
               try
               {
@@ -653,7 +653,7 @@ main(int argc, char ** argv)
               std::string intraSubjectTransformFileName =
                 std::string("")
                   .append(outputDir)
-                  .append(GetStrippedImageFileNameExtension((*imIt).c_str()))
+                  .append(GetStrippedImageFileNameExtension(imIt->c_str()))
                   .append("_to_")
                   .append(GetStrippedImageFileNameExtension(GetMapVectorFirstElement(inputVolumeMap)))
                   .append(suffixstr)

--- a/BRAINSABC/brainseg/BRAINSABCUtilities.cxx
+++ b/BRAINSABC/brainseg/BRAINSABCUtilities.cxx
@@ -58,7 +58,7 @@ ResampleImageListToFirstKeyImage(const std::string &            resamplerInterpo
     while (currImageIter != elem.second.end())
     {
       FloatImageType::Pointer tmp = ResampleImageWithIdentityTransform<FloatImageType>(
-        resamplerInterpolatorType, 0, (*currImageIter).GetPointer(), KeyImageFirstRead.GetPointer());
+        resamplerInterpolatorType, 0, currImageIter->GetPointer(), KeyImageFirstRead.GetPointer());
       // Add the image
       outputImageMap[elem.first].push_back(tmp);
       ++currImageIter;
@@ -118,7 +118,7 @@ ResampleToFirstImageList(const std::string &            resamplerInterpolatorTyp
 
       using VersorRigid3DTransformType = itk::VersorRigid3DTransform<double>;
       const VersorRigid3DTransformType::ConstPointer tempRigidTransform =
-        dynamic_cast<VersorRigid3DTransformType const *>((*xfrmIt).GetPointer());
+        dynamic_cast<VersorRigid3DTransformType const *>(xfrmIt->GetPointer());
       if (tempRigidTransform.IsNull())
       {
         std::cerr << "Error in type conversion. " << __FILE__ << __LINE__ << std::endl;
@@ -164,7 +164,7 @@ ResampleToFirstImageList(const std::string &            resamplerInterpolatorTyp
     {
       using MinMaxType = itk::MinimumMaximumImageCalculator<FloatImageType>;
       MinMaxType::Pointer minmaxcalc = MinMaxType::New();
-      minmaxcalc->SetImage((*currModalIter).GetPointer());
+      minmaxcalc->SetImage(currModalIter->GetPointer());
       minmaxcalc->ComputeMinimum();
       minmaxcalc->Compute();
 
@@ -175,7 +175,7 @@ ResampleToFirstImageList(const std::string &            resamplerInterpolatorTyp
       FloatImageType::Pointer resampledToFirstImage =
         ResampleImageWithIdentityTransform<FloatImageType>(resamplerInterpolatorType,
                                                            background_threshold_value,
-                                                           (*currModalIter).GetPointer(),
+                                                           currModalIter->GetPointer(),
                                                            allModalityKeySubjectImage.GetPointer());
 
       using OtsuThresholdType = itk::OtsuThresholdImageFilter<FloatImageType, ByteImageType>;

--- a/BRAINSCommonLib/GenericTransformImage.cxx
+++ b/BRAINSCommonLib/GenericTransformImage.cxx
@@ -420,7 +420,7 @@ ReadTransformFromDisk(const std::string & initialTransform)
            it != currentTransformList.end();
            ++it)
       {
-        tempCopy->AddTransform(static_cast<itk::Transform<TScalarType, 3, 3> *>((*it).GetPointer()));
+        tempCopy->AddTransform(static_cast<itk::Transform<TScalarType, 3, 3> *>(it->GetPointer()));
       }
       genericTransform = tempCopy.GetPointer();
     }

--- a/BRAINSCommonLib/itkInverseConsistentLandmarks.h
+++ b/BRAINSCommonLib/itkInverseConsistentLandmarks.h
@@ -146,7 +146,7 @@ public:
     LocalConstIterator itend = this->end();
     while (it != itend)
     {
-      const PointType   cur = (*it).second;
+      const PointType   cur = it->second;
       PointSetPointType psPoint;
       for (unsigned int i = 0; i < 3; ++i)
       {

--- a/BRAINSCommonLib/itkInverseConsistentLandmarks.hxx
+++ b/BRAINSCommonLib/itkInverseConsistentLandmarks.hxx
@@ -861,7 +861,7 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>::ReadAnalyzePointType
       std::string OriginalLabel(CurrentName);
 
       char labelbuffer[16];
-      while ((*this).find(CurrentName) != (*this).end())
+      while (this->find(CurrentName) != this->end())
       {
         sprintf(labelbuffer, "%d", label);
         CurrentName = OriginalLabel + "_" + std::string(labelbuffer);
@@ -1046,7 +1046,7 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>::ReadAnalyzePointType
       std::string OriginalLabel(CurrentName);
 
       char labelbuffer[16];
-      while ((*this).find(CurrentName) != (*this).end())
+      while (this->find(CurrentName) != this->end())
       {
         sprintf(labelbuffer, "%d", label);
         CurrentName = OriginalLabel + "_" + std::string(labelbuffer);

--- a/BRAINSConstellationDetector/src/BRAINSConstellationLandmarksTransform.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSConstellationLandmarksTransform.cxx
@@ -83,7 +83,7 @@ main(int argc, char * argv[])
       return EXIT_FAILURE;
     }
     auto transformIterator = transformList->begin();
-    auto disk_transform = dynamic_cast<itk::Transform<double, 3, 3> *>((*transformIterator).GetPointer());
+    auto disk_transform = dynamic_cast<itk::Transform<double, 3, 3> *>(transformIterator->GetPointer());
 
     if (isLandmarkTransform)
     {

--- a/BRAINSConstellationDetector/src/BinaryMaskEditorBasedOnLandmarks.cxx
+++ b/BRAINSConstellationDetector/src/BinaryMaskEditorBasedOnLandmarks.cxx
@@ -119,11 +119,11 @@ CutBinaryVolumeByPlaneWithDirection(typename TImageType::Pointer * _imageVolume,
     LandmarkPointType currentPhysicalLocation;
     (*_imageVolume)->TransformIndexToPhysicalPoint(it.GetIndex(), currentPhysicalLocation);
 
-    if (direction == "true" && (*currentPlane).GetRelativeLocationToPlane(currentPhysicalLocation) > 0.0F)
+    if (direction == "true" && currentPlane->GetRelativeLocationToPlane(currentPhysicalLocation) > 0.0F)
     {
       it.Set(0.0F);
     }
-    else if (direction == "false" && (*currentPlane).GetRelativeLocationToPlane(currentPhysicalLocation) < 0.0F)
+    else if (direction == "false" && currentPlane->GetRelativeLocationToPlane(currentPhysicalLocation) < 0.0F)
     {
       it.Set(0.0F);
     }

--- a/BRAINSConstellationDetector/src/landmarksConstellationModelIO.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationModelIO.h
@@ -565,7 +565,7 @@ public:
 
       IndexLocationVectorType::const_iterator locIt = DID.locations.begin();
       IndexLocationVectorType::const_iterator locItEnd = DID.locations.end();
-      for (auto floatIt = (*meanIt).begin(); locIt != locItEnd; ++floatIt, ++locIt)
+      for (auto floatIt = meanIt->begin(); locIt != locItEnd; ++floatIt, ++locIt)
       {
         FloatImageType::IndexType ind;
         for (unsigned k = 0; k < 3; k++)

--- a/BRAINSTransformConvert/BRAINSTransformConvert.cxx
+++ b/BRAINSTransformConvert/BRAINSTransformConvert.cxx
@@ -475,7 +475,7 @@ DoConversion(int argc, char * argv[])
       transformWriter->SetUseCompression(true);
       for (auto it = transformList->begin(); it != transformList->end(); ++it)
       {
-        typename GenericTransformType::Pointer outXfrm = dynamic_cast<GenericTransformType *>((*it).GetPointer());
+        typename GenericTransformType::Pointer outXfrm = dynamic_cast<GenericTransformType *>(it->GetPointer());
         transformWriter->AddTransform(outXfrm);
         //
         std::cout << "Output Transform Type Written to the Disk ==> " << outXfrm->GetTransformTypeAsString()


### PR DESCRIPTION
Simplified code by using the arrow operator, instead of using parentheses,
asterisk and dot operators.

Did so by replacing the regular expression "\(\*(\w+)\)\." with "->", followed
by a few manual fixes.

find . \( -iname "*.cxx" -or -iname "*.hxx" -or -iname "*.h" \) -exec perl -pi -w -e 's/\(\*(\w+)\)\./->/g' {} \;
