### PR TITLE
COMP: Reclaim the CI cache budget and lengthen ccache retention

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,10 +331,12 @@ jobs:
         # Only populate (and later save) when there was a cache miss or a
         # restore-keys fallback hit.  On an exact-key hit the store is already
         # up-to-date; writing it again would waste I/O and cache quota.
-        # ExternalData objects are content-addressed and platform-agnostic, so a
-        # single writer (Linux) populates the shared store; letting both matrix
-        # jobs save the same key races, and the loser's downloads are discarded.
-        if: ${{ !cancelled() && matrix.config.os == 'ubuntu-latest' && steps.restore-externaldata.outputs.cache-hit != 'true' }}
+        # ExternalData objects are content-addressed and platform-agnostic, so
+        # push-to-main on Linux is the sole writer of the shared store.  A PR
+        # cannot write to main's cache scope, and a restore-keys fallback leaves
+        # cache-hit='false', so PR runs would each store a private duplicate of
+        # data they only ever read; new hashes persist when the PR merges.
+        if: ${{ !cancelled() && matrix.config.os == 'ubuntu-latest' && github.event_name == 'push' && steps.restore-externaldata.outputs.cache-hit != 'true' }}
         shell: bash
         run: |
           # ExternalData downloads objects into ExternalData_BINARY_ROOT/Objects/.
@@ -354,9 +356,9 @@ jobs:
         # Only save on a cache miss (exact key not found) — including fallback
         # restore-keys hits, which also leave cache-hit='false'.  Skipping the
         # save on an exact-key hit avoids redundant writes and conserves the
