### PR TITLE
STYLE: Replace declare-then-initialize with direct initialization

### DIFF
--- a/ARCHIVE/BRAINSTalairach/vtkTalairachConversion.cxx
+++ b/ARCHIVE/BRAINSTalairach/vtkTalairachConversion.cxx
@@ -314,8 +314,7 @@ vtkTalairachConversion::ProcessBOX(bool _left)
     /* Base the Distance on the High Resolution Grid */
     yStart1 = this->TalairachGrid->GetPoint(yGridStartIndex * TALAIRACH_X_POINTS)[1];
     yStart2 = this->TalairachGrid->GetPoint((yGridStartIndex + 1) * TALAIRACH_X_POINTS)[1];
-    vtkTalairachConversion::ImageType::PointType regionStart;
-    regionStart.Fill(0.0);
+    vtkTalairachConversion::ImageType::PointType regionStart{};
     regionStart[1] = yStart1 + boxDistancePercentage * (yStart2 - yStart1);
 
     if ((this->SegmentationMode) && (yGridStartIndex == 0) && (boxDistancePercentage == 0.0))
@@ -395,8 +394,7 @@ vtkTalairachConversion::ProcessBOX(bool _left)
     yEnd1 = this->TalairachGrid->GetPoint(yGridEndIndex * TALAIRACH_X_POINTS)[1];
     yEnd2 = this->TalairachGrid->GetPoint((yGridEndIndex + 1) * TALAIRACH_X_POINTS)[1];
 
-    ImageType::PointType regionEnd;
-    regionEnd.Fill(0.0);
+    ImageType::PointType regionEnd{};
     regionEnd[1] = yEnd1 + boxDistancePercentage * (yEnd2 - yEnd1);
 
     if ((this->SegmentationMode) && (yGridEndIndex == 10) && (boxDistancePercentage == 1.0))

--- a/ARCHIVE/BRAINSTexture/CenterOfROIInitTest.cxx
+++ b/ARCHIVE/BRAINSTexture/CenterOfROIInitTest.cxx
@@ -44,10 +44,8 @@ main(int, char **)
   ImageType::Pointer image1 = ImageType::New(), image2 = ImageType::New();
 
   ImageType::RegionType region;
-  ImageType::SizeType   size;
-  ImageType::IndexType  origin;
-  size.Fill(100);
-  origin.Fill(0);
+  auto                  size = itk::MakeFilled<ImageType::SizeType>(100);
+  ImageType::IndexType  origin{};
   region.SetSize(size);
   region.SetIndex(origin);
 
@@ -63,8 +61,8 @@ main(int, char **)
   TransformType::Pointer tfm = TransformType::New();
   tfm->SetIdentity();
 
-  TransformType::OutputVectorType rotAxis;
-  TransformType::OutputVectorType transVector;
+  auto rotAxis = itk::MakeFilled<TransformType::OutputVectorType>(1.);
+  auto transVector = itk::MakeFilled<TransformType::OutputVectorType>(50);
 
   // and two ellipses, one of which is rotated and translated
   EllipseSOType::ArrayType ePar;
@@ -72,7 +70,6 @@ main(int, char **)
   ePar[1] = 20;
   ePar[2] = 40;
 
-  transVector.Fill(50);
 
   tfm->Translate(transVector);
   ellipse->SetRadius(ePar);
@@ -86,7 +83,6 @@ main(int, char **)
   e2image->Update();
   ImageType::Pointer eImage = e2image->GetOutput();
 
-  rotAxis.Fill(1.);
   float rotAngle = 3.14 / 3.;
   tfm->Rotate3D(rotAxis, rotAngle);
   transVector[0] = 10;

