### PR TITLE
ENH: Use Eigen-backed itk::SymmetricEigenAnalysis; drop OpenBLAS dep

### DIFF
--- a/BRAINSSuperResolution/EdgeBasedWeightedTV/CMakeLists.txt
+++ b/BRAINSSuperResolution/EdgeBasedWeightedTV/CMakeLists.txt
@@ -21,8 +21,6 @@ list(REMOVE_DUPLICATES CMAKE_PREFIX_PATH)
 
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../../CMake/LinAlgSelector.cmake)
-
 ## Compiler flags -- TODO This could be better, see ITK it won't work on windows builds
 #--if(${CMAKE_BUILD_TYPE} MATCHES "Release")
 #--    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffast-math -O3") # -Wall -Wextra -Wmissing-prototypes")
@@ -66,7 +64,7 @@ set(MODULE_FOLDER "Module-EdgeBaseWeightedTV")
 
 add_library(SR_support FFTWUpsample.cpp OpWeightedL2.cpp)
 # -- RTK now part of ITK remote modules target_link_libraries(SR_support ${BRAINSSuperResolution_ITK_LIBRARIES} ${RTK_LIBRARIES} ${LINALG_LIBRARIES} ${VTK_LIBRARIES})
-target_link_libraries(SR_support PUBLIC ${BRAINSSuperResolution_ITK_LIBRARIES} ${LINALG_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(SR_support PUBLIC ${BRAINSSuperResolution_ITK_LIBRARIES} ${VTK_LIBRARIES})
 set_target_properties(SR_support PROPERTIES FOLDER ${MODULE_FOLDER})
 
 add_executable(TestSR SRmain.cpp)

--- a/BRAINSSuperResolution/EdgeBasedWeightedTV/itkDivergenceImageFilter.h
+++ b/BRAINSSuperResolution/EdgeBasedWeightedTV/itkDivergenceImageFilter.h
@@ -24,7 +24,7 @@
 #include "itkVector.h"
 #include "vnl/vnl_matrix.h"
 #include "vnl/vnl_vector_fixed.h"
-#include "vnl/algo/vnl_symmetric_eigensystem.h"
+#include "itkSymmetricEigenAnalysis.h"
 #include "itkMath.h"
 
 namespace itk
@@ -479,12 +479,18 @@ protected:
       }
     }
 
-    // Find the eigenvalues of g
-    vnl_symmetric_eigensystem<TRealType> E(g);
+    // Find the eigenvalues of g with the Eigen-backed itk::SymmetricEigenAnalysis
+    // (header-only, no LAPACK/BLAS); eigenvalues are returned in ascending order.
+    SymmetricEigenAnalysisFixedDimension<ImageDimension,
+                                         vnl_matrix<TRealType>,
+                                         vnl_vector_fixed<TRealType, ImageDimension>>
+                                                eigenSystem;
+    vnl_vector_fixed<TRealType, ImageDimension> eigenValues;
+    eigenSystem.ComputeEigenValues(g, eigenValues);
 
     // Return the difference in length between the first two principle axes.
     // Note that other edge strength metrics may be appropriate here instead..
-    return (E.get_eigenvalue(ImageDimension - 1) - E.get_eigenvalue(ImageDimension - 2));
+    return (eigenValues[ImageDimension - 1] - eigenValues[ImageDimension - 2]);
   }
 
   /** The weights used to scale derivatives during processing */


### PR DESCRIPTION
Replace the LAPACK-backed `vnl_symmetric_eigensystem` in
`EdgeBasedWeightedTV/itkDivergenceImageFilter` with the header-only,
Eigen-backed `itk::SymmetricEigenAnalysisFixedDimension`, removing
BRAINSTools' **only** external BLAS/LAPACK/ATLAS link dependency.

**AI assistance:** drafted with Claude Code (code analysis, the edit, and the
local build/test runs below). I reviewed the change and the results and am
accountable for the code; the AI-generated portion is the two-file diff and the
test snippet shown below.

<details>
<summary>What changed</summary>

- `itkDivergenceImageFilter.h`: the symmetric metric-tensor eigenvalues (2×2/3×3,
  edge strength = largest − second-largest eigenvalue) now come from
  `itk::SymmetricEigenAnalysisFixedDimension` (internally
  `Eigen::SelfAdjointEigenSolver`) instead of `vnl_symmetric_eigensystem`.
  Eigenvalue ordering (ascending) is preserved, so results are identical.
- `EdgeBasedWeightedTV/CMakeLists.txt`: drop the `LinAlgSelector.cmake` include
  and `${LINALG_LIBRARIES}` link.
</details>

<details>
<summary>Why</summary>

`vnl_symmetric_eigensystem` lives in `vnl/algo`, which is LAPACK-backed;
`LinAlgSelector` therefore required an external OpenBLAS/LAPACK/ATLAS. That call
was the sole BLAS/LAPACK consumer in the tree, so this removes the dependency
outright. ITK already bundles Eigen and exposes it via
`itk::SymmetricEigenAnalysis`, so no new dependency is added. For the small
fixed-size matrices the closed-form Eigen path also avoids LAPACK call overhead.
</details>

<details>
<summary>Local testing — ITK 5.4.6 and ITK 6 (origin/main)</summary>

Compiled the exact new code path (`SymmetricEigenAnalysisFixedDimension` over a
`vnl_matrix`) against both a built ITK 5.4.6 and a built ITK 6, via
`find_package(ITK COMPONENTS ITKCommon)`:

```
3x3 diag(1,2,3): 1 (expect 1)
2x2 [[2,1],[1,2]]: 2 (expect 2)
PASS ALL
ldd: no libblas / liblapack / libopenblas  (BLAS-free)
```

Both ITK versions: builds, numerically identical edge-strength, and the linked
binary pulls in no BLAS/LAPACK. (The full `BRAINSSuperResolution` SuperBuild
target is independently gated on `USE_ITKMatlabIO`/Matlab, unrelated to this
change, so the changed translation unit was verified in isolation against both
ITK versions rather than through the SuperBuild.)
</details>

<details>
<summary>Follow-up (not in this PR)</summary>

`CMake/LinAlgSelector.cmake` and `CMake/Find{OpenBLAS,LAPACKE,ATLAS}.cmake` are
now unreferenced and could be removed in a separate cleanup.
</details>

<!--
provenance: claude-code session 2026-06-23; testbed itk_forest_build_testbed
change: BRAINSSuperResolution/EdgeBasedWeightedTV (itkDivergenceImageFilter.h + CMakeLists.txt)
verified_itk: v5.4.6 and origin/main (ITK6); BLAS-free via ldd; eig-diff identical
-->
