### PR TITLE
COMP: Fix error C2065: 'FindCenterOfBrain': undeclared identifier

### DIFF
--- a/BRAINSCommonLib/itkFindCenterOfBrainFilter.h
+++ b/BRAINSCommonLib/itkFindCenterOfBrainFilter.h
@@ -37,7 +37,7 @@ public:
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
   itkNewMacro(Self);
-  itkTypeMacro(FindCenterOfBrain, Superclass);
+  itkTypeMacro(FindCenterOfBrainFilter, Superclass);
 
   using ImageType = TInputImage;
   using MaskImageType = TMaskImage;


### PR DESCRIPTION
The error message was:
```log
105>------ Build started: Project: BRAINSCommonLib, Configuration: RelWithDebInfo x64 ------ 105>BRAINSFitHelper.cxx
105>M:\a\Srwd\BRAINSTools\BRAINSCommonLib\itkFindCenterOfBrainFilter.h(40,3): error C2065: 'FindCenterOfBrain': undeclared identifier 105>M:\a\Srwd\BRAINSTools\BRAINSCommonLib\itkFindCenterOfBrainFilter.h(40,3): error C2923: 'std::is_same_v': 'FindCenterOfBrain' is not a valid template type argument for parameter '<unnamed-symbol>' 105>M:\a\Srwd\BRAINSTools\BRAINSCommonLib\itkFindCenterOfBrainFilter.h(40,3): error C2062: type 'unknown-type' unexpected 105>Done building project "BRAINSCommonLib.vcxproj" -- FAILED.
```
This is a stumbling block for updating ITK in Slicer.