--- a/BRAINSCommonLib/ConvertToRigidAffine.h
+++ b/BRAINSCommonLib/ConvertToRigidAffine.h
@@ -100,8 +100,7 @@ AssignConvertedTransform(AffineTransformPointer & result, const VnlTransformMatr
     {
       offset[i] = matrix.get(i, 3);
     }
-    itk::Point<double, 3> ZeroCenter;
-    ZeroCenter.Fill(0.0);
+    itk::Point<double, 3> ZeroCenter{};
     result->SetIdentity();
     result->SetCenter(ZeroCenter); // Assume that rotation is about 0.0
     result->SetMatrix(rotator);

--- a/BRAINSCommonLib/TestSuite/DWIMetaDataDictionaryValidatorTest.cxx
+++ b/BRAINSCommonLib/TestSuite/DWIMetaDataDictionaryValidatorTest.cxx
@@ -90,11 +90,9 @@ CreateVolume(const size_t numOfComponents)
 {
   constexpr int imageSize = 11; // each image component has size of imageSize^3
 
-  VectorImageType::IndexType start;
-  start.Fill(0);
+  VectorImageType::IndexType start{};
 
-  VectorImageType::SizeType size;
-  size.Fill(imageSize);
+  auto size = itk::MakeFilled<VectorImageType::SizeType>(imageSize);
 
   VectorImageType::RegionType region(start, size);
 

--- a/BRAINSCommonLib/TestSuite/itkResampleInPlaceImageFilterTest.cxx
+++ b/BRAINSCommonLib/TestSuite/itkResampleInPlaceImageFilterTest.cxx
@@ -84,12 +84,10 @@ main(int argc, char * argv[])
   }
 
   // Set up transforms
-  itk::Vector<double, 3> rotationAxis;
-  rotationAxis.Fill(0.);
+  auto rotationAxis = itk::MakeFilled<itk::Vector<double, 3>>(0.);
   rotationAxis[0] = 1.;
-  const double           rotationAngle = .5; // in rad
-  itk::Vector<double, 3> translation;
-  translation.Fill(0.);
+  const double rotationAngle = .5; // in rad
+  auto         translation = itk::MakeFilled<itk::Vector<double, 3>>(0.);
   translation[1] = 300.; // in mm along P-axis
   const TransformType::Pointer transform = TransformType::New();
   transform->SetIdentity();

--- a/BRAINSCommonLib/itkBRAINSToolsTestMain.h
+++ b/BRAINSCommonLib/itkBRAINSToolsTestMain.h
@@ -335,8 +335,7 @@ RegressionTestImage(const char *         testImageFilename,
     using ExtractType = itk::ExtractImageFilter<OutputType, DiffOutputType>;
     using WriterType = itk::ImageFileWriter<DiffOutputType>;
     using RegionType = itk::ImageRegion<ITK_TEST_DIMENSION_MAX>;
-    OutputType::SizeType size;
-    size.Fill(0);
+    OutputType::SizeType size{};
 
     RescaleType::Pointer rescale = RescaleType::New();
     rescale->SetOutputMinimum(itk::NumericTraits<unsigned char>::NonpositiveMin());
@@ -347,8 +346,7 @@ RegressionTestImage(const char *         testImageFilename,
 
     // Get the center slice of the image,  In 3D, the first slice
     // is often a black slice with little debugging information.
-    OutputType::IndexType index;
-    index.Fill(0);
+    OutputType::IndexType index{};
     for (unsigned int i = 2; i < ITK_TEST_DIMENSION_MAX; ++i)
     {
       index[i] = size[i] / 2; // NOTE: Integer Divide used to get approximately

--- a/BRAINSCommonLib/itkV3TestKernel/include/itkRandomImageSource.hxx
+++ b/BRAINSCommonLib/itkV3TestKernel/include/itkRandomImageSource.hxx
@@ -200,9 +200,8 @@ void
 RandomImageSource<TOutputImage>::GenerateOutputInformation()
 {
   TOutputImage * output;
-  IndexType      index;
+  IndexType      index{};
 
-  index.Fill(0);
 
   output = this->GetOutput(0);
 

--- a/BRAINSCommonLib/itkV3TestKernel/include/itkTestDriverInclude.h
+++ b/BRAINSCommonLib/itkV3TestKernel/include/itkTestDriverInclude.h
@@ -406,8 +406,7 @@ RegressionTestImage(const char *         testImageFilename,
     using ExtractType = itk::Testing::ExtractSliceImageFilter<OutputType, DiffOutputType>;
     using WriterType = itk::ImageFileWriter<DiffOutputType>;
     using RegionType = itk::ImageRegion<ITK_TEST_DIMENSION_MAX>;
-    OutputType::SizeType size;
-    size.Fill(0);
+    OutputType::SizeType size{};
 
     RescaleType::Pointer rescale = RescaleType::New();
     rescale->SetOutputMinimum(itk::NumericTraits<unsigned char>::NonpositiveMin());
@@ -418,8 +417,7 @@ RegressionTestImage(const char *         testImageFilename,
 
     // Get the center slice of the image,  In 3D, the first slice
     // is often a black slice with little debugging information.
-    OutputType::IndexType index;
-    index.Fill(0);
+    OutputType::IndexType index{};
     for (unsigned int i = 2; i < ITK_TEST_DIMENSION_MAX; i++)
     {
       index[i] = size[i] / 2; // NOTE: Integer Divide used to get approximately

--- a/BRAINSCommonLib/itkV3TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/BRAINSCommonLib/itkV3TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -74,12 +74,10 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::SetExtractionRegion(InputIma
 {
   m_ExtractionRegion = extractRegion;
 
-  unsigned int        nonzeroSizeCount = 0;
-  InputImageSizeType  inputSize = extractRegion.GetSize();
-  OutputImageSizeType outputSize;
-  outputSize.Fill(0);
-  OutputImageIndexType outputIndex;
-  outputIndex.Fill(0);
+  unsigned int         nonzeroSizeCount = 0;
+  InputImageSizeType   inputSize = extractRegion.GetSize();
+  OutputImageSizeType  outputSize{};
+  OutputImageIndexType outputIndex{};
   /**
    * check to see if the number of non-zero entries in the extraction region
    * matches the number of dimensions in the output image.

--- a/BRAINSConstellationDetector/gui/BRAINSConstellationDetectorGUI.cxx
+++ b/BRAINSConstellationDetector/gui/BRAINSConstellationDetectorGUI.cxx
@@ -254,8 +254,7 @@ main(int argc, char * argv[])
 
   // calculate the physical image extent of input image with identity
   // direction
-  ImageDirectionType direction2;
-  direction2.Fill(0);
+  ImageDirectionType direction2{};
   direction2(0, 0) = 1.0;
   direction2(1, 1) = 1.0;
   direction2(2, 2) = 1.0;

--- a/BRAINSConstellationDetector/src/BRAINSConstellationModeler.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSConstellationModeler.cxx
@@ -261,8 +261,7 @@ main(int argc, char * argv[])
       image = volOrig;
     }
 
-    SImageType::PointType origin;
-    origin.Fill(0);
+    SImageType::PointType origin{};
 
     // This section assumes that the landmarks are defined as
     // ITK compliant physical space
@@ -534,8 +533,7 @@ main(int argc, char * argv[])
   std::vector<float> RPPC_to_RPAC_angle(myModel.GetNumDataSets());
   std::vector<float> RPAC_over_RPPC(myModel.GetNumDataSets());
   // Initializing CMtoRPMean
-  SImageType::PointType::VectorType CMtoRPMean;
-  CMtoRPMean.Fill(0.0);
+  SImageType::PointType::VectorType CMtoRPMean{};
   // This for loop does two jobs
   for (unsigned int currentDataset = 0; currentDataset < myModel.GetNumDataSets(); currentDataset++)
   {

--- a/BRAINSConstellationDetector/src/itkReflectiveCorrelationCenterToImageMetric.h
+++ b/BRAINSConstellationDetector/src/itkReflectiveCorrelationCenterToImageMetric.h
@@ -434,8 +434,7 @@ public:
     }
 
     // Define start index
-    SImageType::IndexType outputImageStartIndex;
-    outputImageStartIndex.Fill(0);
+    SImageType::IndexType outputImageStartIndex{};
 
     // Define the output image direction identical
     SImageType::DirectionType outputImageDirection;

--- a/BRAINSConstellationDetector/src/landmarkIO.cxx
+++ b/BRAINSConstellationDetector/src/landmarkIO.cxx
@@ -84,9 +84,8 @@ GenerateRGB2DImage(const RGBImageType::Pointer & orientedImage)
 {
   // Alocate 2DImage
   RGB2DImageType::Pointer   TwoDImage = RGB2DImageType::New();
-  RGB2DImageType::IndexType TwoDIndex;
+  RGB2DImageType::IndexType TwoDIndex{};
 
-  TwoDIndex[0] = 0;
   TwoDIndex[1] = 0;
   RGB2DImageType::SizeType TwoDSize;
   TwoDSize[0] = orientedImage->GetLargestPossibleRegion().GetSize()[1];

--- a/BRAINSConstellationDetector/src/landmarksConstellationCommon.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationCommon.cxx
@@ -496,11 +496,10 @@ computeTmspFromPoints(SImageType::PointType RP,
 VersorRigidTransformType::Pointer
 GetACPCAlignedZeroCenteredTransform(const LandmarksMapType & landmarks)
 {
-  SImageType::PointType ZeroCenter;
+  SImageType::PointType ZeroCenter{};
 
   const auto orig_AC = GetNamedPointFromLandmarkList(landmarks, "AC");
 
-  ZeroCenter.Fill(0.0);
   VersorRigidTransformType::Pointer landmarkDefinedACPCAlignedToZeroTransform =
     computeTmspFromPoints_Versor(GetNamedPointFromLandmarkList(landmarks, "RP"),
                                  orig_AC,
@@ -660,13 +659,10 @@ MakeIsoTropicReferenceImage()
   SImageType::DirectionType Ident;
 
   Ident.SetIdentity();
-  SImageType::PointType Origin;
-  Origin.Fill(-127.5);
-  SImageType::SpacingType Spacing;
-  Spacing.Fill(1.0);
+  auto Origin = itk::MakeFilled<SImageType::PointType>(-127.5);
+  auto Spacing = itk::MakeFilled<SImageType::SpacingType>(1.0);
 
-  SImageType::SizeType Size;
-  Size.Fill(256);
+  auto                   Size = itk::MakeFilled<SImageType::SizeType>(256);
   SImageType::RegionType Region;
   Region.SetSize(Size);
 

--- a/BRAINSConstellationDetector/src/landmarksConstellationDetector.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationDetector.cxx
@@ -61,8 +61,7 @@ landmarksConstellationDetector::Compute_orig2msp_img_tfm(const SImagePointType &
                                                          const SImagePointType & AC,
                                                          const SImagePointType & PC)
 {
-  SImageType::PointType ZeroCenter;
-  ZeroCenter.Fill(0.0);
+  SImageType::PointType ZeroCenter{};
 
   const Euler3DTransformType::Pointer orig2msp_lmk_tfm_estimate = computeTmspFromPoints(RP, AC, PC, ZeroCenter);
 
@@ -372,8 +371,7 @@ landmarksConstellationDetector::FindCandidatePoints(
     roiSize[1] = static_cast<SImageType::SizeType::SizeValueType>(1.0 + LPS_END[1] - LPS_BEGIN[1]);
     roiSize[2] = static_cast<SImageType::SizeType::SizeValueType>(1.0 + LPS_END[2] - LPS_BEGIN[2]);
     // start index
-    SImageType::IndexType roiStart;
-    roiStart.Fill(0);
+    SImageType::IndexType roiStart{};
     // region
     const SImageType::RegionType roiRegion(roiStart, roiSize);
     roiImage->SetRegions(roiRegion);
@@ -499,8 +497,7 @@ landmarksConstellationDetector::FindCandidatePoints(
   mi_size[0] = 2 * height + 1;
   mi_size[1] = 2 * radii + 1;
   mi_size[2] = 2 * radii + 1;
-  FImageType3D::IndexType mi_start;
-  mi_start.Fill(0);
+  FImageType3D::IndexType        mi_start{};
   const FImageType3D::RegionType mi_region(mi_start, mi_size);
   lmkTemplateImage->SetRegions(mi_region);
   lmkTemplateImage->Allocate();
@@ -682,8 +679,7 @@ landmarksConstellationDetector::LinearEstimation(LandmarksMapType &             
     return;
   }
   const std::string &   newPointName = processingList[processingList.size() - 1];
-  SImageType::PointType newPoint;
-  newPoint.Fill(0);
+  SImageType::PointType newPoint{};
 
   // Construct Xi_t
   VectorType Xi_t;

--- a/BRAINSConstellationDetector/src/landmarksConstellationDetectorCompute.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationDetectorCompute.cxx
@@ -132,8 +132,7 @@ landmarksConstellationDetector::Compute(const SImageType::Pointer & orig_space_i
     LandmarksMapType zeroEyeCenters;
     if (this->m_HoughEyeFailure)
     {
-      SImageType::PointType zeroPoint;
-      zeroPoint.Fill(0);
+      SImageType::PointType zeroPoint{};
 
       zeroEyeCenters["LE"] = zeroPoint;
       zeroEyeCenters["RE"] = zeroPoint;

--- a/BRAINSConstellationDetector/src/tempSphereFromAreaEstimates.cxx
+++ b/BRAINSConstellationDetector/src/tempSphereFromAreaEstimates.cxx
@@ -257,8 +257,7 @@ FindCenterOfBrainBasedOnTopOfHead(SImageType::Pointer & foreground,
     double SupInf_thickness = 0;
     double RLbyAP_area = 0;
     {
-      SImageType::IndexType origin;
-      origin.Fill(0);
+      SImageType::IndexType           origin{};
       const auto                      physOrigin = volOrig->template TransformIndexToPhysicalPoint<double>(origin);
       itk::ContinuousIndex<double, 3> originPlusOne;
       originPlusOne[0] = volOrig->GetSpacing()[0];

--- a/BRAINSDeface/BRAINSDeface.cxx
+++ b/BRAINSDeface/BRAINSDeface.cxx
@@ -251,10 +251,8 @@ main(int argc, char * argv[])
     maskInterpolator->SetInputImage(mask_labels);
 
     // pad the distance map
-    MaskImageType::SizeType lowerPadBound;
-    lowerPadBound.Fill(80); // 40 mm @ 0.5 mm spacing
-    MaskImageType::SizeType upperPadBound;
-    upperPadBound.Fill(80); // 40 mm @ 0.5 mm spacing
+    auto lowerPadBound = itk::MakeFilled<MaskImageType::SizeType>(80);
+    auto upperPadBound = itk::MakeFilled<MaskImageType::SizeType>(80);
 
     const itk::ConstantPadImageFilter<MaskImageType, MaskImageType>::Pointer padImageFilter =
       itk::ConstantPadImageFilter<MaskImageType, MaskImageType>::New();

--- a/BRAINSFit/TestSuite/CenterOfROIInitTest.cxx
+++ b/BRAINSFit/TestSuite/CenterOfROIInitTest.cxx
@@ -52,8 +52,7 @@ main(int, char **)
   using CastType = itk::CastImageFilter<ImageType, LocalMaskImageType>;
   using CompositeTransformType = itk::CompositeTransform<double, 3>;
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = itk::MakeFilled<ImageType::SizeType>(100);
 
   const TransformType::Pointer tfm = TransformType::New();
   tfm->SetIdentity();
@@ -85,8 +84,7 @@ main(int, char **)
 
   ImageType::Pointer eTfmImage;
   {
-    TransformType::OutputVectorType rotAxis;
-    rotAxis.Fill(1.);
+    auto        rotAxis = itk::MakeFilled<TransformType::OutputVectorType>(1.);
     const float rotAngle = 3.14 / 3.;
     tfm->Rotate3D(rotAxis, rotAngle);
     transVector[0] = 10;

--- a/BRAINSROIAuto/TestSuite/TestImage.cxx
+++ b/BRAINSROIAuto/TestSuite/TestImage.cxx
@@ -41,8 +41,7 @@ main(int, char * argv[])
   ImageType::RegionType::IndexType index;
   index[0] = index[1] = index[2] = 0;
   region.SetIndex(index);
-  ImageType::RegionType::SizeType size;
-  size[0] = imageDim;
+  auto size = ImageType::RegionType::SizeType::Filled(imageDim);
   size[1] = imageDim;
   size[2] = imageDim;
   region.SetSize(size);

--- a/BRAINSSuperResolution/EdgeBasedWeightedTV/FFTWUpsampleTest.cpp
+++ b/BRAINSSuperResolution/EdgeBasedWeightedTV/FFTWUpsampleTest.cpp
@@ -71,8 +71,7 @@ int
 main(int, char *[])
 {
   const std::complex<float>                     Zero(0.8F, 0.8F);
-  HalfHermetianImageType::RegionType::IndexType startIndex;
-  startIndex.Fill(0);
+  HalfHermetianImageType::RegionType::IndexType startIndex{};
   HalfHermetianImageType::RegionType region;
   region.SetIndex(startIndex);
   HalfHermetianImageType::RegionType::SizeType size;
@@ -160,16 +159,13 @@ main(int, char *[])
   using Image2D = itk::Image<float,3>;
   Image2D::Pointer im2 = Image2D::New();
   Image2D::RegionType region;
-  Image2D::RegionType::SizeType size;
-  size.Fill(IM2DSIZE);
+  auto size = itk::MakeFilled<Image2D::RegionType::SizeType>(IM2DSIZE);
   region.SetSize(size);
-  Image2D::SpacingType spacing;
-  spacing.Fill(1.25);
+  auto spacing = itk::MakeFilled<Image2D::SpacingType>(1.25);
   im2->SetSpacing(spacing);
   im2->SetRegions(region);
   im2->Allocate();
-  Image2D::IndexType idx;
-  idx.Fill(IM2DSIZE/2);
+  auto idx = itk::MakeFilled<Image2D::IndexType>(IM2DSIZE/2);
   idx.Fill(0);
   im2->SetPixel(idx,1.0F);
   //using GradientType = itk::GradientImageFilter<Image2D>;

--- a/BRAINSSuperResolution/EdgeBasedWeightedTV/GradientTest.cpp
+++ b/BRAINSSuperResolution/EdgeBasedWeightedTV/GradientTest.cpp
@@ -73,8 +73,7 @@ int
 main(int argc, char * argv[])
 {
   const std::complex<float>                     Zero(0.8F, 0.8F);
-  HalfHermetianImageType::RegionType::IndexType startIndex;
-  startIndex.Fill(0);
+  HalfHermetianImageType::RegionType::IndexType startIndex{};
   HalfHermetianImageType::RegionType region;
   region.SetIndex(startIndex);
   HalfHermetianImageType::RegionType::SizeType size;
@@ -162,16 +161,13 @@ main(int argc, char * argv[])
   using Image2D = itk::Image<float,3>;
   Image2D::Pointer im2 = Image2D::New();
   Image2D::RegionType region;
-  Image2D::RegionType::SizeType size;
-  size.Fill(IM2DSIZE);
+  auto size = itk::MakeFilled<Image2D::RegionType::SizeType>(IM2DSIZE);
   region.SetSize(size);
-  Image2D::SpacingType spacing;
-  spacing.Fill(1.25);
+  auto spacing = itk::MakeFilled<Image2D::SpacingType>(1.25);
   im2->SetSpacing(spacing);
   im2->SetRegions(region);
   im2->Allocate();
-  Image2D::IndexType idx;
-  idx.Fill(IM2DSIZE/2);
+  auto idx = itk::MakeFilled<Image2D::IndexType>(IM2DSIZE/2);
   idx.Fill(0);
   im2->SetPixel(idx,1.0F);
   //using GradientType = itk::GradientImageFilter<Image2D>;

--- a/BRAINSSuperResolution/EdgeBasedWeightedTV/OpWeightedL2.cpp
+++ b/BRAINSSuperResolution/EdgeBasedWeightedTV/OpWeightedL2.cpp
@@ -138,8 +138,7 @@ static FloatImageType::Pointer
 GetDiracDeltaImage(FloatImageType::Pointer edgemask)
 {
   FloatImageType::Pointer   p_image = CreateEmptyImage<FloatImageType>(edgemask);
-  FloatImageType::IndexType zeroIdx;
-  zeroIdx.Fill(0);
+  FloatImageType::IndexType zeroIdx{};
   p_image->SetPixel(zeroIdx, 1);
   return p_image;
 }

--- a/BRAINSSuperResolution/EdgeBasedWeightedTV/TestFFTW2D.cpp
+++ b/BRAINSSuperResolution/EdgeBasedWeightedTV/TestFFTW2D.cpp
@@ -59,8 +59,7 @@ main(int argc, char * argv[])
   CImageType::Pointer CR = CImageType::New();
   {
     CImageType::RegionType region;
-    CImageType::SizeType   size;
-    size.Fill(9);
+    auto size = itk::MakeFilled<CImageType::SizeType>(9);
     region.SetSize(size);
     CR->SetRegions(region);
   }

--- a/BRAINSSuperResolution/EdgeBasedWeightedTV/itkDivergenceImageFilter.h
+++ b/BRAINSSuperResolution/EdgeBasedWeightedTV/itkDivergenceImageFilter.h
@@ -234,8 +234,7 @@ public:
   virtual const RadiusType
   GetNeighborhoodRadius() const
   {
-    RadiusType r1;
-    r1.Fill(1);
+    auto r1 = itk::MakeFilled<RadiusType>(1);
     return r1;
   }
 

--- a/BRAINSSuperResolution/EdgeBasedWeightedTV/itkDivergenceImageFilter.hxx
+++ b/BRAINSSuperResolution/EdgeBasedWeightedTV/itkDivergenceImageFilter.hxx
@@ -112,8 +112,7 @@ DivergenceImageFilter<TInputImage, TRealType, TOutputImage>::GenerateInputReques
   // get a copy of the input requested region (should equal the output requested region)
   typename TInputImage::RegionType inputRequestedRegion = inputPtr->GetRequestedRegion();
 
-  RadiusType r1;
-  r1.Fill(1);
+  auto r1 = MakeFilled<RadiusType>(1);
   // pad the input requested region by the operator radius
   inputRequestedRegion.PadByRadius(r1);
 
@@ -207,8 +206,7 @@ DivergenceImageFilter<TInputImage, TRealType, TOutputImage>::ThreadedGenerateDat
   // Find the data-set boundary "faces"
   typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<RealVectorImageType>::FaceListType faceList;
   NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<RealVectorImageType>                        bC;
-  RadiusType                                                                                      r1;
-  r1.Fill(1);
+  auto r1 = MakeFilled<RadiusType>(1);
   faceList =
     bC(dynamic_cast<const RealVectorImageType *>(m_RealValuedInputImage.GetPointer()), outputRegionForThread, r1);
 

--- a/DWIConvert/DWIConverter.cxx
+++ b/DWIConvert/DWIConverter.cxx
@@ -23,8 +23,7 @@ DWIConverter::~DWIConverter() = default;
 DWIConverter::RotationMatrixType
 DWIConverter::GetSpacingMatrix() const
 {
-  RotationMatrixType SpacingMatrix;
-  SpacingMatrix.Fill(0.0);
+  RotationMatrixType SpacingMatrix{};
   SpacingMatrix[0][0] = this->m_Volume->GetSpacing()[0];
   SpacingMatrix[1][1] = this->m_Volume->GetSpacing()[1];
   SpacingMatrix[2][2] = this->m_Volume->GetSpacing()[2];
@@ -521,8 +520,7 @@ DWIConverter::ThreeDToFourDImage(const Volume3DUnwrappedType::Pointer & img) con
     size4D[1] = size3D[1];
     size4D[2] = size3D[2] / nVolumes;
     size4D[3] = nVolumes;
-    Volume4DType::IndexType index4D;
-    index4D.Fill(0);
+    Volume4DType::IndexType index4D{};
     region4D.SetIndex(index4D);
     region4D.SetSize(size4D);
 
@@ -535,10 +533,8 @@ DWIConverter::ThreeDToFourDImage(const Volume3DUnwrappedType::Pointer & img) con
   }
   Volume4DType::DirectionType direction4D;
   direction4D.SetIdentity();
-  Volume4DType::SpacingType spacing4D;
-  spacing4D.Fill(1.0);
-  Volume4DType::PointType origin4D;
-  origin4D.Fill(0.0);
+  auto                    spacing4D = itk::MakeFilled<Volume4DType::SpacingType>(1.0);
+  Volume4DType::PointType origin4D{};
   for (unsigned i = 0; i < 3; ++i)
   {
     for (unsigned j = 0; j < 3; ++j)
@@ -588,8 +584,7 @@ DWIConverter::FourDToThreeDImage(const Volume4DType::Pointer & img4D) const
     const int nVolumes = img4D->GetLargestPossibleRegion().GetSize()[3];
     size3D[2] = size4D[2] * nVolumes;
 
-    Volume3DUnwrappedType::IndexType index3D;
-    index3D.Fill(0);
+    Volume3DUnwrappedType::IndexType index3D{};
     region3D.SetIndex(index3D);
     region3D.SetSize(size3D);
 
@@ -602,10 +597,8 @@ DWIConverter::FourDToThreeDImage(const Volume4DType::Pointer & img4D) const
   }
   Volume3DUnwrappedType::DirectionType direction3D;
   direction3D.SetIdentity();
-  Volume3DUnwrappedType::SpacingType spacing3D;
-  spacing3D.Fill(1.0);
-  Volume3DUnwrappedType::PointType origin3D;
-  origin3D.Fill(0.0);
+  auto                             spacing3D = itk::MakeFilled<Volume3DUnwrappedType::SpacingType>(1.0);
+  Volume3DUnwrappedType::PointType origin3D{};
   for (unsigned i = 0; i < 3; ++i)
   {
     for (unsigned j = 0; j < 3; ++j)

--- a/DebugImageViewer/DebugImageViewerClientTest2.cxx
+++ b/DebugImageViewer/DebugImageViewerClientTest2.cxx
@@ -37,9 +37,7 @@ main(int, char **)
   region.SetIndex(2, 0);
 
   ImageType::SpacingType spacing;
-  spacing[0] = 1.0;
-  spacing[1] = 1.0;
-  spacing[2] = 1.0;
+  spacing.Fill(1.0);
 
   ImageType::Pointer   img = itkUtil::AllocateImageFromRegionAndSpacing<ImageType>(region, spacing);
   ImageType::IndexType index;

--- a/GTRACT/Cmdline/gtractAverageBvalues.cxx
+++ b/GTRACT/Cmdline/gtractAverageBvalues.cxx
@@ -134,12 +134,10 @@ main(int argc, char * argv[])
     throw;
   }
 
-  itk::Array<int> lut;
-  lut.SetSize(imageReader->GetOutput()->GetVectorLength());
+  itk::Array<int> lut(imageReader->GetOutput()->GetVectorLength(), 0);
   lut.Fill(0);
 
-  itk::Array<int> count;
-  count.SetSize(imageReader->GetOutput()->GetVectorLength());
+  itk::Array<int> count(imageReader->GetOutput()->GetVectorLength(), 0);
   count.Fill(0);
 
   if (debug)

--- a/GTRACT/Cmdline/gtractResampleCodeImage.cxx
+++ b/GTRACT/Cmdline/gtractResampleCodeImage.cxx
@@ -161,8 +161,7 @@ main(int argc, char * argv[])
   referenceImageReader->GetOutput()->Print(std::cout);
 
   CodeImageType::PointType        p2;
-  itk::ContinuousIndex<double, 3> imageIndex;
-  imageIndex[0] = 0;
+  itk::ContinuousIndex<double, 3> imageIndex{};
   imageIndex[1] = 0;
   imageIndex[2] = 0;
   const auto p1 = codeImageReader->GetOutput()->template TransformContinuousIndexToPhysicalPoint<double>(imageIndex);

--- a/GTRACT/Cmdline/gtractResampleFibers.cxx
+++ b/GTRACT/Cmdline/gtractResampleFibers.cxx
@@ -196,8 +196,7 @@ main(int argc, char * argv[])
 
   using boundaryConditionType = itk::ConstantBoundaryCondition<DisplacementFieldType>;
   using ConstNeighborhoodIteratorType = itk::ConstNeighborhoodIterator<DisplacementFieldType, boundaryConditionType>;
-  ConstNeighborhoodIteratorType::RadiusType radius;
-  radius[0] = 1;
+  auto radius = ConstNeighborhoodIteratorType::RadiusType::Filled(1);
   radius[1] = 1;
   radius[2] = 1;
 

--- a/GTRACT/Cmdline/gtractTensor.cxx
+++ b/GTRACT/Cmdline/gtractTensor.cxx
@@ -245,9 +245,7 @@ main(int argc, char * argv[])
       resampler->SetDefaultPixelValue(0);
 
       IndexImageType::SpacingType spacing;
-      spacing[0] = voxelSize;
-      spacing[1] = voxelSize;
-      spacing[2] = voxelSize;
+      spacing.Fill(voxelSize);
       resampler->SetOutputSpacing(spacing);
 
       // Use the same origin

--- a/GTRACT/Common/itkAnatomicalBSplineFilter.cxx
+++ b/GTRACT/Common/itkAnatomicalBSplineFilter.cxx
@@ -103,12 +103,11 @@ AnatomicalBSplineFilter::Update()
   /*** Setup the B-SPline Parameters ***/
   TransformRegionType bsplineRegion;
   TransformSizeType   gridSizeOnImage;
-  TransformSizeType   gridBorderSize;
+  auto                gridBorderSize = itk::MakeFilled<TransformSizeType>(m_GridBorderSize);
   TransformSizeType   totalGridSize;
 
   gridSizeOnImage.SetSize(m_GridSize.GetSize());
-  gridBorderSize.Fill(m_GridBorderSize); // Border for spline order = 3 ( 1
-                                         // lower, 2 upper )
+  // lower, 2 upper )
   totalGridSize = gridSizeOnImage + gridBorderSize;
 
   // bsplineRegion.SetSize( totalGridSize );

--- a/GTRACT/Common/itkAnatomicalVersorRigidFilter.cxx
+++ b/GTRACT/Common/itkAnatomicalVersorRigidFilter.cxx
@@ -96,9 +96,8 @@ AnatomicalVersorRigidFilter::Update()
             << std::endl;
 
   VersorType rotation;
-  VectorType axis;
+  VectorType axis{};
 
-  axis[0] = 0.0;
   axis[1] = 0.0;
   axis[2] = 0.0;
   axis[m_InitialRotationAxis] = 1.0;

--- a/GTRACT/Common/itkComputeDiffusionTensorImageFilter.cxx
+++ b/GTRACT/Common/itkComputeDiffusionTensorImageFilter.cxx
@@ -130,8 +130,7 @@ ComputeDiffusionTensorImageFilter ::Update()
       TensorIndex[i] = ADCIndex[i];
     }
 
-    OutputPixelType currentVoxel;
-    currentVoxel.Fill(0);
+    OutputPixelType currentVoxel{};
 
     if (ADC0 > m_BackgroundThreshold)
     {

--- a/GTRACT/Common/itkDtiFastMarchingCostFilter.hxx
+++ b/GTRACT/Common/itkDtiFastMarchingCostFilter.hxx
@@ -70,8 +70,7 @@ DtiFastMarchingCostFilter<TLevelSet, TTensorImage>::DtiFastMarchingCostFilter()
 {
   this->ProcessObject::SetNumberOfRequiredInputs(0);
 
-  OutputSizeType outputSize;
-  outputSize.Fill(16);
+  auto                                  outputSize = MakeFilled<OutputSizeType>(16);
   typename LevelSetImageType::IndexType outputIndex;
   outputIndex.Fill(0);
 
@@ -487,16 +486,14 @@ DtiFastMarchingCostFilter<TLevelSet, TTensorImage>::InitializeTrialPoints(
 
   // Get complete neighborhood of alive point to process as trial points
 
-  ConstNeighborhoodIteratorType::RadiusType radius;
-  radius.Fill(1);
+  auto                          radius = MakeFilled<ConstNeighborhoodIteratorType::RadiusType>(1);
   ConstNeighborhoodIteratorType eigNeighborIt(
     radius, m_EigenvectorImage, m_EigenvectorImage->GetLargestPossibleRegion());
 
   eigNeighborIt.SetLocation(neighIndex); // set center at alive point index
 
   EigenvectorImageType::IndexType           eigIndex = eigNeighborIt.GetIndex();
-  ConstNeighborhoodIteratorType::OffsetType eigoffset;
-  eigoffset.Fill(0);
+  ConstNeighborhoodIteratorType::OffsetType eigoffset{};
   for (unsigned i = 0; i < eigNeighborIt.Size(); i++)
   {
     eigIndex = eigNeighborIt.GetIndex(i); // eigIndex is new trial point
@@ -610,8 +607,7 @@ DtiFastMarchingCostFilter<TLevelSet, TTensorImage>::UpdateNeighbors(
   // Get complete neighborhood of alive point to process as trial points
   using ConstNIterType = itk::ConstNeighborhoodIterator<EigenvectorImageType>;
 
-  ConstNIterType::RadiusType radius;
-  radius.Fill(1);
+  auto           radius = MakeFilled<ConstNIterType::RadiusType>(1);
   ConstNIterType eigNeighborIt(radius, m_EigenvectorImage, m_EigenvectorImage->GetLargestPossibleRegion());
 
   eigNeighborIt.SetLocation(neighIndex); // set center at alive point index
@@ -689,13 +685,11 @@ DtiFastMarchingCostFilter<TLevelSet, TTensorImage>
   // Get complete neighborhood of trial point to calculate normal
 
   using ConstNIterType = itk::ConstNeighborhoodIterator<EigenvectorImageType>;
-  ConstNIterType::RadiusType radius;
-  radius.Fill(1);
+  auto           radius = MakeFilled<ConstNIterType::RadiusType>(1);
   ConstNIterType eigNeighborIt(radius, m_EigenvectorImage, m_EigenvectorImage->GetLargestPossibleRegion());
 
   eigNeighborIt.SetLocation(neighIndex); // set center at trial point index
-  ConstNIterType::OffsetType eigoffset;
-  eigoffset.Fill(0);
+  ConstNIterType::OffsetType eigoffset{};
   offsetList.clear();
   for (unsigned i = 0; i < eigNeighborIt.Size(); i++)
   {
@@ -843,13 +837,11 @@ DtiFastMarchingCostFilter<TLevelSet, TTensorImage>
   // Get complete neighborhood of trial point to calculate normal
 
   using ConstNIterType = itk::ConstNeighborhoodIterator<EigenvectorImageType>;
-  ConstNIterType::RadiusType radius;
-  radius.Fill(1);
+  auto           radius = MakeFilled<ConstNIterType::RadiusType>(1);
   ConstNIterType eigNeighborIt(radius, m_EigenvectorImage, m_EigenvectorImage->GetLargestPossibleRegion());
 
   eigNeighborIt.SetLocation(neighIndex); // set center at trial point index
-  ConstNIterType::OffsetType eigoffset;
-  eigoffset.Fill(0);
+  ConstNIterType::OffsetType eigoffset{};
   eigIndex = eigNeighborIt.GetIndex();
   for (unsigned i = 0; i < eigNeighborIt.Size(); i++)
   {

--- a/GTRACT/Common/itkEigenVectorToColorImageFilter.cxx
+++ b/GTRACT/Common/itkEigenVectorToColorImageFilter.cxx
@@ -74,8 +74,7 @@ EigenVectorToColorImageFilter ::Update()
   {
     index = it.GetIndex();
     InputPixelType  tensor = m_Input->GetPixel(index);
-    OutputPixelType currentVoxel;
-    currentVoxel.Fill(0);
+    OutputPixelType currentVoxel{};
     if (tensor.GetNorm() != 0)
     {
       TMatrix                          M = Tensor2Matrix(tensor);

--- a/GTRACT/Common/itkTensorLinearInterpolateImageFunction.hxx
+++ b/GTRACT/Common/itkTensorLinearInterpolateImageFunction.hxx
@@ -93,8 +93,7 @@ TensorLinearInterpolateImageFunction<TInputImage, TCoordRep>::EvaluateAtContinuo
    * neighbors. The weight for each neighbour is the fraction overlap
    * of the neighbor pixel with respect to a pixel centered on point.
    */
-  OutputType output;
-  output.Fill(0.0);
+  OutputType output{};
 
   RealType totalOverlap = 0.0;
   for (unsigned int counter = 0; counter < m_Neighbors; counter++)

--- a/GTRACT/Common/itkTensorToAnisotropyImageFilter.cxx
+++ b/GTRACT/Common/itkTensorToAnisotropyImageFilter.cxx
@@ -181,8 +181,7 @@ TensorToAnisotropyImageFilter ::computNeighborhoodVoxelAnisotropy()
   using NeighborhoodIteratorType = itk::ConstNeighborhoodIterator<InputImageType>;
   NeighborhoodIteratorType it;
 
-  NeighborhoodIteratorType::RadiusType radius;
-  radius.Fill(1);
+  auto radius = itk::MakeFilled<NeighborhoodIteratorType::RadiusType>(1);
   radius[2] = 0;
 
   // boundary condition


### PR DESCRIPTION
Replace two-line declare-then-initialize patterns with idiomatic C++ single-line initialization across 39 files, following N-Dekker's methodology from ITK.

Locally verified: full ninja build (841 targets), zero errors, zero new warnings.

<details>
<summary>Patterns applied (78 fixes total)</summary>

| Pattern | Files | Fixes | Transformation |
|---------|-------|-------|---------------|
| `fill_zero` | 23 | 37 | `Type v; v.Fill(0)` → `Type v{}` |
| `fill_nonzero` | 15 | 32 | `Type v; v.Fill(N)` → `auto v = MakeFilled<Type>(N)` |
| `elem_same` | 4 | 4 | `Type v; v[i]=x` (all same) → `Fill(x)` |
| `elem_zero` | 3 | 3 | `Type v; v[i]=0` → `Type v{}` |
| `setsize_fill` | 1 | 2 | `v.SetSize(N); v.Fill(V)` → `Type v(N, V)` |

### Patterns intentionally skipped

- **`elem_diff`** (`Type v; v[0]=x; v[1]=y;` → `Type v{x,y}`): ITK derived types (`Vector`, `Point`, `ContinuousIndex`) don't inherit `FixedArray`'s brace-init constructor; narrowing conversions (`int`→`SizeValueType`) also block this pattern.
- **`assign`** (`Type v; v = expr;` → `Type v = expr;`): Script's forward-reference hazard detection is unreliable — several fixes moved variable uses above their declarations.

</details>

<details>
<summary>Reference commits in ITK</summary>

- `6cb6bf9823` — N-Dekker: `fill_nonzero` pattern
- `9962e2f971` — N-Dekker: `elem_same` pattern
- `03941e42d8` — N-Dekker: `elem_diff` pattern

</details>

<!--
provenance: claude-code session 2026-04-12
pattern_tool: find_declare_then_init.py (itk-declare-then-init skill)
build_verified: ninja -j8, 841/841 targets, 0 errors, 0 new warnings
skipped_patterns: elem_diff (no brace-init ctor on derived types), assign (forward-ref hazards)
-->