### PR TITLE
COMP: Support specifying macOS deployment target ≥ 11.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,12 @@ if(APPLE)
   # Note: By setting CMAKE_OSX_* variables before any enable_language() or project() calls,
   #       we ensure that the bitness, and C++ standard library will be properly detected.
   include(InitializeOSXVariables)
-  if(NOT CMAKE_OSX_DEPLOYMENT_TARGET EQUAL "11.0")
-      message(FATAL_ERROR "FAILURE ${CMAKE_OSX_DEPLOYMENT_TARGET} != 11.0")
+  set(required_deployment_target "11.0")
+  if("x${CMAKE_OSX_DEPLOYMENT_TARGET}x" STREQUAL "xx")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET ${required_deployment_target})
+  endif()
+  if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS ${required_deployment_target})
+    message(FATAL_ERROR "CMAKE_OSX_DEPLOYMENT_TARGET ${CMAKE_OSX_DEPLOYMENT_TARGET} must be ${required_deployment_target} or greater.")
   endif()
 endif()
 


### PR DESCRIPTION
Follow-up on 79e98d78 ("COMP: Set apple build environment flags consistently in packages.", 2024-06-03) to support targeting newer macOS versions.

This resolves a configuration error encountered when BRAINSTools is integrated as a subdirectory within the Slicer project:

```
CMake Error at /path/to/Slicer-build/BRAINSTools/CMakeLists.txt:34 (message):
  FAILURE 13.0 != 11.0
```

The regression was introduced following the BRAINSTools update in Slicer (Slicer/Slicer@244a6c3a788, "ENH: Update BRAINSTools from 2024-05-31 to 2024-11-09", 2025-01-24). Slicer itself updated its deployment target in:
- Slicer/Slicer@694731ddaf8 ("COMP: Update minimum required CMAKE_OSX_DEPLOYMENT_TARGET to 12.0", 2024-10-12)
- Slicer/Slicer@ba3a9fdc04c ("COMP: Update minimum required CMAKE_OSX_DEPLOYMENT_TARGET to 13.0", 2024-10-12)

This change ensures consistency between BRAINSTools and Slicer's macOS deployment target settings.