-        # 10 GB per-repo GitHub Actions cache quota.  Linux is the single writer
-        # of this platform-agnostic store; see the populate step above.
-        if: ${{ !cancelled() && matrix.config.os == 'ubuntu-latest' && steps.restore-externaldata.outputs.cache-hit != 'true' }}
+        # 10 GB per-repo GitHub Actions cache quota.  Push-to-main on Linux is
+        # the sole writer of this store; see the populate step above.
+        if: ${{ !cancelled() && matrix.config.os == 'ubuntu-latest' && github.event_name == 'push' && steps.restore-externaldata.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v5
         with:
           path: ${{ runner.temp }}/ExternalData

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,7 +331,10 @@ jobs:
         # Only populate (and later save) when there was a cache miss or a
         # restore-keys fallback hit.  On an exact-key hit the store is already
         # up-to-date; writing it again would waste I/O and cache quota.
-        if: ${{ !cancelled() && steps.restore-externaldata.outputs.cache-hit != 'true' }}
+        # ExternalData objects are content-addressed and platform-agnostic, so a
+        # single writer (Linux) populates the shared store; letting both matrix
+        # jobs save the same key races, and the loser's downloads are discarded.
+        if: ${{ !cancelled() && matrix.config.os == 'ubuntu-latest' && steps.restore-externaldata.outputs.cache-hit != 'true' }}
         shell: bash
         run: |
           # ExternalData downloads objects into ExternalData_BINARY_ROOT/Objects/.
@@ -351,8 +354,9 @@ jobs:
         # Only save on a cache miss (exact key not found) — including fallback
         # restore-keys hits, which also leave cache-hit='false'.  Skipping the
         # save on an exact-key hit avoids redundant writes and conserves the
-        # 10 GB per-repo GitHub Actions cache quota.
-        if: ${{ !cancelled() && steps.restore-externaldata.outputs.cache-hit != 'true' }}
+        # 10 GB per-repo GitHub Actions cache quota.  Linux is the single writer
+        # of this platform-agnostic store; see the populate step above.
+        if: ${{ !cancelled() && matrix.config.os == 'ubuntu-latest' && steps.restore-externaldata.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v5
         with:
           path: ${{ runner.temp }}/ExternalData
@@ -485,3 +489,26 @@ jobs:
             build/BRAINSTools-Release-EPRelease-build/Testing/Temporary/LastTest.log
             build/BRAINSTools-Release-EPRelease-build/Testing/Temporary/CTestCostData.txt
             build/BRAINSTools-Release-EPRelease-build/Testing/**/*.xml
+
+  # ── Cache housekeeping ──────────────────────────────────────────────────────
+  #
+  # Background job: deletes ccache entries whose SHA-suffixed key has been
+  # superseded by a newer build of the same (ref, OS, compiler).  restore-keys
+  # only ever falls back to the newest prefix match, so older entries are dead
+  # weight against the 10 GB per-repository cache budget.  Non-blocking: a fork
+  # PR without actions:write must not redden a green build.
+  prune-superseded-caches:
+    needs: build
+    if: always()
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - name: Prune superseded caches
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 Utilities/Maintenance/PruneSupersededCiCaches.py --keep 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
         shell: bash
         run: |
           ccache --zero-stats
-          ccache --evict-older-than 7d
+          ccache --evict-older-than 60d
           ccache --show-config
 
       # ── Test data cache (ExternalData) ────────────────────────────────────────

--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -1,0 +1,57 @@
+name: Cleanup PR caches
+
+# When a pull request closes (merged or not), delete every GitHub Actions
+# cache entry scoped to its merge ref.  This reclaims the repo's 10 GB
+# cache budget within seconds of close, without adding any overhead to
+# the regular build/test runs.
+#
+# Reference:
+# https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
+
+on:
+  # Use pull_request_target rather than pull_request: GITHUB_TOKEN is
+  # read-only for pull_request events from forks, which would cause every
+  # real-world PR cache delete to return 403.  pull_request_target runs
+  # in the base-repo context with the permissions this workflow requests,
+  # and is safe here because the workflow never checks out or executes
+  # fork-authored code -- it only calls the GitHub API.
+  # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  purge-pr-caches:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write           # required to delete caches
+      contents: read
+    steps:
+      - name: Delete all caches for the closed PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # Sweep both the merge-ref and the head-ref.  Most pull_request
+          # workflows cache against refs/pull/N/merge (github.sha resolves
+          # to the merge commit), but workflows that key on github.head_ref
+          # can write caches to refs/pull/N/head.  Cleaning up both is
+          # belt-and-braces against future workflow additions.
+          total=0
+          for scope in merge head; do
+            ref="refs/pull/${PR_NUM}/${scope}"
+            echo "Purging caches for ${REPO} at ref=${ref}"
+            while read -r id; do
+              [ -z "$id" ] && continue
+              if gh api -X DELETE "repos/${REPO}/actions/caches/${id}" >/dev/null 2>&1; then
+                total=$((total + 1))
+                echo "  deleted cache id=${id} (ref=${ref})"
+              else
+                echo "  WARN: failed to delete cache id=${id} (ref=${ref})"
+              fi
+            done < <(gh api --paginate \
+                       "repos/${REPO}/actions/caches?ref=${ref}&per_page=100" \
+                       --jq '.actions_caches[].id')
+          done
+          echo "Purged ${total} cache entries across merge+head refs."

--- a/.github/workflows/cleanup-stale-caches-nightly.yml
+++ b/.github/workflows/cleanup-stale-caches-nightly.yml
@@ -1,0 +1,84 @@
+name: Cleanup stale caches (nightly sweep)
+
+# Safety net for the cleanup-on-close workflow: once per day, scan the
+# repository's GitHub Actions caches and purge any cache scoped to a
+# pull-request merge ref whose PR has been closed for more than a
+# 3-day grace period.  The grace period lets anyone spot-rerun a
+# just-merged PR before its caches vanish.
+#
+# This catches the edge cases the pull_request:closed trigger misses:
+#   - PRs closed during a cleanup-workflow outage
+#   - caches orphaned when a PR was closed before this workflow existed
+#   - caches stuck on refs/pull/N/merge after branch deletion
+#
+# Reference:
+# https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
+
+on:
+  schedule:
+    - cron: '0 6 * * *'        # 06:00 UTC daily
+  workflow_dispatch:
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write           # required to delete caches
+      pull-requests: read      # required to check PR state
+    steps:
+      - name: Purge caches for PRs closed more than 3 days ago
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          GRACE_DAYS: '3'
+        run: |
+          set -euo pipefail
+          CUTOFF=$(date -u -d "${GRACE_DAYS} days ago" +%s)
+          echo "Grace cutoff: PRs closed before $(date -u -d "@${CUTOFF}" --iso-8601=seconds)"
+
+          # Step 1: enumerate every PR-scoped cache (id + pr number).
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+          gh api --paginate \
+            "repos/${REPO}/actions/caches?per_page=100" \
+            --jq '.actions_caches[] |
+                  select(.ref | startswith("refs/pull/")) |
+                  [.id, (.ref | capture("refs/pull/(?<n>[0-9]+)/").n)] |
+                  @tsv' > "${tmpdir}/caches.tsv"
+          total_scanned=$(wc -l < "${tmpdir}/caches.tsv")
+
+          # Step 2: one API call per *distinct* PR (not per cache).
+          awk '{print $2}' "${tmpdir}/caches.tsv" | sort -u > "${tmpdir}/prs.txt"
+          : > "${tmpdir}/prstate.tsv"
+          while read -r pr; do
+            info=$(gh pr view "$pr" --repo "$REPO" \
+                     --json state,closedAt 2>/dev/null || echo '{}')
+            state=$(echo "$info" | jq -r '.state // "UNKNOWN"')
+            closed=$(echo "$info" | jq -r '.closedAt // "null"')
+            printf '%s\t%s\t%s\n' "$pr" "$state" "$closed" >> "${tmpdir}/prstate.tsv"
+          done < "${tmpdir}/prs.txt"
+
+          # Step 3: join caches with PR state and purge those past the grace cutoff.
+          total_purged=0
+          while read -r id pr; do
+            [ -z "$id" ] && continue
+            row=$(awk -v p="$pr" '$1 == p' "${tmpdir}/prstate.tsv")
+            state=$(echo "$row" | cut -f2)
+            closed=$(echo "$row" | cut -f3)
+            if [ "$state" = "OPEN" ] || [ "$closed" = "null" ]; then
+              continue
+            fi
+            closed_ts=$(date -u -d "$closed" +%s 2>/dev/null || echo 0)
+            [ "$closed_ts" -eq 0 ] && continue
+            if [ "$closed_ts" -lt "$CUTOFF" ]; then
+              if gh api -X DELETE "repos/${REPO}/actions/caches/${id}" >/dev/null 2>&1; then
+                total_purged=$((total_purged + 1))
+                echo "  purged cache id=${id} (PR #${pr} ${state} since ${closed})"
+              else
+                echo "  WARN: failed to delete cache id=${id} (PR #${pr})"
+              fi
+            fi
+          done < "${tmpdir}/caches.tsv"
+
+          distinct_prs=$(wc -l < "${tmpdir}/prs.txt")
+          echo "Scanned ${total_scanned} PR-scoped caches across ${distinct_prs} distinct PRs; purged ${total_purged}."

--- a/Utilities/Maintenance/PruneSupersededCiCaches.py
+++ b/Utilities/Maintenance/PruneSupersededCiCaches.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Prune superseded GitHub Actions caches for the BRAINSTools repository.
+
+The CI workflow seeds ccache via cache keys of the form
+``ccache-v1-<OS>-<compiler>-<sha>``. Each new push produces a new cache
+with a fresh SHA suffix, while ``actions/cache`` ``restore-keys`` falls
+back to the most recent prefix match. Older SHA-suffixed entries are
+therefore dead weight: they consume the per-repository 10 GB cache
+budget but never get restored once a newer entry exists.
+
+For each ``(ref, key-prefix-stripped-of-trailing-SHA)`` tuple this
+script keeps the newest cache and deletes the rest. It is intended to
+run as a non-blocking housekeeping job at the end of each CI workflow.
+It deliberately exits 0 even on partial failure so that a missing
+``actions: write`` permission (e.g. fork-PR runs) cannot turn a green
+build red.
+
+Required environment when run from CI:
+- ``GITHUB_TOKEN``      — token with ``actions: write`` scope
+- ``GITHUB_REPOSITORY`` — ``owner/repo`` of the target repository
+
+Usage::
+
+    python3 PruneSupersededCiCaches.py [--dry-run] [--repo OWNER/REPO]
+                                       [--token TOKEN] [--keep N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+from typing import Any
+
+SHA_RE = re.compile(r"^(?P<prefix>.+)-(?P<sha>[0-9a-f]{40})$")
+REPO_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+
+
+def _gh(args: list[str], token: str) -> tuple[int, str, str]:
+    """Run ``gh`` with the supplied args. Token is passed via env, never argv."""
+    gh = shutil.which("gh")
+    if gh is None:
+        return 127, "", "gh CLI not found on PATH"
+    env = os.environ.copy()
+    env["GH_TOKEN"] = token
+    proc = subprocess.run(  # noqa: S603 — fixed argv, token via env
+        [gh, *args], capture_output=True, text=True, env=env, check=False
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+REF_RE = re.compile(r"^refs/(?:heads|tags|pull)/[A-Za-z0-9._/+-]+$")
+
+
+def list_caches(repo: str, token: str, ref: str | None = None) -> list[dict[str, Any]]:
+    caches: list[dict[str, Any]] = []
+    page = 1
+    # Ref scoping: when this script runs on a PR, the GITHUB_TOKEN is
+    # repo-scoped (not ref-scoped) and would otherwise list and prune
+    # superseded entries across every ref in the repo, including main
+    # and unrelated PRs. Filtering by ref keeps each run honest about
+    # which caches it can touch.
+    ref_query = f"&ref={ref}" if ref else ""
+    while True:
+        path = (
+            f"/repos/{repo}/actions/caches"
+            f"?per_page=100&page={page}&sort=created_at&direction=desc"
+            f"{ref_query}"
+        )
+        rc, out, err = _gh(
+            ["api", "-H", "X-GitHub-Api-Version: 2022-11-28", path], token
+        )
+        if rc != 0:
+            print(f"WARN: list caches failed: {err.strip()[:200]}", file=sys.stderr)
+            return caches
+        try:
+            payload = json.loads(out)
+        except json.JSONDecodeError as exc:
+            print(f"WARN: cannot parse cache list: {exc}", file=sys.stderr)
+            return caches
+        batch = payload.get("actions_caches", [])
+        caches.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return caches
+
+
+def delete_cache(repo: str, token: str, cache_id: int) -> bool:
+    path = f"/repos/{repo}/actions/caches/{cache_id}"
+    rc, _, err = _gh(["api", "-X", "DELETE", path], token)
+    if rc == 0:
+        return True
+    print(f"WARN: delete cache {cache_id} failed: {err.strip()[:200]}", file=sys.stderr)
+    return False
+
+
+def normalize_prefix(key: str) -> str:
+    """Strip a trailing ``-<40-hex-sha>`` so siblings group together."""
+    m = SHA_RE.match(key)
+    return m.group("prefix") if m else key
+
+
+def plan_deletions(
+    caches: list[dict[str, Any]], keep: int
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for c in caches:
+        # An unexpectedly shaped cache entry (missing ref/key/created_at)
+        # must not crash the housekeeping run. Skip with a notice instead.
+        try:
+            groups[(c["ref"], normalize_prefix(c["key"]))].append(c)
+        except KeyError as exc:
+            print(
+                f"WARN: skipping cache with missing field {exc}: id={c.get('id', '?')}",
+                file=sys.stderr,
+            )
+    keep_list: list[dict[str, Any]] = []
+    delete_list: list[dict[str, Any]] = []
+    for members in groups.values():
+        try:
+            members.sort(key=lambda c: c["created_at"], reverse=True)
+        except KeyError:
+            print("WARN: skipping group with missing created_at", file=sys.stderr)
+            continue
+        keep_list.extend(members[:keep])
+        delete_list.extend(members[keep:])
+    return keep_list, delete_list
+
+
+def human_size(n: int) -> str:
+    return f"{n / 1e9:.2f} GB" if n >= 1e9 else f"{n / 1e6:.1f} MB"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY"),
+        help="OWNER/REPO (defaults to $GITHUB_REPOSITORY)",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("GITHUB_TOKEN"),
+        help="GitHub token with actions:write (defaults to $GITHUB_TOKEN)",
+    )
+    parser.add_argument(
+        "--keep",
+        type=int,
+        default=1,
+        help="How many newest caches to keep per (ref, key-prefix). Default: 1",
+    )
+    parser.add_argument(
+        "--ref",
+        default=os.environ.get("GITHUB_REF"),
+        help=(
+            "Restrict the prune to caches that belong to this ref"
+            " (e.g. refs/heads/main, refs/pull/123/merge). Defaults to"
+            " $GITHUB_REF so that PR runs only touch their own caches."
+            " Pass an empty string to operate repo-wide."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the deletion plan without calling DELETE",
+    )
+    args = parser.parse_args(argv)
+
+    if args.repo and not REPO_RE.match(args.repo):
+        print(f"INFO: invalid --repo value: {args.repo!r}. Skipping.", file=sys.stderr)
+        return 0
+
+    if args.ref and not REF_RE.match(args.ref):
+        print(
+            f"INFO: --ref does not look like a refs/... path: {args.ref!r}. Skipping.",
+            file=sys.stderr,
+        )
+        return 0
+
+    # --keep < 1 would empty every group. Treat as a misuse rather than a
+    # silent wipe; exit 0 to keep CI green.
+    if args.keep < 1:
+        print(
+            f"INFO: --keep must be >= 1 (got {args.keep}). Skipping.",
+            file=sys.stderr,
+        )
+        return 0
+
+    if not args.repo or not args.token:
+        # Housekeeping should never fail a build. Exit 0 with a notice.
+        print(
+            "INFO: --repo and --token are required (or $GITHUB_REPOSITORY"
+            " and $GITHUB_TOKEN). Skipping cache prune.",
+            file=sys.stderr,
+        )
+        return 0
+
+    caches = list_caches(args.repo, args.token, ref=args.ref or None)
+    if not caches:
+        print("INFO: no caches found (or insufficient permissions). Nothing to do.")
+        return 0
+
+    keep_list, delete_list = plan_deletions(caches, keep=args.keep)
+    total = sum(c["size_in_bytes"] for c in caches)
+    keep_bytes = sum(c["size_in_bytes"] for c in keep_list)
+    drop_bytes = sum(c["size_in_bytes"] for c in delete_list)
+
+    print(f"Repo:    {args.repo}")
+    print(f"Caches:  {len(caches)} ({human_size(total)})")
+    print(f"Keeping: {len(keep_list)} ({human_size(keep_bytes)})")
+    print(f"Pruning: {len(delete_list)} ({human_size(drop_bytes)})")
+
+    if not delete_list:
+        return 0
+
+    deleted = 0
+    freed = 0
+    try:
+        sorted_delete_list = sorted(
+            delete_list, key=lambda c: (c["ref"], c["created_at"])
+        )
+    except KeyError as exc:
+        print(f"WARN: cannot sort deletion list: missing {exc}", file=sys.stderr)
+        return 0
+    for c in sorted_delete_list:
+        try:
+            action = "DRY-RUN" if args.dry_run else "DELETE "
+            print(
+                f"  {action} id={c['id']:>12}  {c['ref']:<28}  "
+                f"{c['size_in_bytes'] / 1e6:>7.1f} MB  {c['key'][:80]}"
+            )
+            if args.dry_run or delete_cache(args.repo, args.token, c["id"]):
+                deleted += 1
+                freed += c["size_in_bytes"]
+        except KeyError as exc:
+            print(
+                f"WARN: skipping cache with missing field {exc}",
+                file=sys.stderr,
+            )
+            continue
+
+    verb = "Would free" if args.dry_run else "Freed"
+    print(f"{verb} {human_size(freed)} across {deleted} cache(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The repository holds **10.97 GB of GitHub Actions caches against a 10 GB budget**, so warm ccache entries are being evicted on nearly every run. This prunes superseded entries, stops pull requests from duplicating the 1.78 GB ExternalData store, and lengthens ccache retention to match this repo's release cadence.

<details>
<summary>Measured cache inventory (live API, before this change)</summary>

| ref | key | size |
|---|---|---|
| `refs/heads/main` | `ExternalData-BRAINSTools-v5.8` | 1782 MB |
| `refs/heads/main` | `ExternalData-BRAINSTools-v5.8` (duplicate) | 1782 MB |
| `refs/pull/617/merge` | `ExternalData-BRAINSTools-v5.8` | 1782 MB |
| `refs/pull/617/merge` | `ExternalData-BRAINSTools-v5.8` (duplicate) | 1782 MB |
| `refs/heads/main` | `ccache-v1-Linux-g++-<sha>` × 3 | ~340 MB each |
| `refs/heads/main` | `ccache-v1-macOS-clang++-<sha>` × 3 | ~440 MB each |
| `refs/pull/*/merge` | `ccache-v1-*-<sha>` × 4 | ~330-440 MB each |

ExternalData accounts for 7.1 GB of the 10.97 GB total. The ccache directories are ~330-440 MB, far below the 5 GB `CCACHE_MAXSIZE` ceiling, so the ceiling is not the binding constraint and is left unchanged.

</details>

<details>
<summary>Why ExternalData was duplicated four times</summary>

Two independent mechanisms stacked:

1. **Matrix race.** The Linux and macOS jobs run concurrently and both pass `actions/cache/save`'s key-existence check before either finishes writing, so a single run stores two identical-key entries (visible above, created 24 and 34 minutes apart on the same ref).
2. **Per-ref scoping.** A pull request can read `main`'s caches but cannot write to them. The save was gated on `cache-hit != 'true'`, and a restore-keys prefix fallback reports `cache-hit == 'false'` **even when it successfully restored the full store** — so each PR wrote a private duplicate of data it only ever read.

Fix: ExternalData objects are content-addressed and platform-agnostic, so push-to-main on Linux becomes the sole writer. Restore remains unconditional, so PRs still read the shared store; genuinely new object hashes persist once the PR merges.

</details>

<details>
<summary>Cache pruning mechanism (ported from ITK)</summary>

`Utilities/Maintenance/PruneSupersededCiCaches.py` groups caches by `(ref, key-with-trailing-SHA-stripped)` and keeps only the newest per group. Because `restore-keys` only ever falls back to the newest prefix match, older SHA-suffixed entries can never be restored — they are pure budget consumption.

It runs as a trailing `needs: build` / `if: always()` / `continue-on-error: true` job and exits 0 unconditionally, so a fork PR lacking `actions: write` cannot turn a green build red.

Two companion workflows handle PR-scoped entries: `cleanup-pr-caches.yml` purges on PR close (using `pull_request_target`, because a fork PR's `GITHUB_TOKEN` is read-only and would 403), and `cleanup-stale-caches-nightly.yml` sweeps orphans past a 3-day grace period.

A dry run against the live repository reports **5.09 GB reclaimed across 6 entries**.

</details>

<details>
<summary>ccache retention: 7d → 60d</summary>

BRAINSTools sees far less traffic than ITK, and its dependency pins (ITK, VTK, ANTs) move only a few times per year. A 7-day eviction discarded still-valid external-project objects between runs. `--evict-older-than` is retained rather than removed so that space is still reclaimed after a pin bump; at 60 days it will not fire between routine runs.

</details>

<details>
<summary>Verification</summary>

- All three workflow files parse as YAML; `Validate GitHub Workflows` pre-commit hook passes.
- `PruneSupersededCiCaches.py` byte-compiles and was executed `--dry-run` against the live GitHub API (output quoted above).
- Step conditions re-parsed from the YAML to confirm the ExternalData **restore** step remains unconditional while populate/save are gated.
- `pre-commit run --all-files` passes on the branch tip.

Not included: pinning the CI toolchain via pixi/conda-forge, which would stabilise ccache's `COMPILERCHECK=content` identity across runner-image bumps. That is a substantially larger change and belongs in its own PR.

</details>

<!--
provenance: claude-code session 2026-07-21
key_facts:
  - actions cache budget is 10 GB per repository, total across all keys
  - outputs.cache-hit is 'true' only on exact primary-key match; restore-keys
    fallback leaves it 'false' despite a successful restore. Use
    outputs.cache-matched-key to distinguish "restored something usable".
  - ccache dirs measured 328-442 MB; CCACHE_MAXSIZE=5G is NOT the constraint
files:
  - .github/workflows/build.yml (evict 60d; ExternalData populate/save gated on
    ubuntu-latest + github.event_name == 'push'; prune-superseded-caches job)
  - .github/workflows/cleanup-pr-caches.yml (new, from ITK)
  - .github/workflows/cleanup-stale-caches-nightly.yml (new, from ITK)
  - Utilities/Maintenance/PruneSupersededCiCaches.py (new, from ITK)
post_merge_action:
  - after first push-to-main run, re-check total cache size; expect ~4 GB
  - alternative to push-only gating, if PRs need to persist new data:
    test steps.restore-externaldata.outputs.cache-matched-key instead
-->
