### PR TITLE
BUG: Re-enable gtractConcatDwi_Concat_Dicom test (ITK #6003 fixes flake)

### DIFF
--- a/GTRACT/Cmdline/TestSuite/CMakeLists.txt
+++ b/GTRACT/Cmdline/TestSuite/CMakeLists.txt
@@ -128,17 +128,15 @@ set(DWITestFileDir ${DWIConvert_BINARY_DIR})
 #        --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${GTRACTTestName}.nii.test.nrrd
 #        )
 
-# DISABLED: GTRACTTest_gtractConcatDwi_Concat_Dicom — flaky on CI.
-# See https://github.com/BRAINSia/BRAINSTools/issues/596 for details.
-# add_test(NAME ${GTRACTTestName}_Concat_Dicom
-#         COMMAND ${LAUNCH_EXE} $<TARGET_FILE:gtractConcatDwiTests>
-#         gtractConcatDwiTest
-#         --inputVolume ${DWITestFileDir}/PhilipsAchieva1,${DWITestFileDir}/PhilipsAchieva1
-#         --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${GTRACTTestName}.dicom.test.nrrd
-#         )
-# set_property(TEST ${GTRACTTestName}_Concat_Dicom APPEND PROPERTY DEPENDS Uncompress_PhilipsAchieva1.tar.gz)
-
 if(USE_DWIConvert)  #dependancy needed for data creation
+add_test(NAME ${GTRACTTestName}_Concat_Dicom
+        COMMAND ${LAUNCH_EXE} $<TARGET_FILE:gtractConcatDwiTests>
+        gtractConcatDwiTest
+        --inputVolume ${DWITestFileDir}/PhilipsAchieva1,${DWITestFileDir}/PhilipsAchieva1
+        --outputVolume ${CMAKE_CURRENT_BINARY_DIR}/${GTRACTTestName}.dicom.test.nrrd
+        )
+set_property(TEST ${GTRACTTestName}_Concat_Dicom APPEND PROPERTY DEPENDS Uncompress_PhilipsAchieva1.tar.gz)
+
 # new added test case for GTRACT to support multi Dicom
 add_test(NAME ${GTRACTTestName}_Concat_multi_Dicom
         COMMAND ${LAUNCH_EXE} $<TARGET_FILE:gtractConcatDwiTests>


### PR DESCRIPTION
Re-enable `GTRACTTest_gtractConcatDwi_Concat_Dicom`, disabled in #596 for a flaky floating-point origin comparison. The root cause — NRRD float-metadata precision loss — is fixed upstream by [ITK PR #6003](https://github.com/InsightSoftwareConsortium/ITK/pull/6003) (merged, in ITKv6).

<details>
<summary>Why this is safe now</summary>

The test converts the same DICOM dir twice and compares NRRD origins with a
`1e-3` threshold. The flake came from ITK serializing float metadata at default
6-digit `ostream` precision; ITK #6003 switched to `ConvertNumberToString` for a
lossless round-trip.

Validated against the ITKv6 in use (`itkNrrdImageIO.cxx` now calls
`ConvertNumberToString`): a write→read→write→read round-trip of a full-precision
origin recovers it **bit-exactly** (origin distance `0`, 200/200 iterations), and
the on-disk header carries full 17-digit precision. The sibling
`_Concat_multi_Dicom` (same DICOM, same DWIConvert/DCMTK path) has passed
reliably throughout, which argues against the speculative DCMTK-nondeterminism
layer in #596.

The test is moved inside the `USE_DWIConvert` guard it depends on, alongside its
sibling.

</details>

<details>
<summary>Test execution note</summary>

Per local-test-first: this build variant excludes DICOM/DWIConvert/GTRACT (no
DCMTK), so the re-enabled test cannot be exercised locally here; and the original
flake was CI-resource-specific (never reproduced on macOS or locally), so local
execution would not exercise the failure mode regardless. The root-cause
mechanism was validated locally as above; CI (where the flake originally
manifested) is the appropriate first executor for the re-enabled test. Please
watch it over a few runs before relying on it.

</details>

<!--
provenance: claude-code session 2026-06-20 (BRAINSTools updates); closes loop on issue #596
itk_fix: PR #6003 merged 2026-04-09; itkNrrdImageIO.cxx uses ConvertNumberToString
local_validation: NRRD origin round-trip 200/200 bit-exact, dist=0, full-precision header
file: GTRACT/Cmdline/TestSuite/CMakeLists.txt (moved into USE_DWIConvert guard)
-->
