### PR TITLE
ENH: Add USE_SYSTEM_ANTs to build against a prebuilt ANTs

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -55,6 +55,7 @@ cmake_dependent_option(
   )
 
 option(USE_SYSTEM_ITK "Build using an externally defined version of ITK" OFF)
+option(USE_SYSTEM_ANTs "Build using an externally defined version of ANTs (find_package(ANTS); set ANTS_DIR)" OFF)
 option(USE_SYSTEM_SlicerExecutionModel "Build using an externally defined version of SlicerExecutionModel"  OFF)
 option(USE_SYSTEM_VTK "Build using an externally defined version of VTK" OFF)
 option(USE_SYSTEM_zlib "build using the system version of zlib" OFF)

--- a/SuperBuild/External_ANTs.cmake
+++ b/SuperBuild/External_ANTs.cmake
@@ -13,6 +13,26 @@ endif()
 # Set dependency list
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
 
+# Consume a pre-built ANTs instead of building it when USE_SYSTEM_ANTs is ON or
+# an ANTS_DIR is supplied (mirrors External_ITKv5 / External_VTK). The inner
+# build resolves ANTs via find_package(ANTS CONFIG) using ANTS_DIR.
+if(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+  unset(ANTS_DIR CACHE)
+  find_package(ANTS CONFIG REQUIRED)
+endif()
+
+if(DEFINED ANTS_DIR AND NOT EXISTS ${ANTS_DIR})
+  message(FATAL_ERROR "ANTS_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+
+if(DEFINED ANTS_DIR OR ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+  # ANTs supplied externally: add a no-op target so dependents resolve, expose
+  # ANTS_DIR to the inner build, and skip building ANTs.
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDENCIES})
+  mark_as_superbuild(VARS ANTS_DIR:PATH LABELS "FIND_PACKAGE")
+  return()
+endif()
+
 
 
 ### --- Project specific additions here


### PR DESCRIPTION
Add a `USE_SYSTEM_ANTs` option so BRAINSTools can build against a pre-built ANTs (via `find_package(ANTS CONFIG)`) instead of cloning and building its own, mirroring the existing `USE_SYSTEM_ITK` / `USE_SYSTEM_VTK` pattern.

<details>
<summary>What changed</summary>

`SuperBuild/External_ANTs.cmake` previously always built ANTs. It now, when `USE_SYSTEM_ANTs` is ON **or** an `ANTS_DIR` is supplied:
- runs `find_package(ANTS CONFIG REQUIRED)` (when `USE_SYSTEM_ANTs`),
- validates `ANTS_DIR`,
- adds a no-op `ExternalProject_Add_Empty(ANTs DEPENDS …)` so dependents still resolve (same mechanism `External_ITKv5.cmake` uses),
- exposes `ANTS_DIR` to the inner build (which already calls `find_package(ANTS CONFIG REQUIRED)`),
- and skips building ANTs.

`SuperBuild.cmake` gains the `option(USE_SYSTEM_ANTs …)` next to `USE_SYSTEM_ITK`.

The default path is unchanged: with neither flag set, ANTs is built from the configured `GIT_REPOSITORY`/`GIT_TAG`.

Usage:
```bash
cmake … -DUSE_SYSTEM_ANTs:BOOL=ON -DANTS_DIR:PATH=/path/to/lib/cmake/ANTS
# or simply pass a prebuilt -DANTS_DIR:PATH=… (skip-build is driven by ANTS_DIR, like ITK_DIR)
```
</details>

<details>
<summary>Local validation</summary>

Configured the SuperBuild both ways (CMake 4.3, Ninja):
- `USE_SYSTEM_ANTs=ON` + `ANTS_DIR=<prebuilt>`: configure succeeds; the ANTs EP performs **no** download/configure/build step (no-op empty target); dependents resolve; inner `find_package(ANTS)` consumes `ANTS_DIR`.
- No flags: configure succeeds; the real ANTs EP is scheduled cloning `ANTsX/ANTs`. Default behavior preserved.

`pre-commit run` clean on the changed files.
</details>

<!--
provenance: claude-code session 2026-06-18, itk_forest_build_testbed
base: BRAINSia/BRAINSTools@4349fc15 (main)
files: SuperBuild.cmake, SuperBuild/External_ANTs.cmake (+21 lines)
mechanism: mirrors External_ITKv5 USE_SYSTEM + ExternalProject_Add_Empty placeholder
motivation: forest testbed builds ANTs once (standalone) and reuses it for BRAINSTools
-->
