### PR TITLE
DOC: Trim README and drop nav_order from the generated catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,144 +1,32 @@
-The BRAINSTools is a harness to assist in building the many of the BRAINSTools under development.
+# BRAINSTools
 
-Developers should run the `./Utilities/SetupForDevelopment.sh` script to get started.
+A CMake SuperBuild harness providing a suite of command-line tools for
+brain MRI processing — registration, segmentation, atlas generation, DWI
+processing, and defacing. Developed at the University of Iowa and also
+distributed as part of [3D Slicer](https://www.slicer.org/).
 
-If developing on Mac OS X, make sure the xcode command line tools are installed with the command:
-`xcode-select --install`
+**Documentation: <https://brainsia.github.io/BRAINSTools/>**
 
-For more information on the individual BRAINSTools, please see the following link:
-https://github.com/BRAINSia/BRAINSTools/wiki
+- [Tool catalog](https://brainsia.github.io/BRAINSTools/tools.html)
+- [Wiki](https://github.com/BRAINSia/BRAINSTools/wiki)
 
-## Building
-Linux-based system follows basically similar instruction.
+## Quick start
 
-```sh
-clone https://github.com/BRAINSia/BRAINSTools.git
-mkdir BRAINSTools_build
-cd BRAINSTools_build
-ccmake ../BRAINSTools
-make #make -j4 or make -j8 depending on the available cores
-```
-
-OS dependent instruction is given for any dependencies or other issues. Please report any issue you found so that we could update the instruction accordingly.
-
->
-> We also recommend to check out NAMICExternalProjects, https://github.com/BRAINSia/NAMICExternalProjects, which provides a set of tools, including ANTs Package, Slicer Modules, and our own BRAINSTools.
->
-
-### Mac OSX
-Building BRAINSTools on mac is the same as any standard out of
-source cmake build. Make a folder for the BRAINSTools project.
-Clone the BRAINSTools repository, and run the set-up script. Make
-a build directory contained in the same folder as the git repository.
-From the build directory, run cmake (or ccmake to manually configure
-the build settings) with the BRAINSTools repo as an argument, then
-run make. For Example:
-
-```sh
-mkdir brains
-cd brains
-git clone http://github.com/BRAINSIa/BRAINSTools.git
-
-cd BRAINSTools
-./Utilities/SetupForDevelopment.sh
-cd ..
-
-mkdir build
-cd build
-cmake ../BRAINSTools
-
-## NOTE: To configure options in the cmake GUI, use:
-##     ccmake ../BRAINSTools
-## instead
-make -j${NUMOFTHREADS} -k
-
-## NOTE: To find the number of threads from the OSX terminal, use:
-##    sysctl -n hw.ncpu
-```
-
-### Linux RedHat 6
-Example session for a clean build:
-
-```sh
-mkdir ~/src/mytester
-cd ~/src/mytester
-git clone https://github.com/BRAINSia/BRAINSTools.git
-
-cd BRAINSTools/
-bash ./Utilities/SetupForDevelopment.sh
-
-mkdir -p ../BRAINSTools-build
-cd ../BRAINSTools-build/
-CC=/usr/bin/gcc-4.2 CXX=/usr/bin/g++-4.2 ccmake ../BRAINSTools \
-    -DUSE_BRAINSConstellationDetector:BOOL=ON \
-    -DUSE_BRAINSABC:BOOL=ON
-
-make -j${NUMOFTHREADS} -k
-
-## NOTE: The fetching of data still has problems with parallel builds, so we need to restart it at least
-#        once
-make
-```
-
-### Linux Debian (Ubuntu)
-Building BRAINSTools on a fresh install has the additional dependency
-of building CMake on your system.  You cannot use the version from
-`apt-get` as that does some unnatural things with Python resources to
-be backwards compatible (see http://public.kitware.com/Bug/view.php?id=14156).
-
-1) Install the necessary dependencies:
-```sh
-sudo apt-get update
-sudo apt-get upgrade
-sudo apt-get install git python2.7
-python2.7-dev g++ freeglut3-dev
-```
-
-2) Get the CMake binaries:
-```sh
-# You can find the URL of the latest CMake binary by
-# * Go to www.cmake.org/download in a browser
-# * Hover over the desired 'Binary distribution' for your operating
-#     system
-# * Right-click and select 'Copy Link Address' for the file ending in
-#     "tar.gz"
-URL=http://www.cmake.org/files/v3.2/cmake-3.2.1-Linux-x86_64.tar.gz
-wget ${URL}
-# Decompress the file
-tar -xzvf cmake-3.2.1-Linux-x86_64.tar.gz
-# Add the binary to your PATH environment variable
-export PATH=${PWD}/cmake-3.2.1-Linux-x86_64/bin:${PATH}
-```
-
-2) Clone the repository and build:
 ```sh
 git clone https://github.com/BRAINSia/BRAINSTools.git
-mkdir build
-cd build
-CC=/usr/bin/gcc-4.8 \
-CXX=/usr/bin/g++-4.8 \
-cmake ../BRAINSTools \
-make -j${NUMOFTHREADS} -k
-```
-:warning: You can find the number of threads on your system in Ubuntu with `lscpu`
-
-## Testing
-`BRAINSTools_MAX_TEST_LEVEL` adjusts how agressive the test suite is
-so that long running tests or incomplete tests can easily be
-silenced
-
-```
-1 - Run the absolute minimum very fast tests (These should always pass before any code commit)
-3 - Run fast tests on continous builds (These need immediate attention if they begin to fail)
-5 - Run moderate nightly tests (These need immediate attention if they begin to fail)
-7 - Run long running extensive test that are a burden to normal development (perhaps test 1x per week)
-8 - Run tests that fail due to incomplete test building, these are good ideas for test that we don't have time to make robust)
-9 - Run silly tests that don't have much untility
-set(BRAINSTools_MAX_TEST_LEVEL 3 CACHE STRING "Testing level for managing test burden")
+cmake -S BRAINSTools -B BRAINSTools-build -DCMAKE_BUILD_TYPE=Release
+cmake --build BRAINSTools-build
 ```
 
-The codebase should conform to clang-format defined standards that are similar to ITK's defintion.
-```
-git filter-branch -f --tree-filter \
-   "~/Dashboard/src/ITK/Utilities/Maintenance/clang-format.bash --clang-format ~/local/clang-format-8.0.0-macosx  --tracked"  HEAD..
-```
+The SuperBuild fetches and builds dependencies (ITK, VTK, ANTs, …)
+automatically, then builds the BRAINSTools. On macOS, first install the
+command line tools with `xcode-select --install`.
+
+## Contributing
+
+Run `./Utilities/SetupForDevelopment.sh`, then `pre-commit install`.
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md).
+
+## License
+
+Apache 2.0. See [LICENSE](LICENSE).

