### PR TITLE
COMP: Find Threads before TBB so TBBConfig imported targets resolve

### DIFF
--- a/BRAINSTools.cmake
+++ b/BRAINSTools.cmake
@@ -73,6 +73,8 @@ if(USE_BRAINSABC)
   else()
     set( TBB_MIN_VERSION "2017.0")
   endif()
+  # TBBConfig's imported targets link Threads::Threads without finding it.
+  find_package(Threads REQUIRED)
   find_package(TBB ${TBB_MIN_VERSION} REQUIRED
 #               COMPONENTS tbb tbbmalloc
                NO_MODULE PATHS ${TBB_DIR} )


### PR DESCRIPTION
Find `Threads` before `find_package(TBB)` so TBB's imported target resolves during a CMake reconfigure of the inner build.

<details>
<summary>Root cause</summary>

The SuperBuild-installed `TBBConfig.cmake` declares `TBB::tbb` with
`INTERFACE_LINK_LIBRARIES "$<LINK_ONLY:Threads::Threads>;..."` but never calls
`find_package(Threads)`. When a consumer reconfigures, CMake fails generation with:

```
The link interface of target "TBB::tbb" contains:
    Threads::Threads
  but the target was not found.
```

Calling `find_package(Threads REQUIRED)` before the TBB lookup defines the
`Threads::Threads` imported target so the interface resolves. One-line, no
behavior change.

</details>

<!--
provenance: claude-code session 2026-06-20 (BRAINSTools updates)
symptom: inner-build CMake regenerate-during-build failed at TBBTargets.cmake set_target_properties (Threads::Threads not found)
file: BRAINSTools.cmake (USE_BRAINSABC TBB block)
-->
