### PR TITLE
COMP: Allow bundled VTK to build under GCC 14

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -189,6 +189,9 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT ${CMAKE_PROJECT_N
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
+  # GCC 14 errors on implicit-function-declaration; bundled VTK hdf5 uses vasprintf without _GNU_SOURCE.
+  string(APPEND ep_CMAKE_C_FLAGS " -Wno-error=implicit-function-declaration")
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${Slicer_${proj}_GIT_REPOSITORY}"


### PR DESCRIPTION
GCC 14 promotes implicit-function-declaration to a hard error. VTK's bundled hdf5 calls `vasprintf` (with `H5_HAVE_VASPRINTF` set but no `_GNU_SOURCE`), so it is implicitly declared and the build fails. This restores the pre-GCC-14 warning behavior for the VTK ExternalProject only; `vasprintf` still links correctly.

<details>
<summary>Context</summary>

Independent of the SuperBuild pin bumps. Needed to build VTK's bundled hdf5 on a GCC 14 toolchain (e.g. conda-forge gcc 14.3); harmless on older compilers.
</details>
