### PR TITLE
BUG: Select MIH baselines with ITK_VERSION instead of ITK_VERSION_FULL

### DIFF
--- a/BRAINSFit/TestSuite/CMakeLists.txt
+++ b/BRAINSFit/TestSuite/CMakeLists.txt
@@ -1070,11 +1070,10 @@ ExternalData_add_test( ${BRAINSTools_ExternalData_DATA_MANAGEMENT_TARGET} NAME $
 
 # ITK #6569 corrected the JointHistogramMutualInformation marginals and
 # derivative, so the MIH registrations converge to a different (correct) result.
-# ITK_VERSION_FULL carries a YYYYMMDD tweak (ITK #6667); unset on older ITK.
-if(ITK_VERSION_FULL VERSION_GREATER_EQUAL 6.0.0.20260715)
-  set(MIH_BASELINE_DIR ${TestData_DIR}/post-ITK6569)
-else()
+if(ITK_VERSION VERSION_LESS 6.0)
   set(MIH_BASELINE_DIR ${TestData_DIR})
+else()
+  set(MIH_BASELINE_DIR ${TestData_DIR}/post-ITK6569)
 endif()
 
 set(BRAINSFitTestName BRAINSFitTest_MIHAffineRotationMasks)


### PR DESCRIPTION
Replaces the `ITK_VERSION_FULL VERSION_GREATER_EQUAL 6.0.0.20260715` MIH baseline gate with a simple `ITK_VERSION VERSION_LESS 6.0` test, since the `ITK_VERSION_FULL` tweak-version feature was rejected upstream. Fixup for the gate introduced in #616.

<details>
<summary>Behavior and known minor failure mode</summary>

ITK 6.0 builds that predate the ITK #6569 JHMI metric correction now select the new (post-6569) baselines and will mismatch. Accepted as minor because 6.0 is not yet broadly deployed; ITK 5.4 and corrected 6.0 both resolve correctly.

</details>