--- a/Utilities/Maintenance/generate_tool_catalog.py
+++ b/Utilities/Maintenance/generate_tool_catalog.py
@@ -12,7 +12,6 @@ OUTPUT = "docs/tools.md"
 
 FRONT_MATTER = """---
 title: Tools
-nav_order: 2
 ---
 
 <!-- GENERATED FILE - DO NOT EDIT.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,5 @@
 ---
 title: Tools
-nav_order: 2
 ---
 
 <!-- GENERATED FILE - DO NOT EDIT.


### PR DESCRIPTION
Two small documentation cleanups following the merge of #617 (the generated tool catalog).

- **Drop `nav_order` from the generated catalog.** The site uses `jekyll-theme-modernist`, where `just-the-docs`' `nav_order` key is meaningless; the catalog is reached by a direct link from the landing page. This regenerates `docs/tools.md` without the dead key. (It was prepared for #617 but landed after that PR merged.)
- **Trim `README.md`** from 144 to 32 lines, removing build instructions that still recommended RedHat 6, gcc-4.2, python2.7, and CMake 3.2.1. The documentation site is now the single source of truth; the quick-start SuperBuild invocation is retained and verified against `CMakeLists.txt` (`SUPERBUILD` defaults `ON`).

<details>
<summary>Verification</summary>

- `pre-commit run --all-files` passes with no `SKIP` and no `--no-verify`.
- Conformance checker: `OK: 69 descriptors conformant.`
- `unittest` suite: 19 tests pass.
- Catalog generator idempotent; `docs/tools.md` regenerated by the generator, not hand-edited.
- README quick-start checked against `CMakeLists.txt:98` (`${LOCAL_PROJECT_NAME}_SUPERBUILD` defaults `ON`).

</details>

<!--
provenance: claude-code session 2026-07-21, branch docs/catalog-followups (fork hjmjohnson), off main aa14f08a
context: post-merge follow-ups to #617. nav_order removal missed #617's squash-merge window; README trim was the agreed separate follow-up.
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
