### PR TITLE
BUG: Restore ITK_VERSION_FULL gate for MIH baseline selection

### DIFF
--- a/BRAINSFit/TestSuite/CMakeLists.txt
+++ b/BRAINSFit/TestSuite/CMakeLists.txt
@@ -1070,10 +1070,12 @@ ExternalData_add_test( ${BRAINSTools_ExternalData_DATA_MANAGEMENT_TARGET} NAME $
 
 # ITK #6569 corrected the JointHistogramMutualInformation marginals and
 # derivative, so the MIH registrations converge to a different (correct) result.
-if(ITK_VERSION VERSION_LESS 6.0)
-  set(MIH_BASELINE_DIR ${TestData_DIR})
-else()
+# ITK #6676 sets ITK_VERSION_TWEAK to the YYYYMMDD commit date, so ITK_VERSION_FULL
+# discriminates ITK builds from before/after #6569 landed (2026-07-16).
+if(ITK_VERSION_FULL VERSION_GREATER_EQUAL 6.0.0.20260716)
   set(MIH_BASELINE_DIR ${TestData_DIR}/post-ITK6569)
+else()
+  set(MIH_BASELINE_DIR ${TestData_DIR})
 endif()
 
 set(BRAINSFitTestName BRAINSFitTest_MIHAffineRotationMasks)


### PR DESCRIPTION
Restore `ITK_VERSION_FULL` as the MIH-baseline discriminator now that upstream ITK #6676 exports a `YYYYMMDD` tweak, reverting the coarse `ITK_VERSION VERSION_LESS 6.0` fallback from e533e741.

<details>
<summary>Why the previous gate was wrong</summary>

Commit e533e741 was written while ITK #6667 (the first attempt at a dated `ITK_VERSION_TWEAK`) had been rejected upstream, so it fell back to `if(ITK_VERSION VERSION_LESS 6.0)`. That check assumes **every** ITK 6.0 build carries the #6569 JointHistogramMutualInformation metric fix — but a 6.0 build predating #6569 would select the post-fix baselines and fail. The commit message flagged this as a known false-positive.

ITK #6676 (https://github.com/InsightSoftwareConsortium/ITK/pull/6676) landed the accepted mechanism: `ITK_VERSION_TWEAK` is computed as the `YYYYMMDD` commit date and exported through `ITKConfig.cmake`/`ITKConfigVersion.cmake` (never `itkConfigure.h`, so it does not invalidate cached objects). `ITK_VERSION_FULL` is therefore a reliable downstream discriminator again.

This gates the `post-ITK6569` baselines on `ITK_VERSION_FULL VERSION_GREATER_EQUAL 6.0.0.20260716`, where `20260716` is the merge date of ITK #6569 (commit 4d47bb119dc).
</details>

<!--
provenance: claude-code session 2026-07-23
supersedes-logic: e533e741 (ITK_VERSION VERSION_LESS 6.0 fallback)
depends-on: ITK PR #6676 (ITK_VERSION_TWEAK=YYYYMMDD), ITK PR #6569 merged 2026-07-16
file: BRAINSFit/TestSuite/CMakeLists.txt:1071
-->
